### PR TITLE
Add support for pairing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Features
 --------
 
 - Automatic discovery of devices (zeroconf/Bonjour)
+- Pairing with devices
 - Most buttons (play, pause, next, previous, select, menu, topmenu)
 - Fetch artwork in PNG format
 - Currently playing (e.g. title, artist, album, total time, etc.)

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,6 @@ As this library is still at an early development stage, functionality is still m
 exist and API may change. Look at this as a "technical preview". API is not considered final
 until version 1.0 is released.
 
-NOTE: As pairing is not yet implemented, you `must` enable home sharing on your Apple TV for
-this library to work! Once pairing is implemented, this restriction will be lifted.
-
 The MIT license is used for this library.
 
 Features
@@ -130,7 +127,7 @@ tracking.
 Tasks related to library features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Pairing with a device
+- Pairing with a device (issue #9)
 - Asynchronous auto discovery
 - Non-polling based API (callbacks)
 - Send URL to AirPlay media

--- a/docs/atvremote.rst
+++ b/docs/atvremote.rst
@@ -27,6 +27,28 @@ time with the -t flag, e.g. ``atvremote -t 10 scan``.
 More details about the discovery process can be found
 :ref:`here<pyatv-finding-devices>`.
 
+Pairing with a device
+---------------------
+To pair with a device, use the ``pair`` command. By default, it will wait
+one minute for the pairing process to complete. The remote control will be
+announced with name *pyatv* and PIN code to be used is 1234:
+
+.. code:: bash
+
+    $ atvremote pair
+    Use pin 1234 to pair with "pyatv" (waiting for 60s)
+    After successful pairing, use login id 0000000000000001
+    Note: If remote does not show up, reboot you Apple TV
+
+You can override all of the settings using ``--remote-name``, ``--pin`` and
+``--pairing-timeout``.
+
+.. note::
+
+    It is hardcoded into pyatv so that pairing guid ``0000000000000001``
+    must always be used. So, if you have paired your device, just use that
+    as login id.
+
 Specifying a device
 -------------------
 You have two choices:

--- a/docs/atvremote.rst
+++ b/docs/atvremote.rst
@@ -37,7 +37,7 @@ announced with name *pyatv* and PIN code to be used is 1234:
 
     $ atvremote pair
     Use pin 1234 to pair with "pyatv" (waiting for 60s)
-    After successful pairing, use login id 0000000000000001
+    After successful pairing, use login id 0x0000000000000001
     Note: If remote does not show up, reboot you Apple TV
 
 You can override all of the settings using ``--remote-name``, ``--pin`` and
@@ -45,9 +45,9 @@ You can override all of the settings using ``--remote-name``, ``--pin`` and
 
 .. note::
 
-    It is hardcoded into pyatv so that pairing guid ``0000000000000001``
+    It is hardcoded into pyatv so that pairing guid ``0x0000000000000001``
     must always be used. So, if you have paired your device, just use that
-    as login id.
+    as login id. It is important that you add ``0x`` in front of the guid!
 
 Specifying a device
 -------------------

--- a/docs/connecting.rst
+++ b/docs/connecting.rst
@@ -2,10 +2,6 @@
 
 Connecting
 ==========
-NOTE: This page currently only covers auto discovery of devices. Pairing will
-be added once that is implemented. You must have home sharing enabled for this
-to work.
-
 When connecting to a device, the IP-address (or hostname) and its login id,
 e.g. HSGID, is required. These details can be specified manually or be
 automatically discovered if home sharing is enabled.
@@ -49,8 +45,9 @@ you need to logout):
 
     NAME = 'My Apple TV'
     ADDRESS = '10.0.10.22'
-    HSGID = '00000000-1111-2222-3333-444444444444'
-    DETAILS = pyatv.AppleTVDevice(NAME, ADDRESS, HSGID)
+    LOGIN_ID = '00000000-1111-2222-3333-444444444444' # HSGID
+    # LOGIN_ID = '0000000000000001'                   # Pairing guid
+    DETAILS = pyatv.AppleTVDevice(NAME, ADDRESS, LOGIN_ID)
 
     @asyncio.coroutine
     def print_what_is_playing(loop, details):
