### PR TITLE
Extract AirPlay code to separate interface

### DIFF
--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -9,9 +9,7 @@ from collections import namedtuple
 from zeroconf import ServiceBrowser, Zeroconf
 from aiohttp import ClientSession
 
-from pyatv.airplay import AirPlay
 from pyatv.pairing import PairingHandler
-from pyatv.daap import (DaapSession, DaapRequester)
 from pyatv.internal.apple_tv import AppleTVInternal
 
 _LOGGER = logging.getLogger(__name__)
@@ -116,11 +114,7 @@ def connect_to_apple_tv(details, loop, session=None):
 
     # If/when needed, the library should figure out the correct type of Apple
     # TV and return the correct type for it.
-    airplay = AirPlay(loop, session, details.address)
-    daap_session = DaapSession(session)
-    requester = DaapRequester(
-        daap_session, details.address, details.login_id, details.port)
-    return AppleTVInternal(loop, session, requester, airplay)
+    return AppleTVInternal(loop, session, details)
 
 
 def pair_with_apple_tv(loop, pin_code, name, pairing_guid=None):

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -227,12 +227,15 @@ def _handle_commands(args, loop):
     return 0
 
 
+# pylint: disable=too-many-return-statements
 @asyncio.coroutine
 def _handle_command(args, cmd, atv, loop):
+    # TODO: Add these to array and use a loop
     playing_resp = yield from atv.metadata.playing()
     ctrl = retrieve_commands(atv.remote_control, developer=args.developer)
     metadata = retrieve_commands(atv.metadata, developer=args.developer)
     playing = retrieve_commands(playing_resp, developer=args.developer)
+    airplay = retrieve_commands(atv.airplay, developer=args.developer)
     other = {'push_updates': 'Listen for push updates'}
 
     # Parse input command and argument from user
@@ -241,6 +244,7 @@ def _handle_command(args, cmd, atv, loop):
         _print_commands('Remote control', ctrl)
         _print_commands('Metadata', metadata)
         _print_commands('Playing', playing)
+        _print_commands('AirPlay', airplay)
         _print_commands('Other', other, newline=False)
 
     elif cmd == 'artwork':
@@ -267,6 +271,9 @@ def _handle_command(args, cmd, atv, loop):
 
     elif cmd in playing:
         return (yield from _exec_command(playing_resp, cmd, *cmd_args))
+
+    elif cmd in airplay:
+        return (yield from _exec_command(atv.airplay, cmd, *cmd_args))
 
     else:
         logging.error('Unknown command: %s', args.command[0])

--- a/pyatv/airplay/__init__.py
+++ b/pyatv/airplay/__init__.py
@@ -1,0 +1,1 @@
+"""AirPlay related functionality."""

--- a/pyatv/airplay/player.py
+++ b/pyatv/airplay/player.py
@@ -15,7 +15,7 @@ TIMEOUT = 10
 
 
 # pylint: disable=too-few-public-methods
-class AirPlay:
+class AirPlayPlayer:
     """This class helps with playing media from an URL."""
 
     def __init__(self, loop, session, address):
@@ -25,12 +25,12 @@ class AirPlay:
         self.session = session
 
     @asyncio.coroutine
-    def play_url(self, url, start_position, port=AIRPLAY_PORT):
+    def play_url(self, url, position=0, port=AIRPLAY_PORT):
         """Play media from an URL on the device."""
         headers = {'User-Agent': 'MediaControl/1.0',
                    'Content-Type': 'text/parameters'}
         body = "Content-Location: {}\nStart-Position: {}\n\n".format(
-            url, start_position)
+            url, position)
 
         address = self._url(port, 'play')
         _LOGGER.debug('AirPlay %s to %s', url, address)

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -122,11 +122,6 @@ class RemoteControl(object):
         """Change repeat mode."""
         raise exceptions.NotSupportedError
 
-    @abstractmethod
-    def play_url(self, url, start_position=0, port=7000):
-        """Play media from an URL on the device."""
-        raise exceptions.NotSupportedError
-
 
 class Playing(object):
     """Base class for retrieving what is currently playing."""
@@ -278,6 +273,17 @@ class PushUpdater(object):
         raise exceptions.NotSupportedError
 
 
+class AirPlay(object):
+    """Base class for AirPlay functionality."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def play_url(self, url, **kwargs):
+        """Play media from an URL on the device."""
+        raise exceptions.NotSupportedError
+
+
 class AppleTV(object):
     """Base class representing an Apple TV."""
 
@@ -312,4 +318,9 @@ class AppleTV(object):
     @abstractproperty
     def push_updater(self):
         """Return API for handling push update from the Apple TV."""
+        raise exceptions.NotSupportedError
+
+    @abstractproperty
+    def airplay(self):
+        """Return API for working with AirPlay."""
         raise exceptions.NotSupportedError

--- a/tests/test_airplay.py
+++ b/tests/test_airplay.py
@@ -6,7 +6,7 @@ from tests.log_output_handler import LogOutputHandler
 from aiohttp import ClientSession
 from aiohttp.test_utils import (AioHTTPTestCase, unittest_run_loop)
 
-from pyatv import airplay
+from pyatv.airplay import player
 from tests.fake_apple_tv import (FakeAppleTV, AppleTVUseCases)
 
 
@@ -14,7 +14,7 @@ STREAM = 'http://airplaystream'
 START_POSITION = 0.8
 
 
-class AirPlayTest(AioHTTPTestCase):
+class AirPlayPlayerTest(AioHTTPTestCase):
 
     def setUp(self):
         AioHTTPTestCase.setUp(self)
@@ -23,7 +23,7 @@ class AirPlayTest(AioHTTPTestCase):
         # This is a hack that overrides asyncio.sleep to avoid making the test
         # slow. It also counts number of calls, since this is quite important
         # to the general function.
-        airplay.asyncio.sleep = self.fake_asyncio_sleep
+        player.asyncio.sleep = self.fake_asyncio_sleep
         self.no_of_sleeps = 0
 
     def tearDown(self):
@@ -54,8 +54,9 @@ class AirPlayTest(AioHTTPTestCase):
         self.usecase.airplay_playback_idle()
 
         session = ClientSession(loop=self.loop)
-        aplay = airplay.AirPlay(self.loop, session, '127.0.0.1')
-        yield from aplay.play_url(STREAM, START_POSITION, self.app.port)
+        aplay = player.AirPlayPlayer(self.loop, session, '127.0.0.1')
+        yield from aplay.play_url(
+            STREAM, position=START_POSITION, port=self.app.port)
 
         self.assertEqual(self.fake_atv.last_airplay_url, STREAM)
         self.assertEqual(self.fake_atv.last_airplay_start, START_POSITION)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -95,8 +95,8 @@ class FunctionalTest(AioHTTPTestCase):
         self.usecase.airplay_playback_playing()
         self.usecase.airplay_playback_idle()
 
-        yield from self.atv.remote_control.play_url(
-            AIRPLAY_STREAM, 0, port=self.app.port)
+        yield from self.atv.airplay.play_url(
+            AIRPLAY_STREAM, port=self.app.port)
 
         self.assertEqual(self.fake_atv.last_airplay_url, AIRPLAY_STREAM)
 


### PR DESCRIPTION
AirPlay will play a bigger part in the future, e.g. with device
authentication. Adding new features in a good way with current API is
pretty tough, so this change aims to make that easier by extracting
AirPlay to a separate public interface (similar to remote_control or
playing).

THIS IS A BREAKING CHANGE! The play_url has moved from remote_control
to airplay and all users must update their code.