### PR TITLE
Make device searchable by device id

### DIFF
--- a/examples/manual_connect.py
+++ b/examples/manual_connect.py
@@ -1,5 +1,6 @@
 """Simple example that shows how to manually connect to an Apple TV."""
 
+import sys
 import asyncio
 import pyatv
 from pyatv import conf
@@ -15,7 +16,12 @@ LOOP = asyncio.get_event_loop()
 # Method that is dispatched by the asyncio event loop
 async def print_what_is_playing(loop):
     """Connect to device and print what is playing."""
-    details = conf.AppleTV(ADDRESS, NAME)
+    device_id = pyatv.get_device_id(ADDRESS, loop)
+    if device_id is None:
+        print('Unable to determine device id', file=sys.stderr)
+        sys.exit(1)
+
+    details = conf.AppleTV(ADDRESS, device_id, NAME)
     details.add_service(conf.DmapService(HSGID))
 
     print('Connecting to {}'.format(details.address))

--- a/examples/pairing.py
+++ b/examples/pairing.py
@@ -1,10 +1,10 @@
 """Simple example showing of pairing."""
 
+import sys
 import asyncio
 from zeroconf import Zeroconf
 
 import pyatv
-from pyatv import conf
 
 
 PIN_CODE = 1234
@@ -17,9 +17,14 @@ LOOP = asyncio.get_event_loop()
 async def pair_with_device(loop):
     """Make it possible to pair with device."""
     my_zeroconf = Zeroconf()
-    details = conf.AppleTV('127.0.0.1', 'Apple TV')
-    details.add_service(conf.DmapService('login_id'))
-    atv = await pyatv.connect_to_apple_tv(details, loop)
+
+    atvs = await pyatv.scan_for_apple_tvs(loop, timeout=5)
+
+    if not atvs:
+        print('no device found', file=sys.stderr)
+        return
+
+    atv = await pyatv.connect_to_apple_tv(atvs[0], loop)
 
     atv.pairing.pin(PIN_CODE)
     await atv.pairing.start(zeroconf=my_zeroconf, name=REMOTE_NAME)

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -1,5 +1,4 @@
 """Configuration when connecting to an Apple TV."""
-
 from pyatv import convert
 from pyatv.const import (PROTOCOL_MRP, PROTOCOL_DMAP, PROTOCOL_AIRPLAY)
 