@@ -64,5 +61,8 @@ you need to logout):
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(print_what_is_playing(loop, DETAILS))
+
+Specify ``LOGIN_ID`` to be either HSGID or ``0000000000000001`` if you
+have paired with your device.
 
 API Reference: :py:meth:`pyatv.connect_to_apple_tv`, :py:class:`pyatv.AppleTVDevice`

--- a/docs/finding_devices.rst
+++ b/docs/finding_devices.rst
@@ -32,6 +32,12 @@ basically all you need. Any client that can list Bonjour services can be used, s
 But you can of course also use ``atvremote``, see
 :ref:`this page<pyatv-atvremote>`.
 
+No home sharing
+---------------
+If you do not want or can't enable home sharing, you can pair with your device
+instead and gain a pairing guid that you can use as login id. See
+:ref:`pairing<pyatv-pairing>` for more information about that.
+
 Code Example
 ------------
 Discovering devices is as easy as using ``pyatv.scan_for_apple_tvs``, which is

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,8 +51,8 @@ Connecting to a specific device:
 
     NAME = 'My Apple TV'
     ADDRESS = '10.0.10.22'
-    HSGID = '00000000-1111-2222-3333-444444444444'
-    DETAILS = pyatv.AppleTVDevice(NAME, ADDRESS, HSGID)
+    LOGIN_ID = '00000000-1111-2222-3333-444444444444'
+    DETAILS = pyatv.AppleTVDevice(NAME, ADDRESS, LOGIN_ID)
 
 
     @asyncio.coroutine
@@ -72,7 +72,8 @@ Connecting to a specific device:
     loop.run_until_complete(print_what_is_playing(loop, DETAILS))
 
 
-Where to find HSGID? See :ref:`this<pyatv-finding-devices>` page.
+What is LOGIN_ID and where to find it? See :ref:`this<pyatv-finding-devices>`
+page.
 
 
 Dependencies
@@ -107,6 +108,7 @@ Contents
 
    protocol
    finding_devices
+   pairing
    connecting
    controlling
    metadata

