### PR TITLE
Add proxy MRP script

### DIFF
--- a/pyatv/mrp/messages.py
+++ b/pyatv/mrp/messages.py
@@ -20,15 +20,21 @@ def device_information(name, identifier):
     # pylint: disable=no-member
     message = create(protobuf.DEVICE_INFO_MESSAGE)
     info = message.inner()
-    info.uniqueIdentifier = identifier
-    info.name = name
-    info.localizedModelName = 'iPhone'
-    info.systemBuildVersion = '14G60'
+    info.allowsPairing = True
     info.applicationBundleIdentifier = 'com.apple.TVRemote'
     info.applicationBundleVersion = '273.12'
-    info.protocolVersion = 1
     info.lastSupportedMessageType = 58
+    info.localizedModelName = 'iPhone'
+    info.name = name
+    info.protocolVersion = 1
+    info.sharedQueueVersion = 2
+    info.supportsACL = True
     info.supportsExtendedMotion = True
+    info.supportsSharedQueue = True
+    info.supportsSystemPairing = True
+    info.systemBuildVersion = '14G60'
+    info.systemMediaApplication = "com.apple.TVMusic"
+    info.uniqueIdentifier = identifier
     return message
 
 

--- a/scripts/autogen_protobuf_extensions.py
+++ b/scripts/autogen_protobuf_extensions.py
@@ -84,7 +84,7 @@ def extract_message_info():
 
 
 def extract_unreferenced_messages():
-
+    """Get messages not referenced anywhere."""
     base_path = BASE_PACKAGE.replace('.', '/')
 
     for filename in os.listdir(base_path):
@@ -121,7 +121,6 @@ def main():
         constants.append(
             '{0} = ProtocolMessage.{0}'.format(
                 info.const))
-
 
     # Look for remaining messages
     for module_name, message_name in extract_unreferenced_messages():

--- a/scripts/chacha20_decrypt.py
+++ b/scripts/chacha20_decrypt.py
@@ -9,8 +9,10 @@
 # Data decrypted!
 #  - Nounce : 000000000000000000000000
 #  - Key    : 7f0a54c5b15ccafc4927582c11d3394a55c95e489e72d12222a91b06f34c6094
-#  - Data   : 080b200082012d0a2b6b4d5254656c65766973696f6e52656d6f74654e6f77506c6179696e67417274776f726b4368616e676564
+#  - Data   : 080b200082012d0a2b6b4d5254656c65766973696f6e52656d6f74654e6f7750
+#             6c6179696e67417274776f726b4368616e676564
 #
+"""Manually decrypt some ChaCha20Poly1305 encrypted data."""
 
 import sys
 import binascii
@@ -18,29 +20,38 @@ from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
 
 # Example data
-DATA = "E8E786E4E673A38808063FEFDAF79D66B99C0745DA45C704DE51D4855FAE752F3B92ECA29E1DF5EF6B48C72BE4E87FC660BF5CE57D768365E60397E7C97D16AB233441B9"
+DATA = "E8E786E4E673A38808063FEFDAF79D66B99C0745DA45C704DE51D4855FAE752F3" \
+    "B92ECA29E1DF5EF6B48C72BE4E87FC660BF5CE57D768365E60397E7C97D16AB233441B9"
 KEYS = ["70743888c9eda99d1a24c5a94a26f85a0fec26f4cba16f919e5c23f892ecfbab",
         "7f0a54c5b15ccafc4927582c11d3394a55c95e489e72d12222a91b06f34c6094"]
 
 
 def decrypt(data, nounce, key):