@@ -14,10 +13,11 @@ class AppleTV:
     AirPlay.
     """
 
-    def __init__(self, address, name, **kwargs):
+    def __init__(self, address, device_id, name, **kwargs):
         """Initialize a new AppleTV."""
         self.address = address
         self.name = name
+        self.device_id = device_id
         self._services = {}
         self._supported_protocols = \
             kwargs.get('supported_services', _SUPPORTED_PROTOCOLS)
@@ -77,15 +77,18 @@ class AppleTV:
     def __eq__(self, other):
         """Compare instance with another instance."""
         if isinstance(other, self.__class__):
-            print(self.address == other.address)
-            return self.address == other.address
+            return self.device_id == other.device_id
         return False
 
     def __str__(self):
         """Return a string representation of this object."""
         services = [' - {0}'.format(s) for s in self._services.values()]
-        return 'Device "{0}" at {1} supports these services:\n{2}'.format(
-            self.name, self.address, '\n'.join(services))
+        return '    Name: {0}\n' \
+               ' Address: {1}\n' \
+               '      Id: {2}\n' \
+               'Services:\n' \
+               '{3}'.format(self.name, self.address,
+                            self.device_id, '\n'.join(services))
 
 
 # pylint: disable=too-few-public-methods
@@ -141,7 +144,7 @@ class DmapService(BaseService):
 
     def __str__(self):
         """Return a string representation of this object."""
-        return super().__str__() + ', Device Credentials: {0}'.format(
+        return super().__str__() + ', Credentials: {0}'.format(
             self.device_credentials)
 
 
@@ -160,7 +163,7 @@ class MrpService(BaseService):
 
     def __str__(self):
         """Return a string representation of this object."""
-        return super().__str__() + ', Device Credentials: {0}'.format(
+        return super().__str__() + ', Credentials: {0}'.format(
             self.device_credentials)
 
 

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -363,8 +363,7 @@ class DmapAppleTV(AppleTV):
 
     # This is a container class so it's OK with many attributes
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, loop,  # pylint: disable=too-many-arguments
-                 device_id, session, details, airplay):
+    def __init__(self, loop, session, details, airplay):
         """Initialize a new Apple TV."""
         super().__init__()
         self._session = session
@@ -378,7 +377,7 @@ class DmapAppleTV(AppleTV):
 
         self._apple_tv = BaseDmapAppleTV(self._requester)
         self._dmap_remote = DmapRemoteControl(self._apple_tv)
-        self._dmap_metadata = DmapMetadata(device_id, self._apple_tv)
+        self._dmap_metadata = DmapMetadata(details.device_id, self._apple_tv)
         self._dmap_push_updater = DmapPushUpdater(loop, self._apple_tv)
         self._dmap_pairing = pairing.DmapPairingHandler(loop)
         self._airplay = airplay

--- a/pyatv/exceptions.py
+++ b/pyatv/exceptions.py
@@ -45,5 +45,5 @@ class DeviceAuthenticationError(Exception):
     """Thrown when device authentication fails."""
 
 
-class DeviceIdUnknownError(Exception):
-    """Thrown when device ID could not be determined."""
+class DeviceIdMissingError(Exception):
+    """Thrown when device id is missing."""

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -340,8 +340,7 @@ class MrpAppleTV(AppleTV):
 
     # This is a container class so it's OK with many attributes
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, loop,  # pylint: disable=too-many-arguments
-                 device_id, session, details, airplay):
+    def __init__(self, loop, session, details, airplay):
         """Initialize a new Apple TV."""
         super().__init__()
 
@@ -355,7 +354,7 @@ class MrpAppleTV(AppleTV):
             loop, self._connection, self._srp, self._mrp_service)
 
         self._mrp_remote = MrpRemoteControl(loop, self._protocol)
-        self._mrp_metadata = MrpMetadata(self._protocol, device_id)
+        self._mrp_metadata = MrpMetadata(self._protocol, details.device_id)
         self._mrp_push_updater = MrpPushUpdater(
             loop, self._mrp_metadata, self._protocol)
         self._mrp_pairing = MrpPairingHandler(

--- a/tests/common_functional_tests.py
+++ b/tests/common_functional_tests.py
@@ -35,17 +35,18 @@ class CommonFunctionalTests(AioHTTPTestCase):
         raise NotImplementedError()
 
     @unittest_run_loop
-    async def test_failed_to_determine_device_id(self):
-        conf = AppleTV(getmac_stub.IP_UNKNOWN, 'Apple TV')
-
-        with self.assertRaises(exceptions.DeviceIdUnknownError):
-            await pyatv.connect_to_apple_tv(conf, self.loop)
+    async def test_get_device_id(self):
+        self.assertIsNone(
+            await pyatv.get_device_id(getmac_stub.IP_UNKNOWN, self.loop))
+        self.assertEqual(
+            await pyatv.get_device_id(getmac_stub.IP, self.loop),
+            'aabbccddeeff')
 
     @unittest_run_loop
-    async def test_device_id_failure(self):
-        conf = AppleTV(getmac_stub.IP_EXCEPTION, 'Apple TV')
+    async def test_connect_missing_device_id(self):
+        conf = AppleTV('1.2.3.4', None, 'Apple TV')
 
-        with self.assertRaises(exceptions.DeviceIdUnknownError):
+        with self.assertRaises(exceptions.DeviceIdMissingError):
             await pyatv.connect_to_apple_tv(conf, self.loop)
 
     @unittest_run_loop

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -51,7 +51,7 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         return self.fake_atv.app
 
     async def get_connected_device(self, identifier):
-        conf = AppleTV(getmac_stub.IP, 'Apple TV')
+        conf = AppleTV(getmac_stub.IP, 'aabbccddeeff', 'Apple TV')
         conf.add_service(DmapService(identifier, port=self.server.port))
         conf.add_service(AirPlayService(self.server.port))
         return await connect_to_apple_tv(conf, self.loop)

--- a/tests/getmac_stub.py
+++ b/tests/getmac_stub.py
@@ -17,14 +17,15 @@ IP_UNKNOWN = '127.0.0.2'
 IP_EXCEPTION = '127.0.0.3'
 
 
-def get_mac_address_stub(ip=None, network_request=True):
-    if ip == IP:
-        return MAC
-    if ip == IP_EXCEPTION:
-        raise exceptions.DeviceIdUnknownError('error')
-    return None
-
-
-def stub(module):
+def stub(module, mapping=None):
     """Stub a module using getmac."""
+    def get_mac_address_stub(ip=None, network_request=True):
+        if ip == IP:
+            return MAC
+        if mapping is not None and ip in mapping:
+            return mapping[ip]
+        if ip == IP_EXCEPTION:
+            raise exceptions.DeviceIdUnknownError('error')
+        return None
+
     module.get_mac_address = get_mac_address_stub

--- a/tests/mrp/test_mrp_functional.py
+++ b/tests/mrp/test_mrp_functional.py
@@ -29,7 +29,7 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         return self.fake_atv
 
     async def get_connected_device(self, port):
-        conf = AppleTV(getmac_stub.IP, 'Test device')
+        conf = AppleTV(getmac_stub.IP, 'aabbccddeeff', 'Test device')
         conf.add_service(MrpService(port))
         conf.add_service(AirPlayService(self.server.port))
         return await connect_to_apple_tv(conf, loop=self.loop)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -14,13 +14,16 @@ ADDRESS_2 = '192.168.0.1'
 NAME = 'Alice'
 PORT_1 = 1234
 PORT_2 = 5678
+DEVICE_ID_1 = 'id1'
+DEVICE_ID_2 = 'id2'
 
 
 class ConfTest(unittest.TestCase):
 
     def setUp(self):
         self.atv = conf.AppleTV(
-            ADDRESS_1, NAME, supported_services=SUPPORTED_PROTOCOLS)
+            ADDRESS_1, DEVICE_ID_1,
+            NAME, supported_services=SUPPORTED_PROTOCOLS)
         self.service_mock = MagicMock()
         self.service_mock.protocol = PROTOCOL_1
         self.service_mock.port = PORT_1
@@ -40,11 +43,8 @@ class ConfTest(unittest.TestCase):
     def test_equality(self):
         self.assertEqual(self.atv, self.atv)
 
-        atv2 = conf.AppleTV(ADDRESS_2, NAME)
+        atv2 = conf.AppleTV(ADDRESS_1, DEVICE_ID_2, NAME)
         self.assertNotEqual(self.atv, atv2)
-
-        atv2.address = ADDRESS_1
-        self.assertEqual(self.atv, atv2)
 
     def test_add_services_and_get(self):
         self.atv.add_service(self.service_mock)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,7 @@ class MockAppleTV:
 class HelpersTest(asynctest.TestCase):
 
     def setUp(self):
-        self.device_details = conf.AppleTV('address', 'name')
+        self.device_details = conf.AppleTV('address', 'id', 'name')
         self.mock_device = asynctest.mock.Mock(MockAppleTV())
 
     @patch('pyatv.scan_for_apple_tvs', return_value=[])

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -5,32 +5,78 @@ import ipaddress
 import asynctest
 
 from pyatv.conf import AppleTV
-from tests import zeroconf_stub
+from tests import getmac_stub, zeroconf_stub
 
+
+IP_1 = '10.0.0.1'
+IP_2 = '10.0.0.2'
+IP_3 = '10.0.0.3'
+IP_4 = '10.0.0.4'
+IP_5 = '10.0.0.5'
+IP_6 = '10.0.0.6'
+
+DEVICE_ID_1 = 'id1'
+DEVICE_ID_2 = 'id2'
+DEVICE_ID_3 = 'id3'
+DEVICE_ID_4 = 'id4'
+DEVICE_ID_5 = 'id5'
+DEVICE_ID_6 = 'id6'
 
 HOMESHARING_SERVICE_1 = zeroconf_stub.homesharing_service(
-    'AAAA', b'Apple TV 1', '10.0.0.1', b'aaaa')
+    'AAAA', b'Apple TV 1', IP_1, b'aaaa')
 HOMESHARING_SERVICE_2 = zeroconf_stub.homesharing_service(
-    'BBBB', b'Apple TV 2', '10.0.0.2', b'bbbb')
+    'BBBB', b'Apple TV 2', IP_2, b'bbbb')
 HOMESHARING_SERVICE_3 = zeroconf_stub.homesharing_service(
-    'CCCC', b'Apple TV 3', '10.0.0.3', b'cccc')
+    'CCCC', b'Apple TV 3', IP_3, b'cccc')
 DEVICE_SERVICE_1 = zeroconf_stub.device_service(
-    'CCCC', b'Apple TV 3', '10.0.0.3')
+    'CCCC', b'Apple TV 3', IP_3)
 MRP_SERVICE_1 = zeroconf_stub.mrp_service(
-    'DDDD', b'Apple TV 4', '10.0.0.4')
+    'DDDD', b'Apple TV 4', IP_4)
 MRP_SERVICE_2 = zeroconf_stub.mrp_service(
-    'EEEE', b'Apple TV 5', '10.0.0.5')
+    'EEEE', b'Apple TV 5', IP_5)
 AIRPLAY_SERVICE_1 = zeroconf_stub.airplay_service(
-    'Apple TV 6', '10.0.0.6')
+    'Apple TV 6', IP_6)
+NO_DEVICE_ID_SERVICE = zeroconf_stub.airplay_service(
+    'Apple TV', getmac_stub.IP_UNKNOWN)
+EXCEPTION_DEVICE_ID_SERVICE = zeroconf_stub.airplay_service(
+    'Apple TV', getmac_stub.IP_EXCEPTION)
 
 
 class FunctionalTest(asynctest.TestCase):
+
+    def setUp(self):
+        mapping = {
+          IP_1: DEVICE_ID_1,
+          IP_2: DEVICE_ID_2,
+          IP_3: DEVICE_ID_3,
+          IP_4: DEVICE_ID_4,
+          IP_5: DEVICE_ID_5,
+          IP_6: DEVICE_ID_6,
+        }
+        getmac_stub.stub(pyatv, mapping=mapping)
 
     async def test_scan_no_device_found(self):
         zeroconf_stub.stub(pyatv)
 
         atvs = await pyatv.scan_for_apple_tvs(self.loop, timeout=0)
         self.assertEqual(len(atvs), 0)
+
+    async def test_scan_device_id_missing(self):
+        zeroconf_stub.stub(pyatv, NO_DEVICE_ID_SERVICE)
+
+        atvs = await pyatv.scan_for_apple_tvs(
+          self.loop, timeout=0, only_usable=False)
+        self.assertEqual(len(atvs), 1)
+        self.assertIsNone(atvs[0].device_id)
+
+    # Defensive test for general failures (maybe not necessary)
+    async def test_scan_device_id_failure(self):
+        zeroconf_stub.stub(pyatv, EXCEPTION_DEVICE_ID_SERVICE)
+
+        atvs = await pyatv.scan_for_apple_tvs(
+          self.loop, timeout=0, only_usable=False)
+        self.assertEqual(len(atvs), 1)
+        self.assertIsNone(atvs[0].device_id)
 
     async def test_scan_for_apple_tvs(self):
         zeroconf_stub.stub(
@@ -41,15 +87,15 @@ class FunctionalTest(asynctest.TestCase):
         self.assertEqual(len(atvs), 3)
 
         # First device
-        dev1 = AppleTV(ipaddress.ip_address('10.0.0.1'), 'Apple TV 1')
+        dev1 = AppleTV(ipaddress.ip_address(IP_1), DEVICE_ID_1, 'Apple TV 1')
         self.assertIn(dev1, atvs)
 
         # Second device
-        dev2 = AppleTV(ipaddress.ip_address('10.0.0.2'), 'Apple TV 2')
+        dev2 = AppleTV(ipaddress.ip_address(IP_2), DEVICE_ID_2, 'Apple TV 2')
         self.assertIn(dev2, atvs)
 
         # Third device
-        dev3 = AppleTV(ipaddress.ip_address('10.0.0.4'), 'Apple TV 4')
+        dev3 = AppleTV(ipaddress.ip_address(IP_4), DEVICE_ID_4, 'Apple TV 4')
         self.assertIn(dev3, atvs)
 
     async def test_scan_abort_on_first_usable_found(self):
@@ -103,10 +149,10 @@ class FunctionalTest(asynctest.TestCase):
             self.loop, only_usable=False, timeout=0)
         self.assertEqual(len(atvs), 2)
 
-        dev1 = AppleTV(ipaddress.ip_address('10.0.0.4'), 'Apple TV 4')
+        dev1 = AppleTV(ipaddress.ip_address(IP_4), DEVICE_ID_4, 'Apple TV 4')
         self.assertIn(dev1, atvs)
 
-        dev2 = AppleTV(ipaddress.ip_address('10.0.0.5'), 'Apple TV 5')
+        dev2 = AppleTV(ipaddress.ip_address(IP_5), DEVICE_ID_5, 'Apple TV 5')
         self.assertIn(dev2, atvs)
 
     async def test_scan_airplay_device(self):
@@ -128,7 +174,7 @@ class FunctionalTest(asynctest.TestCase):
         zeroconf_stub.stub(pyatv, HOMESHARING_SERVICE_1, HOMESHARING_SERVICE_2)
 
         atvs = await pyatv.scan_for_apple_tvs(
-            self.loop, timeout=0, only_usable=False, device_ip='10.0.0.2')
+            self.loop, timeout=0, only_usable=False, device_id=DEVICE_ID_2)
         self.assertEqual(len(atvs), 1)
         self.assertEqual(atvs[0].name, 'Apple TV 2')
-        self.assertEqual(atvs[0].address, ipaddress.ip_address('10.0.0.2'))
+        self.assertEqual(atvs[0].address, ipaddress.ip_address(IP_2))


### PR DESCRIPTION
This is a breaking change as searching based on address is no longer possible. Device id should be used instead.

Searching looks like this:
```shell
$ atvremote scan

Scan Results
========================================
Name: Vardagsrum
Address: 10.0.10.81
Id: aabbccddeeff 
Services:
  - Protocol: AirPlay, Port: 7000
  - Protocol: MRP, Port: 49152, Credentials: None
```
And doing something with the device like this:
```shell
$ atvremote -a --id aabbccddeeff playing
Media type: Unknown
Play state: Paused
```