--- a/docs/pairing.rst
+++ b/docs/pairing.rst
@@ -1,0 +1,119 @@
+.. _pyatv-pairing:
+
+Pairing with a device
+=====================
+An alternative to using home sharing and the ``HSGID`` identifier is to pair
+with the device and use a ``pairing guid`` instead. This is useful if you
+for some reason do not want to set up home sharing or if you do not have an
+Apple account.
+
+The library automatically handles both types of identifiers. Once you have one
+of them, it should just work. So, from now on the term ``login id`` will be
+used, which can be either a HSGID or pairing guid.
+
+How does it work
+----------------
+Pairing with a device is sort of a reversed process compared to when sending
+commands to it. The Apple TV listens to a specific Bonjour service with type
+``_touch-remote._tcp.local.`` and all remote controls publishes this service.
+Included in this service is a bunch of data that is needed for the pairing
+process:
+
+* IP-address of the host (remote control)
+* A TCP-port open on the host
+* Various properties, like the remote name and the pairing guid to be used
+
+When pyatv publishes this service, it might look something like this:
+
+.. code::
+
+    ServiceInfo(type='_touch-remote._tcp.local.',
+                name='0000000000000000000000000000000000000001._touch-remote._tcp.local.',
+                address=b'\n\x00\n\x19',
+                port=57469,
+                weight=0,
+                priority=0,
+                server='0000000000000000000000000000000000000001._touch-remote._tcp.local.',
+                properties={
+		    b'DvNm': b'pyatv',
+                    b'txtvers': b'1',
+                    b'RemV': b'10000',
+                    b'Pair': b'0000000000000001',
+                    b'DvTy': b'iPod',
+                    b'RemN': b'Remote'
+                }
+    )
+
+Note the ``port``, ``DvNM`` (name of the remote) and ``Pair``. These are the
+most interesting parameters.
+
+When this service is published, a new remote will "popup" on the Apple TV.
+Next is the actual pairing, which is the tricky part. To avoid sending
+the pin code over the network (which would eliminate integrity all together),
+it instead generates a MD5 hash based on the Pair property and the PIN you
+manuelly entered on scren. In case of pyatv, the "algorithm" is:
+
+.. code:: python
+
+    hash = md5('0000000000000001' + pin)
+
+It then connects to the port on the host (remote control) and performs a GET
+request, including this hash as well as a service name. An example might look
+like this:
+
+.. code::
+
+    INFO: 10.0.10.22 - - [04/Feb/2017:15:26:29 +0000] "GET /pair?pairingcode=AAB15DF9F73AA252A7934E0AF9C86B13&servicename=AAAAAAAAAAAAAAAA HTTP/1.1" 200 49 "-" "AppleTV/7.2.2 iOS/8.4.2 AppleTV/7.2.2 model/AppleTV3,1 build/12H606 (3; dt:12)"
+
+The remote control then calculates the hash in the same way and verifies if
+it is correct. Of course, the remote decides if the pairing should succeed so
+this verification can be skipped altogether to allow any PIN code.
+
+After verifying the hash, a response must be sent sent back to the device.
+It is DAAP data and looks like this:
+
+.. code::
+
+    cmpa: [container, dacp.pairinganswer]
+      cmpg: 1 [uint, dacp.pairingguid]
+      cmnm: pyatv remote [str, dacp.devicename]
+      cmty: ipod [str, dacp.devicetype]
+
+As can be seen, the name to be used for the remote is included in the response.
+After this response, the pairing process is complete and ``0000000000000001``
+can be used as login id when sending commands to the device.
+
+Code Example: Pairing
+---------------------
+When performing pairing, the application is responsible for starting and stopping
+the process. In practice this means publishing the Bonjour service, starting the
+web server and the opposite. This is done using a
+:py:class:`pyatv.pairing.PairingHandler`, which is returned when you call
+:py:meth:`pyatv.pair_with_apple_tv`. The process itself is quite simple:
+
+.. code:: python
+
+    import pyatv
+    import asyncio
+
+    PIN_CODE = 1234
+    REMOTE_NAME = 'my remote control'
+
+    @asyncio.coroutine
+    def pair_with_device(loop):
+        handler = pyatv.pair_with_apple_tv(loop, PIN_CODE, REMOTE_NAME)
+
+        yield from handler.start()
+        yield from asyncio.sleep(60, loop=loop)
+        yield from handler.stop()
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(pair_with_device(loop))
+
+This example is available in ``examples``.
+
+References
+----------
+http://dacp.jsharkey.org/
+
+http://jsharkey.org/blog/2009/06/21/itunes-dacp-pairing-hash-is-broken/

--- a/examples/pairing.py
+++ b/examples/pairing.py
@@ -1,0 +1,27 @@
+"""Simple example showing of pairing."""
+
+import pyatv
+import asyncio
+
+
+PIN_CODE = 1234
+REMOTE_NAME = 'my remote control'
+
+
+# Method that is dispatched by the asyncio event loop
+@asyncio.coroutine
+def pair_with_device(loop):
+    handler = pyatv.pair_with_apple_tv(loop, PIN_CODE, REMOTE_NAME)
+
+    yield from handler.start()
+    print('You can now pair with pyatv')
+
+    # Wait for a minute to allow pairing
+    yield from asyncio.sleep(60, loop=loop)
+
+    yield from handler.stop()
+
+
+# Setup event loop and connect
+loop = asyncio.get_event_loop()
+loop.run_until_complete(pair_with_device(loop))

--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -13,6 +13,7 @@ from pyatv.internal.apple_tv import AppleTVInternal
 
 _LOGGER = logging.getLogger(__name__)
 
+
 HOMESHARING_SERVICE = '_appletv-v2._tcp.local.'
 
 
@@ -72,6 +73,6 @@ def connect_to_apple_tv(details, loop):
     return AppleTVInternal(session, requester)
 
 
-def pair_with_apple_tv(loop, timeout, pin_code, name):
+def pair_with_apple_tv(loop, pin_code, name):
     """Initiate pairing process with an Apple TV."""
-    return PairingHandler(loop, timeout, name, pin_code).run()
+    return PairingHandler(loop, name, pin_code)

