### PR TITLE
Do no requests when listing commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,9 @@ Changes:
 - Support scanning for Apple TVs with home sharing disabled
 - Support for shuffle and repeat modes
 - Support for "stop" button
+- New "hash" function in Playing API
 - Multiple commands can be given to atvremote
+- Doing "atvremote commands" requires no device and is a lot faster
 - Handle additional media kinds
 - Fix atvremote exit codes
 - Support python 3.6

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -28,7 +28,7 @@ def _get_first_sentence_in_pydoc(obj):
 def retrieve_commands(obj, developer=False):
     """Retrieve all commands and help texts from an API object."""
     commands = {}  # Name and help
-    for member in [obj]+obj.__class__.mro():
+    for member in [obj]:
         for func in member.__dict__:
             if not inspect.isfunction(member.__dict__[func]) and \
                not isinstance(member.__dict__[func], property):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -104,8 +104,7 @@ class PlayingDummy(interface.Playing):
 class InterfaceTest(unittest.TestCase):
 
     def setUp(self):
-        self.obj = TestClass()
-        self.methods = interface.retrieve_commands(self.obj)
+        self.methods = interface.retrieve_commands(TestClass)
 
     # COMMANDS AND HELP TEXT
 
@@ -117,7 +116,7 @@ class InterfaceTest(unittest.TestCase):
         self.assertTrue('abbrev_help' in self.methods)
 
     def test_get_developer_command(self):
-        methods = interface.retrieve_commands(self.obj, developer=True)
+        methods = interface.retrieve_commands(TestClass, developer=True)
         self.assertEqual(6, len(methods))
         self.assertEqual('Developer help', methods['dev_method'])
 


### PR DESCRIPTION
Previously when doing "atvremote commands", a device was needed and a
connection was made to it in order to figure out explicitly which
commands the device supports. All devices are currently treated as
supporting all commands so it just slows everything down. Listing
commands is now fast.