### PR TITLE
Allow passing a custom session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 CHANGES
 =======
 
+0.1.3 (2017-02-09)
+------------------
+
+Changes:
+
+- Made it possible to pass a custom ClientSession
+
+Notes:
+
+- Renamed topmenu to top_menu which is a breaking change
+
+0.1.2 (2017-02-09)
+------------------
+
 Changes:
 
 - aiohttp bumped to 1.3.0

--- a/docs/connecting.rst
+++ b/docs/connecting.rst
@@ -6,6 +6,25 @@ When connecting to a device, the IP-address (or hostname) and its login id,
 e.g. HSGID, is required. These details can be specified manually or be
 automatically discovered if home sharing is enabled.
 
+Custom aiohttp session
+----------------------
+If you are integrating pyatv in an application that already has a
+``ClientSession``, then you might want to re-use that session. You can just
+pass it as an optional parameter when connecting:
+
+.. code:: python
+
+    other_session = ... # Some session
+    atv = pyatv.connect_to_apple_tv(atv, loop, session=other_session)
+
+If no session is given, a default ``ClientSession`` will be created for you.
+
+.. note::
+
+    When you logout from a device by calling (yield from) ``atv.logout()``,
+    the session will be closed. So, if you share the session with other
+    instances, you might not want to do that.
+
 Code Example: Auto discovery
 ----------------------------
 Using auto discovery makes the connection procedure simple. But do not forget

--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -6,6 +6,7 @@ import logging
 import ipaddress
 from collections import namedtuple
 from zeroconf import ServiceBrowser, Zeroconf
+from aiohttp import ClientSession
 
 from pyatv.airplay import AirPlay
 from pyatv.pairing import PairingHandler
@@ -64,14 +65,18 @@ def scan_for_apple_tvs(loop, timeout=5):
     return listener.found_devices
 
 
-def connect_to_apple_tv(details, loop):
+def connect_to_apple_tv(details, loop, session=None):
     """Connect and logins to an Apple TV."""
+    # If no session is given, create a default one
+    if session is None:
+        session = ClientSession(loop=loop)
+
     # If/when needed, the library should figure out the correct type of Apple
     # TV and return the correct type for it.
-    airplay = AirPlay(loop, details.address)
-    session = DaapSession(loop)
+    airplay = AirPlay(loop, session, details.address)
+    daap_session = DaapSession(session)
     requester = DaapRequester(
-        session, details.address, details.login_id, details.port)
+        daap_session, details.address, details.login_id, details.port)
     return AppleTVInternal(session, requester, airplay)
 
 

--- a/pyatv/daap.py
+++ b/pyatv/daap.py
@@ -6,7 +6,6 @@ import logging
 import asyncio
 
 from copy import copy
-from aiohttp import ClientSession
 
 from pyatv import (dmap, exceptions)
 from pyatv.tag_definitions import lookup_tag
@@ -33,14 +32,10 @@ class DaapSession(object):
     It automatically adds the required headers and also does DMAP parsing.
     """
 
-    def __init__(self, loop, timeout=DEFAULT_TIMEOUT):
+    def __init__(self, session, timeout=DEFAULT_TIMEOUT):
         """Initialize a new DaapSession."""
-        self._session = ClientSession(loop=loop)
+        self._session = session
         self._timeout = timeout
-
-    def close(self):
-        """Close the underlying client session."""
-        return self._session.close()
 
     @asyncio.coroutine
     def get_data(self, url, should_parse=True):

--- a/tests/test_airplay.py
+++ b/tests/test_airplay.py
@@ -3,6 +3,7 @@
 import asyncio
 
 from tests.log_output_handler import LogOutputHandler
+from aiohttp import ClientSession
 from aiohttp.test_utils import (AioHTTPTestCase, unittest_run_loop)
 
 from pyatv import airplay
@@ -51,9 +52,12 @@ class AirPlayTest(AioHTTPTestCase):
         self.usecase.airplay_playback_playing()
         self.usecase.airplay_playback_idle()
 
-        aplay = airplay.AirPlay(self.loop, '127.0.0.1')
+        session = ClientSession(loop=self.loop)
+        aplay = airplay.AirPlay(self.loop, session, '127.0.0.1')
         yield from aplay.play_url(STREAM, START_POSITION, self.app.port)
 
         self.assertEqual(self.fake_atv.last_airplay_url, STREAM)
         self.assertEqual(self.fake_atv.last_airplay_start, START_POSITION)
         self.assertEqual(self.no_of_sleeps, 2)  # playback + idle = 3
+
+        yield from session.close()


### PR DESCRIPTION
Instead of always creating a default ClientSession, it's now possible to
pass a custom one. If no session is given, a default one is created so
this change is backwards compatible.