### PR TITLE
Fix broken device_id

### DIFF
--- a/pyatv/internal/apple_tv.py
+++ b/pyatv/internal/apple_tv.py
@@ -10,6 +10,8 @@ import asyncio
 import binascii
 import hashlib
 
+from urllib.parse import urlparse
+
 from pyatv import (const, exceptions, dmap, tags, convert)
 from pyatv.airplay import player
 from pyatv.daap import DaapRequester
@@ -290,9 +292,9 @@ class MetadataInternal(Metadata):
         super().__init__()
         self.apple_tv = apple_tv
 
-        # Strip port number and base hash only on address
-        self._device_id = hashlib.sha256(
-            daap.base_url.split(':')[0].encode('utf-8')).hexdigest()
+        # Extract hostname and use that as base for hash
+        address = urlparse(daap.base_url).hostname
+        self._device_id = hashlib.sha256(address.encode('utf-8')).hexdigest()
 
     @property
     def device_id(self):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -236,10 +236,10 @@ class FunctionalTest(AioHTTPTestCase):
         self.assertEqual(self.fake_atv.last_button_pressed, 'topmenu')
 
     def test_metadata_device_id(self):
-        # This is a reference case for a server running at 127.0.0.1
+        # This is a reference case for a server running at 127.0.0.1:3689
         self.assertEqual(
             self.atv.metadata.device_id,
-            'e0603c499aae47eb89343ad0ef3178e044c62e70ae2309b35591d1d49a3211ec')
+            '12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0')
 
     @unittest_run_loop
     def test_metadata_artwork(self):


### PR DESCRIPTION
The intention behind device_id is to generate a unique device ID using the device address. I failed this simple mission by not properly handle the input URL, assuming it was using format ip:port instead of http://ip:port. This resulted in "http" was used as address for all devices. So basically always the same hash. This PR fixes this embarrassing issue...