### PR TITLE
Remove developer commands from atvremote

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,8 +189,7 @@ You can run the tests with ``python setup.py test``. Also, make sure that
 pylint, flake8 and pydoc passes before committing. This is done automatically
 if you run just run ``tox``.
 
-When using ``atvremote``, pass ``--developer`` to enable some developer friendly
-commands. You may also pass ``--debug`` to get better logging.
+When using ``atvremote``, pass ``--debug`` to get better logging.
 
 .. |Build Status| image:: https://travis-ci.org/postlund/pyatv.svg?branch=master
    :target: https://travis-ci.org/postlund/pyatv

--- a/docs/atvremote.rst
+++ b/docs/atvremote.rst
@@ -237,6 +237,4 @@ If you want additional help for a specific command, use ``help``:
 Logging and debugging
 ---------------------
 You can enable additional debugging information by specifying either
-``--verbose`` or ``--debug``. There are also some additional developer commands
-that might be useful, if you also specify ``--developer``. They will
-show up if you query all available commands.
+``--verbose`` or ``--debug``.

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -16,6 +16,13 @@ from pyatv import (const, dmap, exceptions, interface, tag_definitions)
 from pyatv.interface import retrieve_commands
 
 
+def _print_commands(title, api):
+    cmd_list = retrieve_commands(api)
+    commands = ' - ' + '\n - '.join(
+        map(lambda x: x[0] + ' - ' + x[1], sorted(cmd_list.items())))
+    print('{} commands:\n{}\n'.format(title, commands))
+
+
 class GlobalCommands:
     """Commands not bound to a specific device."""
 
@@ -27,20 +34,14 @@ class GlobalCommands:
     @asyncio.coroutine
     def commands(self):
         """Print a list with available commands."""
-        self._print_commands('Remote control', interface.RemoteControl)
-        self._print_commands('Metadata', interface.Metadata)
-        self._print_commands('Playing', interface.Playing)
-        self._print_commands('AirPlay', interface.AirPlay)
-        self._print_commands('Device', DeviceCommands)
-        self._print_commands('Global', self.__class__)
+        _print_commands('Remote control', interface.RemoteControl)
+        _print_commands('Metadata', interface.Metadata)
+        _print_commands('Playing', interface.Playing)
+        _print_commands('AirPlay', interface.AirPlay)
+        _print_commands('Device', DeviceCommands)
+        _print_commands('Global', self.__class__)
 
         return 0
-
-    def _print_commands(self, title, api):
-        cmd_list = retrieve_commands(api, self.args.developer)
-        commands = ' - ' + '\n - '.join(
-            map(lambda x: x[0] + ' - ' + x[1], sorted(cmd_list.items())))
-        print('{} commands:\n{}\n'.format(title, commands))
 
     @asyncio.coroutine
     def help(self):
@@ -225,9 +226,6 @@ def cli_handler(loop):
     debug = parser.add_argument_group('debugging')
     debug.add_argument('-v', '--verbose', help='increase output verbosity',
                        action='store_true', dest='verbose')
-    debug.add_argument('--developer', help='show developer commands',
-                       action='store_true', dest='developer',
-                       default=False)
     debug.add_argument('--debug', help='print debug information',
                        action='store_true', dest='debug')
 
@@ -247,7 +245,7 @@ def cli_handler(loop):
             (not args.login_id and args.address):
         parser.error('both --login_id and --address must be given')
 
-    cmds = retrieve_commands(GlobalCommands, developer=args.developer)
+    cmds = retrieve_commands(GlobalCommands)
 
     if args.command[0] in cmds:
         glob_cmds = GlobalCommands(args, loop)
@@ -343,11 +341,11 @@ def _handle_commands(args, loop):
 @asyncio.coroutine
 def _handle_device_command(args, cmd, atv, loop):
     # TODO: Add these to array and use a loop
-    device = retrieve_commands(DeviceCommands, developer=args.developer)
-    ctrl = retrieve_commands(interface.RemoteControl, developer=args.developer)
-    metadata = retrieve_commands(interface.Metadata, developer=args.developer)
-    playing = retrieve_commands(interface.Playing, developer=args.developer)
-    airplay = retrieve_commands(interface.AirPlay, developer=args.developer)
+    device = retrieve_commands(DeviceCommands)
+    ctrl = retrieve_commands(interface.RemoteControl)
+    metadata = retrieve_commands(interface.Metadata)
+    playing = retrieve_commands(interface.Playing)
+    airplay = retrieve_commands(interface.AirPlay)
 
     # Parse input command and argument from user
     cmd, cmd_args = _extract_command_with_args(cmd)

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -25,20 +25,17 @@ def _get_first_sentence_in_pydoc(obj):
     return doc[0:index]
 
 
-def retrieve_commands(obj, developer=False):
+def retrieve_commands(obj):
     """Retrieve all commands and help texts from an API object."""
     commands = {}  # Name and help
-    for member in [obj]:
-        for func in member.__dict__:
-            if not inspect.isfunction(member.__dict__[func]) and \
-               not isinstance(member.__dict__[func], property):
-                continue
-            if func.startswith('_'):
-                continue
-            if func.startswith('dev_') and not developer:
-                continue
-            commands[func] = _get_first_sentence_in_pydoc(
-                member.__dict__[func])
+    for func in obj.__dict__:
+        if not inspect.isfunction(obj.__dict__[func]) and \
+           not isinstance(obj.__dict__[func], property):
+            continue
+        if func.startswith('_'):
+            continue
+        commands[func] = _get_first_sentence_in_pydoc(
+            obj.__dict__[func])
     return commands
 
 

--- a/pyatv/internal/apple_tv.py
+++ b/pyatv/internal/apple_tv.py
@@ -304,22 +304,6 @@ class MetadataInternal(Metadata):
         playstatus = yield from self.apple_tv.playstatus()
         return PlayingInternal(playstatus)
 
-    def dev_playstatus(self):
-        """Return raw playstatus response (developer command)."""
-        return self.apple_tv.playstatus()
-
-    def dev_playstatus_wait(self):
-        """Wait for device to change state(developer command)."""
-        return self.apple_tv.playstatus(use_revision=True)
-
-    def dev_playqueue(self):
-        """Return raw playqueue response (developer command)."""
-        return self.apple_tv.playqueue()
-
-    def dev_server_info(self):
-        """Return raw server-info sersponse (developer command)."""
-        return self.apple_tv.server_info()
-
 
 class PushUpdaterInternal(PushUpdater):
     """Implementation of API for handling push update from an Apple TV."""

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -22,10 +22,6 @@ class TestClass:
         """Property help"""
         pass
 
-    def dev_method(self):
-        """Developer help."""
-        pass
-
     def abbrev_help(self):
         """Type, e.g. a, b or c."""
         pass
@@ -114,11 +110,6 @@ class InterfaceTest(unittest.TestCase):
         self.assertTrue('another_method' in self.methods)
         self.assertTrue('some_property' in self.methods)
         self.assertTrue('abbrev_help' in self.methods)
-
-    def test_get_developer_command(self):
-        methods = interface.retrieve_commands(TestClass, developer=True)
-        self.assertEqual(6, len(methods))
-        self.assertEqual('Developer help', methods['dev_method'])
 
     def test_get_first_sentence_without_leading_period_in_pydoc(self):
         self.assertEqual('Help text', self.methods['test_method'])


### PR DESCRIPTION
They no longer work after refactoring commands and help texts. This
makes the code less cluttered and conforms to the public API better.