### PR TITLE
Require at least aiohttp 1.3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements
 
 - python>=3.4.2
 - zeroconf>=0.17.7
-- aiohttp>=1.3.0
+- aiohttp>=1.3.5
 
 Getting started
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,7 +84,7 @@ Dependencies
 
 - python>=3.4.2
 - zeroconf>=0.17.7
-- aiohttp>=1.3.0
+- aiohttp>=1.3.5
 
 Contributing
 ------------

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'aiohttp>=1.3.5',
+        'aiohttp>=1.3.5, <3.0',
         'zeroconf>=0.17.7',
     ],
     test_suite='tests',


### PR DESCRIPTION
Push updates stopped working around 1.3.2-1.3.4 but bug was fixed in
aiohttp 1.3.5. Also pin upper version so that < 3.0 is required.