-  data = binascii.unhexlify(data.replace(' ', ''))
-  inputKey = binascii.unhexlify(key.replace(' ', ''))
-  inputNonce = b'\x00\x00\x00\x00' + nounce.to_bytes(length=8, byteorder='little')
-  chacha = ChaCha20Poly1305(inputKey)
-  try:
-    print('Trying key {0} with nounce {1}'.format(inputKey, inputNonce))
-    decryptedData = chacha.decrypt(inputNonce, data, None)
-    print('Data decrypted!\n - Nounce : {0}\n - Key    : {1}\n - Data   : {2}'.format(
-        binascii.hexlify(inputNonce).decode(),
-        binascii.hexlify(inputKey).decode(),
-        binascii.hexlify(decryptedData).decode()))
-    sys.exit(0)
-  except Exception as ex:
-    pass
+    """Decrypt data with specified key and nounce."""
+    data = binascii.unhexlify(data.replace(' ', ''))
+    input_key = binascii.unhexlify(key.replace(' ', ''))
+    input_nonce = b'\x00\x00\x00\x00' + nounce.to_bytes(
+        length=8, byteorder='little')
+    chacha = ChaCha20Poly1305(input_key)
+    try:
+        print('Trying key {0} with nounce {1}'.format(input_key, input_nonce))
+        decrypted_data = chacha.decrypt(input_nonce, data, None)
+        print('Data decrypted!\n - Nounce : {0}'
+              '\n - Key    : {1}\n - Data   : {2}'.format(
+                binascii.hexlify(input_nonce).decode(),
+                binascii.hexlify(input_key).decode(),
+                binascii.hexlify(decrypted_data).decode()))
+        sys.exit(0)
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+
+def main(key_set):
+    """Script starts here."""
+    for key in key_set:
+        for nounce in range(128):
+            decrypt(DATA, nounce, key)
 
 
 if __name__ == '__main__':
-  for key in KEYS:
-    for nounce in range(128):
-      decrypt(DATA, nounce, key)
+    main(KEYS)

