### PR TITLE
Use iPhone as device type when pairing

### DIFF
--- a/pyatv/pairing.py
+++ b/pyatv/pairing.py
@@ -112,7 +112,7 @@ class PairingHandler:
         if self._verify_pin(received_code):
             cmpg = tags.uint64_tag('cmpg', int(self.pairing_guid, 16))
             cmnm = tags.string_tag('cmnm', self._name)
-            cmty = tags.string_tag('cmty', 'ipod')
+            cmty = tags.string_tag('cmty', 'iPhone')
             response = tags.container_tag('cmpa', cmpg + cmnm + cmty)
             self.has_paired = True
             return web.Response(body=response)

--- a/tests/fake_apple_tv.py
+++ b/tests/fake_apple_tv.py
@@ -293,7 +293,7 @@ class FakeAppleTV(web.Application):
         self.tc.assertEqual(dmap.first(parsed, 'cmpa', 'cmpg'), 1)
         self.tc.assertEqual(dmap.first(parsed, 'cmpa', 'cmnm'),
                             pairing_response.remote_name)
-        self.tc.assertEqual(dmap.first(parsed, 'cmpa', 'cmty'), 'ipod')
+        self.tc.assertEqual(dmap.first(parsed, 'cmpa', 'cmty'), 'iPhone')
 
     # Verifies that all needed headers are included in the request. Should be
     # checked in all requests, but that seems a bit too much and not that

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -71,7 +71,7 @@ class PairingTest(asynctest.TestCase):
         parsed = dmap.parse(data, tag_definitions.lookup_tag)
         self.assertEqual(dmap.first(parsed, 'cmpa', 'cmpg'), 1)
         self.assertEqual(dmap.first(parsed, 'cmpa', 'cmnm'), REMOTE_NAME)
-        self.assertEqual(dmap.first(parsed, 'cmpa', 'cmty'), 'ipod')
+        self.assertEqual(dmap.first(parsed, 'cmpa', 'cmty'), 'iPhone')
 
     def test_succesful_pairing_with_any_pin(self):
         self.pairing.pin_code = None
@@ -83,7 +83,7 @@ class PairingTest(asynctest.TestCase):
         parsed = dmap.parse(data, tag_definitions.lookup_tag)
         self.assertEqual(dmap.first(parsed, 'cmpa', 'cmpg'), 1)
         self.assertEqual(dmap.first(parsed, 'cmpa', 'cmnm'), REMOTE_NAME)
-        self.assertEqual(dmap.first(parsed, 'cmpa', 'cmty'), 'ipod')
+        self.assertEqual(dmap.first(parsed, 'cmpa', 'cmty'), 'iPhone')
 
     def test_pair_custom_pairing_guid(self):
         self.pairing.pin_code = PIN_CODE2


### PR DESCRIPTION
During pairing, pyatv reports back to the Apple TV that it is an iPod.
This is mostly becuase all other libraries out there does that. But for
some reason tvOS will now remove all paired devices with the ipod type
(probably other as well - no tested). But when changed to iPhone
instead, like the iTunes Remote app sends, it sticks like it used to. So
chaning this to make pairing useful again.