### PR TITLE
Unpin external dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,8 @@ Requirements
 ------------
 
 - python>=3.4.2
-- zeroconf==0.18.0
-- aiohttp==1.3.0
+- zeroconf>=0.17.7
+- aiohttp>=1.3.0
 
 Getting started
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,10 +79,9 @@ page.
 Dependencies
 ------------
 
-- Python 3.4.2+
-- zeroconf
-- aiohtto
-
+- python>=3.4.2
+- zeroconf>=0.17.7
+- aiohttp>=1.3.0
 
 Contributing
 ------------

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'aiohttp==1.3.1',
-        'zeroconf==0.18.0',
+        'aiohttp>=1.3.0',
+        'zeroconf>=0.17.7',
     ],
     test_suite='tests',
     keywords=['apple', 'tv'],


### PR DESCRIPTION
Require the least-known-to-work version to minimize risk for dependency
problems for users. Fixes #42.