--- a/scripts/print_protobuf.py
+++ b/scripts/print_protobuf.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Decode and print a protobuf message from hex."""
 
 import sys
 import binascii

--- a/scripts/proxy.py
+++ b/scripts/proxy.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+#
+# This is a hack to sort-of intercept traffic between an Apple TV and the iOS
+# app. It will establish a connection to the ATV-of-interest (using code from
+# pyatv to do so), publish a fake device called "ATVProxy" that can be paired
+# with the app and forward messages between the two devices. Two sets of
+# encryption keys are used: one set between ATV and this proxy and a second set
+# between this proxy and the app. So all messages are "re-encrypted".
+#
+# What you need is:
+#
+# * Credentials to device of interest (atvremote -a --id <device> pair)
+# * Unique identifer of device, look for UniqueIdentifier in a zeroconf browser
+# * IP-address and port to the Apple TV of interest
+# * IP-address of an interface that is on the same network as the Apple TV
+#
+# Then you just call this script like:
+#
+#   python ./scripts/proxy.py `cat credentials` 10.0.0.20 10.0.10.30 49152 \
+#      aaaaaaaa-bbbb-ccccccccc-dddddddddddd
+#
+# Argument order: <credentials> <local ip> <atv ip> <atv port> <identifier>
+#
+# The script should connect to the Apple TV immediately and you should be able
+# to connect to ATVProxy from your phone (the file "credentials" contains the
+# credentials you got during pairing). Use pin 1111 when pairing. You will have
+# to re-pair everytime you connect and you have to restart this script if you
+# disconnect, e.g. close the app.
+#
+# Please note that this script is perhaps not a 100% accurate MITM of all
+# traffic. It takes shortcuts, doesn't imitate everything correctly and also
+# has a connection established before the app (this should maybe be reversed
+# here?), so some traffic might be missed. Also note that printed protobuf
+# messages are based on the definitions in pyatv. If new fields have been added
+# by Apple, they will not be seen in the logs.
+#
+# Some suggestions for improvements:
+#
+# * Support re-connection better without having to restart script
+# * Use pyatv to discover device (based on device id) to not have to enter all
+#   details on command line
+# * Use argparse for arguments
+# * Base proxy device name on real device (e.g. Bedroom -> Bedroom Proxy)
+# * Re-work logging to make it more clear what is what
+# * General clean-ups
+#
+# Help to improve the proxy is greatly appreciated! I will only make
+# improvements in case I personally see any benefits of doing so.
+"""Simple MRP proxy server to intercept traffic."""
+
+import sys
+import socket
+import hashlib
+import asyncio
+import logging
+import binascii
+
+import zeroconf
+from zeroconf import ServiceInfo
+
+import curve25519
+from srptools import (SRPContext, SRPServerSession, constants)
+from ed25519.keys import SigningKey
+
+from pyatv.conf import MrpService
+from pyatv.mrp.srp import SRPAuthHandler, hkdf_expand
+from pyatv.mrp.connection import MrpConnection
+from pyatv.mrp.protocol import MrpProtocol
+from pyatv.mrp import (chacha20, messages, protobuf, variant, tlv8)
+from pyatv.log import log_binary
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# TODO: Refactor and clean up: this is very messy
+class ProxyMrpAppleTV(asyncio.Protocol):  # pylint: disable=too-many-instance-attributes  # noqa
+    """Implementation of a fake MRP Apple TV."""
+
+    def __init__(self, loop, credentials, atv_device_id):
+        """Initialize a new instance of ProxyMrpAppleTV."""
+        self.loop = loop
+        self.credentials = credentials
+        self.atv_device_id = atv_device_id
+        self.server = None
+        self.buffer = b''
+        self.has_paired = False
+        self.transport = None
+        self.chacha = None
+        self.connection = None
+        self.input_key = None
+        self.output_key = None
+        self.mapping = {
+            protobuf.DEVICE_INFO_MESSAGE: self.handle_device_info,
+            protobuf.CRYPTO_PAIRING_MESSAGE: self.handle_crypto_pairing,
+            }
+
+        self._shared = None
+        self._session_key = None
+        self._signing_key = SigningKey(32 * b'\x01')
+        self._auth_private = self._signing_key.to_seed()
+        self._auth_public = self._signing_key.get_verifying_key().to_bytes()
+        self._verify_private = curve25519.Private(secret=32 * b'\x01')
+        self._verify_public = self._verify_private.get_public()
+
+        self.context = SRPContext(
+            'Pair-Setup', str(1111),
+            prime=constants.PRIME_3072,
+            generator=constants.PRIME_3072_GEN,
+            hash_func=hashlib.sha512,
+            bits_salt=128)
+        self.username, self.verifier, self.salt = \
+            self.context.get_user_data_triplet()
+
+        context_server = SRPContext(
+            'Pair-Setup',
+            prime=constants.PRIME_3072,
+            generator=constants.PRIME_3072_GEN,
+            hash_func=hashlib.sha512,
+            bits_salt=128)
+
+        self._session = SRPServerSession(
+            context_server,
+            self.verifier,
+            binascii.hexlify(self._auth_private).decode())
+
+    def start(self, address, port):
+        """Start the proxy instance."""
+        # Establish connection to ATV
+        self.connection = MrpConnection(address, port, self.loop)
+        protocol = MrpProtocol(
+            self.loop, self.connection, SRPAuthHandler(),
+            MrpService(port, device_credentials=self.credentials))
+        self.loop.run_until_complete(
+            protocol.start(skip_initial_messages=True))
+        self.connection.listener = self
+
+        # Setup server used to publish a fake MRP server
+        coro = self.loop.create_server(lambda: self, '0.0.0.0', 8888)
+        self.server = self.loop.run_until_complete(coro)
+        _LOGGER.info('Started MRP server at port %d', self.port)
+
+    @property
+    def port(self):
+        """Port used by MRP proxy server."""
+        return self.server.sockets[0].getsockname()[1]
+
+    def connection_made(self, transport):
+        """Client did connect to proxy."""
+        self.transport = transport
+
+    def _send(self, message):
+        data = message.SerializeToString()
+        _LOGGER.info('<<(DECRYPTED): %s', message)
+        if self.chacha:
+            data = self.chacha.encrypt(data)
+            log_binary(_LOGGER, '<<(ENCRYPTED)', Message=message)
+
+        length = variant.write_variant(len(data))
+        self.transport.write(length + data)
+
+    def _send_raw(self, raw):
+        parsed = protobuf.ProtocolMessage()
+        parsed.ParseFromString(raw)
+
+        log_binary(_LOGGER, 'ATV->APP', Raw=raw)
+        _LOGGER.info('ATV->APP Parsed: %s', parsed)
+        if self.chacha:
+            raw = self.chacha.encrypt(raw)
+            log_binary(_LOGGER, 'ATV->APP', Encrypted=raw)
+
+        length = variant.write_variant(len(raw))
+        try:
+            self.transport.write(length + raw)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception('Failed to send to app')
+
+    def message_received(self, _, raw):
+        """Message received from ATV."""
+        self._send_raw(raw)
+
+    def data_received(self, data):
+        """Message received from iOS app/client."""
+        self.buffer += data
+
+        while self.buffer:
+            length, raw = variant.read_variant(self.buffer)
+            if len(raw) < length:
+                break
+
+            data = raw[:length]
+            self.buffer = raw[length:]
+            if self.chacha:
+                log_binary(_LOGGER, 'ENC Phone->ATV', Encrypted=data)
+                data = self.chacha.decrypt(data)
+
+            parsed = protobuf.ProtocolMessage()
+            parsed.ParseFromString(data)
+            _LOGGER.info('(DEC Phone->ATV): %s', parsed)
+
+            try:
+                def unhandled_message(_, raw):
+                    self.connection.send_raw(raw)
+
+                self.mapping.get(parsed.type, unhandled_message)(parsed, data)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception('Error while dispatching message')
+
+    def handle_device_info(self, message, _):
+        """Handle received device information message."""
+        _LOGGER.debug('Received device info message')
+
+        # TODO: Consolidate this better with message.device_information(...)
+        resp = messages.create(protobuf.DEVICE_INFO_MESSAGE)
+        resp.identifier = message.identifier
+        resp.inner().uniqueIdentifier = self.atv_device_id.decode()
+        resp.inner().name = 'ATVProxy'
+        resp.inner().systemBuildVersion = '15K600'
+        resp.inner().applicationBundleIdentifier = 'com.apple.mediaremoted'
+        resp.inner().protocolVersion = 1
+        resp.inner().lastSupportedMessageType = 58
+        resp.inner().supportsSystemPairing = True
+        resp.inner().allowsPairing = True
+        resp.inner().systemMediaApplication = "com.apple.TVMusic"
+        resp.inner().supportsACL = True
+        resp.inner().supportsSharedQueue = True
+        resp.inner().supportsExtendedMotion = True
+        resp.inner().sharedQueueVersion = 2
+        self._send(resp)
+
+    def handle_crypto_pairing(self, message, _):
+        """Handle incoming crypto pairing message."""
+        _LOGGER.debug('Received crypto pairing message')
+        pairing_data = tlv8.read_tlv(message.inner().pairingData)
+        seqno = pairing_data[tlv8.TLV_SEQ_NO][0]
+        getattr(self, "_seqno_" + str(seqno))(pairing_data)
+
+    def _seqno_1(self, pairing_data):
+        if self.has_paired:
+            server_pub_key = self._verify_public.serialize()
+            client_pub_key = pairing_data[tlv8.TLV_PUBLIC_KEY]
+
+            self._shared = self._verify_private.get_shared_key(
+                curve25519.Public(client_pub_key), hashfunc=lambda x: x)
+
+            session_key = hkdf_expand('Pair-Verify-Encrypt-Salt',
+                                      'Pair-Verify-Encrypt-Info',
+                                      self._shared)
+
+            info = server_pub_key + self.atv_device_id + client_pub_key
+            signature = SigningKey(self._signing_key.to_seed()).sign(info)
+
+            tlv = tlv8.write_tlv({
+                tlv8.TLV_IDENTIFIER: self.atv_device_id,
+                tlv8.TLV_SIGNATURE: signature
+            })
+
+            chacha = chacha20.Chacha20Cipher(session_key, session_key)
+            encrypted = chacha.encrypt(tlv, nounce='PV-Msg02'.encode())
+
+            msg = messages.crypto_pairing({
+                tlv8.TLV_SEQ_NO: b'\x02',
+                tlv8.TLV_PUBLIC_KEY: server_pub_key,
+                tlv8.TLV_ENCRYPTED_DATA: encrypted
+            })
+
+            self.output_key = hkdf_expand('MediaRemote-Salt',
+                                          'MediaRemote-Write-Encryption-Key',
+                                          self._shared)
+
+            self.input_key = hkdf_expand('MediaRemote-Salt',
+                                         'MediaRemote-Read-Encryption-Key',
+                                         self._shared)
+
+            log_binary(_LOGGER,
+                       'Keys',
+                       Output=self.output_key,
+                       Input=self.input_key)
+
+        else:
+            msg = messages.crypto_pairing({
+                tlv8.TLV_SALT: binascii.unhexlify(self.salt),
+                tlv8.TLV_PUBLIC_KEY: binascii.unhexlify(self._session.public),
+                tlv8.TLV_SEQ_NO: b'\x02'
+            })
+
+        self._send(msg)
+
+    def _seqno_3(self, pairing_data):
+        if self.has_paired:
+            self._send(messages.crypto_pairing({tlv8.TLV_SEQ_NO: b'\x04'}))
+            self.chacha = chacha20.Chacha20Cipher(
+                self.input_key, self.output_key)
+        else:
+            pubkey = binascii.hexlify(
+                pairing_data[tlv8.TLV_PUBLIC_KEY]).decode()
+            self._session.process(pubkey, self.salt)
+
+            proof = binascii.unhexlify(self._session.key_proof_hash)
+            assert self._session.verify_proof(
+                binascii.hexlify(pairing_data[tlv8.TLV_PROOF]))
+
+            msg = messages.crypto_pairing({
+                tlv8.TLV_PROOF: proof,
+                tlv8.TLV_SEQ_NO: b'\x04'
+            })
+            self._send(msg)
+
+    def _seqno_5(self, _):
+        self._session_key = hkdf_expand(
+            'Pair-Setup-Encrypt-Salt',
+            'Pair-Setup-Encrypt-Info',
+            binascii.unhexlify(self._session.key))
+
+        chacha = chacha20.Chacha20Cipher(self._session_key, self._session_key)
+
+        acc_device_x = hkdf_expand(
+            'Pair-Setup-Accessory-Sign-Salt',
+            'Pair-Setup-Accessory-Sign-Info',
+            binascii.unhexlify(self._session.key))
+
+        device_info = acc_device_x + self.atv_device_id + self._auth_public
+        signature = self._signing_key.sign(device_info)
+
+        tlv = tlv8.write_tlv({tlv8.TLV_IDENTIFIER: self.atv_device_id,
+                              tlv8.TLV_PUBLIC_KEY: self._auth_public,
+                              tlv8.TLV_SIGNATURE: signature})
+
+        chacha = chacha20.Chacha20Cipher(self._session_key, self._session_key)
+        encrypted = chacha.encrypt(tlv, nounce='PS-Msg06'.encode())
+
+        msg = messages.crypto_pairing({
+            tlv8.TLV_SEQ_NO: b'\x06',
+            tlv8.TLV_ENCRYPTED_DATA: encrypted,
+        })
+        self.has_paired = True
+
+        self._send(msg)
+
+
+def publish_zeroconf(zconf, ip_address, port):
+    """Publish zeroconf service for ATV proxy instance."""
+    props = {
+        b'ModelName': False,
+        b'AllowPairing': b'YES',
+        b'BluetoothAddress': False,
+        b'Name': b'ATVProxy',
+        b'UniqueIdentifier': '4d797fd3-3538-427e-a47b-a32fc6cf3a69'.encode(),
+        b'SystemBuildVersion': b'15K600',
+        }
+
+    service = ServiceInfo(
+        '_mediaremotetv._tcp.local.',
+        'ATVProxy._mediaremotetv._tcp.local.',
+        socket.inet_aton(ip_address), port, 0, 0, props)
+    zconf.register_service(service)
+    _LOGGER.debug('Published zeroconf service: %s', service)
+
+
+def main(loop):
+    """Script starts here."""
+    # To get logging from pyatv
+    logging.basicConfig(level=logging.DEBUG)
+
+    if len(sys.argv) != 6:
+        print("Usage: {0} <credentials> <local ip> "
+              "<atv ip> <atv port> <unique identifier>".format(
+                  sys.argv[0]))
+        sys.exit(1)
+
+    credentials = sys.argv[1]
+    local_ip_addr = sys.argv[2]
+    atv_ip_addr = sys.argv[3]
+    atv_port = int(sys.argv[4])
+    unique_identifier = sys.argv[5].encode()
+    zconf = zeroconf.Zeroconf()
+    proxy = ProxyMrpAppleTV(loop, credentials, unique_identifier)
+
+    proxy.start(atv_ip_addr, atv_port)
+    publish_zeroconf(zconf, local_ip_addr, proxy.port)
+    loop.run_forever()
+
+
+if __name__ == '__main__':
+    main(asyncio.get_event_loop())

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ deps =
 basepython = python3
 ignore_errors = True
 commands =
-     flake8 --exclude=pyatv/mrp/protobuf pyatv tests examples
+     flake8 --exclude=pyatv/mrp/protobuf pyatv tests examples scripts
      pylint pyatv examples
-     pydocstyle -v --match='(?!test_).*[^pb2]\.py' pyatv examples
+     pydocstyle -v --match='(?!test_).*[^pb2]\.py' pyatv examples scripts
 
 [testenv:typing]
 basepython = python3


### PR DESCRIPTION
This script will mimic an MRP device that you can pair with, using for instance the iOS app. It will then relay messages to a real device, doing re-encryption on the fly so that messages can be intercepted and read in plain text. Usage instructions and caveats are placed as comments in the script.