--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -7,6 +7,7 @@ import ipaddress
 from collections import namedtuple
 from zeroconf import ServiceBrowser, Zeroconf
 
+from pyatv.pairing import PairingHandler
 from pyatv.daap import (DaapSession, DaapRequester)
 from pyatv.internal.apple_tv import AppleTVInternal
 
@@ -71,7 +72,6 @@ def connect_to_apple_tv(details, loop):
     return AppleTVInternal(session, requester)
 
 
-# TODO: API not determined for this yet, might change when implemented
-def pair_with_apple_tv():
+def pair_with_apple_tv(loop, timeout, pin_code, name):
     """Initiate pairing process with an Apple TV."""
-    raise NotImplementedError
+    return PairingHandler(loop, timeout, name, pin_code).run()

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -40,11 +40,16 @@ def cli_handler(loop):
                         const=logging.DEBUG, default=logging.WARNING)
     parser.add_argument('--name', help='apple tv name',
                         dest='name', default='Apple TV')
+    parser.add_argument('--remote-name', help='remote pairing name',
+                        dest='remote_name', default='pyatv')
     parser.add_argument('--address', help='device ip address or hostname',
                         dest='address', default=None)
     parser.add_argument('-t', '--scan-timeout', help='timeout when scanning',
                         dest='scan_timeout', type=_in_range(1, 10),
                         metavar='TIMEOUT', default=3)
+    parser.add_argument('-p', '--pin', help='pairing pin code',
+                        dest='pin_code', type=_in_range(0, 9999),
+                        metavar='PIN', default=1234)
     ident = parser.add_mutually_exclusive_group()
 
     ident.add_argument('-a', '--autodiscover',
@@ -67,7 +72,9 @@ def cli_handler(loop):
     if args.command == 'scan':
         yield from _handle_scan(args, loop)
     elif args.command == 'pair':
-        pyatv.pair_with_apple_tv()
+        # TODO: hardcoded timeout
+        yield from pyatv.pair_with_apple_tv(
+            loop, 60, args.pin_code, args.remote_name)
     elif args.autodiscover:
         return (yield from _handle_autodiscover(args, loop))
     elif args.login_id:

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -84,7 +84,7 @@ def cli_handler(loop):
             loop, args.pin_code, args.remote_name)
         print('Use pin {} to pair with "{}" (waiting for {}s)'.format(
             args.pin_code, args.remote_name, args.pairing_timeout))
-        print('After successful pairing, use login id {}'.format(
+        print('After successful pairing, use login id 0x{}'.format(
             pyatv.pairing.PAIRING_GUID))
         print('Note: If remote does not show up, reboot you Apple TV')
         yield from handler.start()

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -83,9 +83,9 @@ def cli_handler(loop):
         handler = pyatv.pair_with_apple_tv(
             loop, args.pin_code, args.remote_name)
         print('Use pin {} to pair with "{}" (waiting for {}s)'.format(
-              args.pin_code, args.remote_name, args.pairing_timeout))
+            args.pin_code, args.remote_name, args.pairing_timeout))
         print('After successful pairing, use login id {}'.format(
-                pyatv.pairing.PAIRING_GUID))
+            pyatv.pairing.PAIRING_GUID))
         print('Note: If remote does not show up, reboot you Apple TV')
         yield from handler.start()
         yield from asyncio.sleep(args.pairing_timeout, loop=loop)

--- a/pyatv/pairing.py
+++ b/pyatv/pairing.py
@@ -14,6 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PAIRING_GUID = '0000000000000001'
 
