### PR TITLE
Decode ceSD in DMAP

### DIFF
--- a/pyatv/dmap/parser.py
+++ b/pyatv/dmap/parser.py
@@ -11,7 +11,7 @@ a four byte big endian unsigned int as length and the data as data. So:
 from collections import namedtuple
 
 from pyatv import exceptions
-from .tags import (read_str, read_uint)
+from .tags import (read_str, read_uint, read_bplist)
 
 
 class DmapTag(namedtuple('DmapTag', ['type', 'name'])):
@@ -70,7 +70,7 @@ def pprint(data, tag_lookup, indent=0):
     if isinstance(data, dict):
         for key, value in data.items():
             tag = tag_lookup(key)
-            if isinstance(value, (dict, list)):
+            if isinstance(value, (dict, list)) and tag.type != read_bplist:
                 output += '{0}{1}: {2}\n'.format(indent*' ', key, tag)
                 output += pprint(value, tag_lookup, indent+2)
             else:

--- a/pyatv/dmap/tag_definitions.py
+++ b/pyatv/dmap/tag_definitions.py
@@ -2,7 +2,8 @@
 
 import logging
 from .parser import DmapTag
-from .tags import (read_bool, read_uint, read_str, read_raw, read_ignore)
+from .tags import (
+    read_bool, read_uint, read_str, read_ignore, read_bplist)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ _TAGS = {
     'cave': DmapTag(read_bool,   'dacp.dacpvisualizerenabled'),
     'cavs': DmapTag(read_uint,   'dacp.visualizer'),
     'ceQR': DmapTag('container', 'com.apple.itunes.playqueue-contents-response'),  # NOQA
+    'ceSD': DmapTag(read_bplist, 'playing metadata'),
     'cmcp': DmapTag('container', 'dmcp.controlprompt'),
     'cmmk': DmapTag(read_uint,   'dmcp.mediakind'),
     'cmnm': DmapTag(read_str,    'dacp.devicename'),
@@ -85,7 +87,6 @@ _TAGS = {
     'casc': DmapTag(read_uint,   'unknown tag'),
     'cass': DmapTag(read_uint,   'unknown tag'),
     'ceQA': DmapTag(read_uint,   'unknown tag'),
-    'ceSD': DmapTag(read_raw,    'unknown tag'),
     'cmbe': DmapTag(read_str,    'unknown tag'),
     'cmcc': DmapTag(read_str,    'unknown tag'),
     'cmce': DmapTag(read_str,    'unknown tag'),

--- a/pyatv/dmap/tags.py
+++ b/pyatv/dmap/tags.py
@@ -1,5 +1,7 @@
 """Util functions for extracting and constructing DMAP data."""
 
+import plistlib
+
 
 def read_str(data, start, length):
     """Extract a string from a position in a sequence."""
@@ -16,9 +18,12 @@ def read_bool(data, start, length):
     return read_uint(data, start, length) == 1
 
 
-def read_raw(data, start, length):
-    """Extract raw data from a position in a sequence."""
-    return data[start:start+length]
+def read_bplist(data, start, length):
+    """Extract a binary plist from a position in a sequence."""
+    # TODO: pylint doesn't find FMT_BINARY, why?
+    # pylint: disable=no-member
+    return plistlib.loads(data[start:start+length],
+                          fmt=plistlib.FMT_BINARY)
 
 
 # pylint: disable=unused-argument

--- a/tests/dmap/test_parser.py
+++ b/tests/dmap/test_parser.py
@@ -1,6 +1,7 @@
 """Unit tests for pyatv.dmap.parser."""
 
 import unittest
+import plistlib
 
 from pyatv import exceptions
 from pyatv.dmap import (tags, parser)
@@ -14,10 +15,10 @@ TEST_TAGS = {
     'bolb': parser.DmapTag(tags.read_bool, 'bool'),
     'stra': parser.DmapTag(tags.read_str, 'string'),
     'strb': parser.DmapTag(tags.read_str, 'string'),
-    'rawa': parser.DmapTag(tags.read_raw, 'raw'),
     'cona': parser.DmapTag('container', 'container'),
     'conb': parser.DmapTag('container', 'container 2'),
     'igno': parser.DmapTag(tags.read_ignore, 'ignore'),
+    'plst': parser.DmapTag(tags.read_bplist, 'bplist'),
 }
 
 
@@ -55,11 +56,13 @@ class ParserTest(unittest.TestCase):
         self.assertEqual('', parser.first(parsed, 'stra'))
         self.assertEqual('test string', parser.first(parsed, 'strb'))
 
-    def test_parse_raw_data(self):
-        in_data = tags.raw_tag('rawa', b'\x01\x02\x03')
+    def test_parse_binary_plist(self):
+        data = {"key": "value"}
+        in_data = tags.raw_tag(
+            'plst', plistlib.dumps(data, fmt=plistlib.FMT_BINARY))
         parsed = parser.parse(in_data, lookup_tag)
         self.assertEqual(1, len(parsed))
-        self.assertEqual(b'\x01\x02\x03', parser.first(parsed, 'rawa'))
+        self.assertEqual(data, parser.first(parsed, 'plst'))
 
     def test_parse_value_in_container(self):
         in_data = tags.container_tag('cona',


### PR DESCRIPTION
The ceSD tag (unknown name) contains additional metadata about what is
playing. More exactly it contains an id that maps to the media in it's
source service (e.g. if it's a Youtube video it would be a Youtube id).