### PR TITLE
Multiple commands

### DIFF
--- a/tests/test_airplay.py
+++ b/tests/test_airplay.py
@@ -30,8 +30,9 @@ class AirPlayTest(AioHTTPTestCase):
         AioHTTPTestCase.tearDown(self)
         self.log_handler.tearDown()
 
-    def get_app(self, loop):
-        self.fake_atv = FakeAppleTV(loop, 0, 0, 0, self)
+    @asyncio.coroutine
+    def get_application(self, loop=None):
+        self.fake_atv = FakeAppleTV(self.loop, 0, 0, 0, self)
         self.usecase = AppleTVUseCases(self.fake_atv)
 
         # Import TestServer here and not globally, otherwise py.test will

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -49,9 +49,9 @@ class FunctionalTest(AioHTTPTestCase):
         self.log_handler.tearDown()
 
     @asyncio.coroutine
-    def get_application(self, loop):
+    def get_application(self, loop=None):
         self.fake_atv = FakeAppleTV(
-            loop, HSGID, PAIRING_GUID, SESSION_ID, self)
+            self.loop, HSGID, PAIRING_GUID, SESSION_ID, self)
         self.usecase = AppleTVUseCases(self.fake_atv)
 
         # Import TestServer here and not globally, otherwise py.test will


### PR DESCRIPTION
It is now possible to specify multiple commands at the same time, which
decreases execution time a lot. An example:

   atvremote -a topmenu right down menu menu

Note: Arrow keys, e.g. right and down, are not yet supported.