### PR TITLE
Add base code for MRP

### DIFF
--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -296,7 +296,8 @@ def _print_found_apple_tvs(atvs, outstream=sys.stdout):
 @asyncio.coroutine
 def _handle_autodiscover(args, loop):
     atvs = yield from pyatv.scan_for_apple_tvs(
-        loop, timeout=args.scan_timeout, abort_on_found=True)
+        loop, timeout=args.scan_timeout, abort_on_found=True,
+        device_ip=args.address, only_usable=False)
     if not atvs:
         logging.error('Could not find any Apple TV on current network')
         return 1
@@ -307,7 +308,12 @@ def _handle_autodiscover(args, loop):
         return 1
 
     apple_tv = atvs[0]
-    service = apple_tv.usable_service()
+
+    # Extract the preferred service here instead of a usable service. The
+    # reason for this is that some services are never usable after a scan,
+    # like MRP, but might become usable after the user has filled in
+    # additional information (which will be done here).
+    service = apple_tv.preferred_service()
 
     # Common parameters for all protocols
     args.address = apple_tv.address

--- a/pyatv/dmap/apple_tv.py
+++ b/pyatv/dmap/apple_tv.py
@@ -7,13 +7,11 @@ import hashlib
 from urllib.parse import urlparse
 
 from pyatv import (const, exceptions, convert)
-from pyatv.airplay import player
 from pyatv.dmap import (parser, tags)
 from pyatv.dmap.daap import DaapRequester
 from pyatv.net import HttpSession
 from pyatv.interface import (AppleTV, RemoteControl, Metadata,
                              Playing, PushUpdater)
-from pyatv.airplay.api import AirPlayAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -397,7 +395,7 @@ class DmapAppleTV(AppleTV):
 
     # This is a container class so it's OK with many attributes
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, loop, session, details):
+    def __init__(self, loop, session, details, airplay):
         """Initialize a new Apple TV."""
         super().__init__()
         self._session = session
@@ -412,14 +410,7 @@ class DmapAppleTV(AppleTV):
         self._atv_remote = DmapRemoteControl(self._apple_tv)
         self._atv_metadata = DmapMetadata(self._apple_tv, daap_http)
         self._atv_push_updater = DmapPushUpdater(loop, self._apple_tv)
-
-        airplay_service = details.airplay_service()
-        airplay_player = player.AirPlayPlayer(
-            loop, session, details.address, airplay_service.port)
-        airplay_http = HttpSession(
-            session, 'http://{0}:{1}/'.format(
-                details.address, airplay_service.port))
-        self._airplay = AirPlayAPI(airplay_http, airplay_player)
+        self._airplay = airplay
 
     def login(self):
         """Perform an explicit login.

--- a/pyatv/mrp/apple_tv.py
+++ b/pyatv/mrp/apple_tv.py
@@ -1,0 +1,81 @@
+"""Implementation of the MediaRemoteTV Protocol used by ATV4 and later."""
+
+import logging
+import asyncio
+
+from pyatv.interface import (AppleTV, RemoteControl, Metadata,
+                             Playing, PushUpdater)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MrpRemoteControl(RemoteControl):
+    """Implementation of API for controlling an Apple TV."""
+
+    pass
+
+
+class MrpPlaying(Playing):
+    """Implementation of API for retrieving what is playing."""
+
+    pass
+
+
+class MrpMetadata(Metadata):
+    """Implementation of API for retrieving metadata."""
+
+    pass
+
+
+class MrpPushUpdater(PushUpdater):
+    """Implementation of API for handling push update from an Apple TV."""
+
+    pass
+
+
+class MrpAppleTV(AppleTV):
+    """Implementation of API support for Apple TV."""
+
+    # This is a container class so it's OK with many attributes
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, loop, session, details, airplay):
+        """Initialize a new Apple TV."""
+        super().__init__()
+
+        self._atv_remote = MrpRemoteControl()
+        self._atv_metadata = MrpMetadata()
+        self._atv_push_updater = MrpPushUpdater()
+        self._airplay = airplay
+
+    @asyncio.coroutine
+    def login(self):
+        """Perform an explicit login."""
+        _LOGGER.debug('Login called')
+
+    @asyncio.coroutine
+    def logout(self):
+        """Perform an explicit logout.
+
+        Must be done when session is no longer needed to not leak resources.
+        """
+        _LOGGER.debug('Logout called')
+
+    @property
+    def remote_control(self):
+        """Return API for controlling the Apple TV."""
+        return self._atv_remote
+
+    @property
+    def metadata(self):
+        """Return API for retrieving metadata from Apple TV."""
+        return self._atv_metadata
+
+    @property
+    def push_updater(self):
+        """Return API for handling push update from the Apple TV."""
+        return self._atv_push_updater
+
+    @property
+    def airplay(self):
+        """Return API for working with AirPlay."""
+        return self._airplay

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -123,3 +123,12 @@ class FunctionalTest(asynctest.TestCase):
 
         service = services[0]
         self.assertEqual(service.port, 7000)
+
+    def test_scan_for_particular_device(self):
+        zeroconf_stub.stub(pyatv, HOMESHARING_SERVICE_1, HOMESHARING_SERVICE_2)
+
+        atvs = yield from pyatv.scan_for_apple_tvs(
+            self.loop, timeout=0, only_usable=False, device_ip='10.0.0.2')
+        self.assertEqual(len(atvs), 1)
+        self.assertEqual(atvs[0].name, 'Apple TV 2')
+        self.assertEqual(atvs[0].address, ipaddress.ip_address('10.0.0.2'))


### PR DESCRIPTION
This code is not usable at the moment as an MRP device can never have a
usable service at the moment. But the base code is there to allow for
further implementation.