### PR TITLE
Restore requirements to fix setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ share
 htmlcov
 
 artwork.png
+.Python

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,2 +1,0 @@
-zeroconf==0.18.0
-aiohttp==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,10 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
+    install_requires=[
+        'aiohttp==1.2.0',
+        'zeroconf==0.18.0',
+    ],
     test_suite='tests',
     keywords=['apple', 'tv'],
     tests_require=['tox'],

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ setenv =
 commands =
      py.test -v --timeout=30 --duration=10 --cov --cov-report=html {posargs}
 deps =
-     -r{toxinidir}/requirements_all.txt
      -r{toxinidir}/requirements_test.txt
 
 [testenv:lint]


### PR DESCRIPTION
Dependencies must be listed in setup.py for setuptools to work
properly, so they have now moved from requirements_all.txt.