### PR TITLE
Suspend support for MRP

### DIFF
--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -177,6 +177,11 @@ class DmapRemoteControl(RemoteControl):
         """Press key topmenu."""
         return self.apple_tv.controlprompt_cmd('topmenu')
 
+    async def suspend(self):
+        """Suspend the device."""
+        # Not supported by DMAP
+        raise exceptions.NotSupportedError
+
     def set_position(self, pos):
         """Seek in the current playing media."""
         time_in_ms = int(pos)*1000

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -144,6 +144,11 @@ class RemoteControl:
         raise exceptions.NotSupportedError
 
     @abstractmethod
+    def suspend(self):
+        """Suspend the device."""
+        raise exceptions.NotSupportedError
+
+    @abstractmethod
     def set_position(self, pos):
         """Seek in the current playing media."""
         raise exceptions.NotSupportedError

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -29,6 +29,7 @@ _KEY_LOOKUP = {
     'select': [1, 0x89],
     'menu': [1, 0x86],
     'top_menu': [12, 0x60],
+    'suspend': [1, 0x82],
 
     # 'mic': [12, 0x04]  # Siri
 }
@@ -99,6 +100,10 @@ class MrpRemoteControl(RemoteControl):
     def top_menu(self):
         """Go to main menu (long press menu)."""
         return self._press_key('top_menu')
+
+    def suspend(self):
+        """Suspend the device."""
+        return self._press_key('suspend')
 
     def set_position(self, pos):
         """Seek in the current playing media."""

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -56,6 +56,11 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         details.add_service(AirPlayService(self.server.port))
         return connect_to_apple_tv(details, self.loop)
 
+    @unittest_run_loop
+    async def test_not_supportedt(self):
+        with self.assertRaises(exceptions.NotSupportedError):
+            await self.atv.remote_control.suspend()
+
     # This is not a pretty test and it does crazy things. Should probably be
     # re-written later but will do for now.
     @unittest_run_loop


### PR DESCRIPTION
Experimental suspend support for MRP. It is not supported with DMAP. Should work by running

`atvremote -a --protocol mrp suspend`