### PR TITLE
Support arrow keys for ATV4

### DIFF
--- a/pyatv/dmap.py
+++ b/pyatv/dmap.py
@@ -55,14 +55,19 @@ def parse(data, tag_lookup):
 
 
 # TODO: Rewrite this (you should be proud if you understand it...)
-def first(dmap_data, *path):
-    """Look up a value given a path in some parsed DMAP data."""
+def matches(dmap_data, *path):
+    """Look up all values matching a path in some parsed DMAP data."""
     if not (path and isinstance(dmap_data, list)):
-        return dmap_data
+        yield dmap_data
 
     for key in dmap_data:
         if path[0] in key:
-            return first(key[path[0]], *path[1:])
+            yield first(key[path[0]], *path[1:])
+
+
+def first(dmap_data, *path):
+    """Look up a value given a path in some parsed DMAP data."""
+    return next(matches(dmap_data, *path))
 
 
 # #TODO: Also a bad method that should be re-written

--- a/tests/test_dmap.py
+++ b/tests/test_dmap.py
@@ -78,6 +78,16 @@ class DmapTest(unittest.TestCase):
         parsed = dmap.parse(in_data, lookup_tag)
         self.assertEqual(12, dmap.first(parsed, 'cona', 'conb', 'uuu8'))
 
+    def test_extract_multiple_with_same_name(self):
+        in_data = tags.uint8_tag('uuu8', 1) + \
+                  tags.uint8_tag('uuu8', 2) + \
+                  tags.uint8_tag('uuu8', 3)
+        parsed = dmap.parse(in_data, lookup_tag)
+        iter = dmap.matches(parsed, 'uuu8')
+        self.assertEqual(1, next(iter))
+        self.assertEqual(2, next(iter))
+        self.assertEqual(3, next(iter))
+
     def test_ignore_value(self):
         elem = tags.uint8_tag('igno', 44)
         parsed = dmap.parse(elem, lookup_tag)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -131,6 +131,37 @@ class FunctionalTest(AioHTTPTestCase):
         session_id = yield from self.atv.login()
         self.assertEqual(SESSION_ID, session_id)
 
+    # When moving around using the arrow keys, a sequence of seven
+    # different requests are sent to the device. To simplify the
+    # test, verify that seven commands were sent and that the last
+    # command matches the expected arrow key. This does not guarantee
+    # that the earlier six commands were correct, but it's good
+    # enough to keep the tests clean.
+
+    @unittest_run_loop
+    def test_button_up(self):
+        yield from self.atv.remote_control.up()
+        self.assertEqual(self.fake_atv.buttons_press_count, 7)
+        self.assertEqual(self.fake_atv.last_button_pressed, 'up')
+
+    @unittest_run_loop
+    def test_button_down(self):
+        yield from self.atv.remote_control.down()
+        self.assertEqual(self.fake_atv.buttons_press_count, 7)
+        self.assertEqual(self.fake_atv.last_button_pressed, 'down')
+
+    @unittest_run_loop
+    def test_button_left(self):
+        yield from self.atv.remote_control.left()
+        self.assertEqual(self.fake_atv.buttons_press_count, 7)
+        self.assertEqual(self.fake_atv.last_button_pressed, 'left')
+
+    @unittest_run_loop
+    def test_button_right(self):
+        yield from self.atv.remote_control.right()
+        self.assertEqual(self.fake_atv.buttons_press_count, 7)
+        self.assertEqual(self.fake_atv.last_button_pressed, 'right')
+
     @unittest_run_loop
     def test_button_play(self):
         yield from self.atv.remote_control.play()


### PR DESCRIPTION
This is the quick-n-easy solution where I ignore the fact that ATV3 does not seem to support these commands. But since it just ignores them I find it to be good enough since it does not increase complexity of handling multiple device types in the library.

I have not verified if this PR works since I don't own a gen 4 device, so if someone can help me with that I would be grateful. Will not merge until verification is done.