### PR TITLE
Remove wait_for with timeout in atvremote

### DIFF
--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -300,10 +300,9 @@ def main():
     """Start the asyncio event loop and runs the application."""
     # Helper method so that the coroutine exits cleanly if an exception
     # happens (which would leave resources dangling)
-    @asyncio.coroutine
     def _run_application(loop):
         try:
-            return (yield from asyncio.wait_for(cli_handler(loop), timeout=15))
+            return cli_handler(loop)
 
         except KeyboardInterrupt:
             pass  # User pressed Ctrl+C, just ignore it


### PR DESCRIPTION
In the beginning it was used to ensure that commands did nog hang for
too long, but it doesn't work with long running tasks like AirPlay.
This fixes #68.