+
 class PairingHandler:
     """Handle the pairing process.
 
@@ -26,11 +27,12 @@ class PairingHandler:
         self.loop = loop
         self.name = name
         self.pairing_code = pairing_code
+        self.zeroconf = Zeroconf()
+        self.server = None
 
     @asyncio.coroutine
     def start(self):
         """Start the pairing server and publish service."""
-        self.zeroconf = Zeroconf()
         web_server = web.Server(self.handle_request, loop=self.loop)
         self.server = yield from self.loop.create_server(web_server, '0.0.0.0')
         allocated_port = self.server.sockets[0].getsockname()[1]

--- a/pyatv/pairing.py
+++ b/pyatv/pairing.py
@@ -1,0 +1,94 @@
+"""Module used for pairing pyatv with a device."""
+
+import socket
+import asyncio
+import hashlib
+import logging
+from io import StringIO
+
+from aiohttp import web
+from zeroconf import Zeroconf, ServiceInfo
+from pyatv import tags
+
+_LOGGER = logging.getLogger(__name__)
+
+PAIR = '0000000000000001'
+
+
+class PairingHandler:
+    """Handle the pairing process.
+
+    This class will publish a bonjour service and configure a webserver
+    that responds to pairing requests.
+    """
+
+    def __init__(self, loop, timeout, name, pairing_code):
+        """Initialize a new instance."""
+        self.loop = loop
+        self.timeout = timeout
+        self.name = name
+        self.pairing_code = pairing_code
+        self.zeroconf = Zeroconf()
+
+    @asyncio.coroutine
+    def run(self):
+        """Start the pairing server and publish service."""
+        web_server = web.Server(self.handle_request, loop=self.loop)
+        server = yield from self.loop.create_server(web_server, '0.0.0.0')
+        allocated_port = server.sockets[0].getsockname()[1]
+        service = self._setup_zeroconf(allocated_port)
+        print("lol: " + str(self.zeroconf))
+        print("timeout: " + str(self.timeout))
+        try:
+            yield from asyncio.sleep(self.timeout, loop=self.loop)
+        finally:
+            # TODO: should close here but that makes it hard to test
+            # Use have a stop method instead?
+            # server.close()
+            self.zeroconf.unregister_service(service)
+            self.zeroconf.close()
+
+    def _setup_zeroconf(self, port):
+        props = {
+            'DvNm': self.name,
+            'RemV': '10000',
+            'DvTy': 'iPod',
+            'RemN': 'Remote',
+            'txtvers': '1',
+            'Pair': PAIR
+            }
+
+        local_ip = socket.inet_aton(socket.gethostbyname(socket.gethostname()))
+        service = ServiceInfo('_touch-remote._tcp.local.',
+                              '0'*39 + '1._touch-remote._tcp.local.',
+                              local_ip, port, 0, 0, props)
+        self.zeroconf.register_service(service)
+        return service
+
+    @asyncio.coroutine
+    def handle_request(self, request):
+        """Respond to request if PIN is correct."""
+        received_code = request.rel_url.query['pairingcode'].lower()
+
+        if self._verify_pin(received_code):
+            cmpg = tags.uint64_tag('cmpg', 1)
+            cmnm = tags.string_tag('cmnm', self.name)
+            cmty = tags.string_tag('cmty', 'ipod')
+            response = tags.container_tag('cmpa', cmpg + cmnm + cmty)
+            # TODO: take down web server and cancel delay when done?
+            return web.Response(body=response)
+
+        # Code did not match, generate an error
+        return web.Response(status=500)
+
+    def _verify_pin(self, received_code):
+        merged = StringIO()
+        merged.write(PAIR)
+        for char in str(self.pairing_code):
+            merged.write(char)
+            merged.write("\x00")
+
+        expected_code = hashlib.md5(merged.getvalue().encode()).hexdigest()
+        _LOGGER.debug('Got code %s, expects %s', received_code, expected_code)
+
+        return received_code == expected_code

--- a/pyatv/tag_definitions.py
+++ b/pyatv/tag_definitions.py
@@ -41,9 +41,13 @@ _TAGS = {
     'ceQR': DmapTag('container', 'com.apple.itunes.playqueue-contents-response'),  # NOQA
     'cmcp': DmapTag('container', 'dmcp.controlprompt'),
     'cmmk': DmapTag(read_uint,   'dmcp.mediakind'),
+    'cmnm': DmapTag(read_str,    'dacp.devicename'),
+    'cmpa': DmapTag('container', 'dacp.pairinganswer'),
+    'cmpg': DmapTag(read_uint,   'dacp.pairingguid'),
     'cmpr': DmapTag(read_uint,   'dmcp.protocolversion'),
     'cmsr': DmapTag(read_uint,   'dmcp.serverrevision'),
     'cmst': DmapTag('container', 'dmcp.playstatus'),
+    'cmty': DmapTag(read_str,    'dacp.devicetype'),
     'mdcl': DmapTag('container', 'dmap.dictionary'),
     'miid': DmapTag(read_uint,   'dmap.itemid'),
     'minm': DmapTag(read_str,    'dmap.itemname'),

--- a/pyatv/tags.py
+++ b/pyatv/tags.py
@@ -48,6 +48,13 @@ def uint32_tag(name, value):
         value.to_bytes(4, byteorder='big')
 
 
+def uint64_tag(name, value):
+    """Create a DMAP tag with uint64 data."""
+    return name.encode('utf-8') + \
+        b'\x00\x00\x00\x08' + \
+        value.to_bytes(8, byteorder='big')
+
+
 def bool_tag(name, value):
     """Create a DMAP tag with boolean data."""
     return name.encode('utf-8') + \

--- a/tests/test_dmap.py
+++ b/tests/test_dmap.py
@@ -8,6 +8,7 @@ TEST_TAGS = {
     'uuu8': dmap.DmapTag(tags.read_uint, 'uint8'),
     'uu16': dmap.DmapTag(tags.read_uint, 'uint16'),
     'uu32': dmap.DmapTag(tags.read_uint, 'uint32'),
+    'uu64': dmap.DmapTag(tags.read_uint, 'uint64'),
     'bola': dmap.DmapTag(tags.read_bool, 'bool'),
     'bolb': dmap.DmapTag(tags.read_bool, 'bool'),
     'stra': dmap.DmapTag(tags.read_str, 'string'),
@@ -28,12 +29,14 @@ class DmapTest(unittest.TestCase):
     def test_parse_uint_of_various_lengths(self):
         in_data = tags.uint8_tag('uuu8', 12) + \
                   tags.uint16_tag('uu16', 37888) + \
-                  tags.uint32_tag('uu32', 305419896)
+                  tags.uint32_tag('uu32', 305419896) + \
+                  tags.uint64_tag('uu64', 8982983289232)
         parsed = dmap.parse(in_data, lookup_tag)
-        self.assertEqual(3, len(parsed))
+        self.assertEqual(4, len(parsed))
         self.assertEqual(12, dmap.first(parsed, 'uuu8'))
         self.assertEqual(37888, dmap.first(parsed, 'uu16'))
         self.assertEqual(305419896, dmap.first(parsed, 'uu32'))
+        self.assertEqual(8982983289232, dmap.first(parsed, 'uu64'))
 
     def test_parse_bool(self):
         in_data = tags.bool_tag('bola', True) + \

--- a/tests/zeroconf_stub.py
+++ b/tests/zeroconf_stub.py
@@ -38,6 +38,7 @@ class ZeroconfStub:
     def __init__(self, services):
         """Create a new instance of Zeroconf."""
         self.services = services
+        self.registered_services = []
 
     def get_service_info(self, service_type, service_name):
         """Look up service information."""
@@ -45,15 +46,28 @@ class ZeroconfStub:
             if service.name == service_name:
                 return service
 
+    def register_service(self, service):
+        """Save services registered services."""
+        self.registered_services.append(service)
+
+    def unregister_service(self, service):
+        """Stub for unregistering services (does nothing)."""
+        pass
+
     def close(self):
         """Stub for closing zeroconf (does nothing)."""
         pass
 
 
+instance = None
+
+
 def stub(module, *services):
     """Stub a module using zeroconf."""
     def _zeroconf():
-        return ZeroconfStub(services)
+        global instance
+        instance = ZeroconfStub(list(services))
+        return instance
 
     module.Zeroconf = _zeroconf
     module.ServiceBrowser = ServiceBrowserStub


### PR DESCRIPTION
Should work by using atvremote:

    atvremote pair

And then add the remote on the Apple TV. Default pin is 1234 (which
must be correctly entered) and name is "pyatv remote". These settings
can be changed with parameters to atvremote. Currently a pairing
timer is set to 60 seconds, so the process must be finished within
that time.

NOTE: Before merging this, some work must be done with tearing down the webserver and zeroconf after the paring period is done. It currently leaks.