### PR TITLE
Fix broken play_url in AirPlay

### DIFF
--- a/pyatv/airplay/player.py
+++ b/pyatv/airplay/player.py
@@ -3,6 +3,7 @@
 import logging
 import asyncio
 import plistlib
+from uuid import uuid4
 
 from pyatv import exceptions
 
@@ -33,7 +34,11 @@ class AirPlayPlayer:
         """Play media from an URL on the device."""
         headers = {'User-Agent': 'MediaControl/1.0',
                    'Content-Type': 'application/x-apple-binary-plist'}
-        body = {'Content-Location': url, 'Start-Position': position}
+        body = {
+            'Content-Location': url,
+            'Start-Position': position,
+            'X-Apple-Session-ID': str(uuid4()),
+            }
 
         address = self._url(self.port, 'play')
         _LOGGER.debug('AirPlay %s to %s', url, address)

--- a/tests/airplay/fake_airplay_device.py
+++ b/tests/airplay/fake_airplay_device.py
@@ -43,6 +43,8 @@ class FakeAirPlayDevice:
         self.responses['airplay_playback'] = []
         self.has_authenticated = True
         self.last_airplay_url = None
+        self.last_airplay_start = None
+        self.last_airplay_uuid = None
         self.tc = testcase
         self.app = web.Application()
 
@@ -87,6 +89,7 @@ class FakeAirPlayDevice:
 
         self.last_airplay_url = parsed['Content-Location']
         self.last_airplay_start = parsed['Start-Position']
+        self.last_airplay_uuid = parsed['X-Apple-Session-ID']
 
         return web.Response(status=200)
 

--- a/tests/airplay/test_airplay.py
+++ b/tests/airplay/test_airplay.py
@@ -45,6 +45,7 @@ class AirPlayPlayerTest(AioHTTPTestCase):
 
         self.assertEqual(self.fake_device.last_airplay_url, STREAM)
         self.assertEqual(self.fake_device.last_airplay_start, START_POSITION)
+        self.assertIsNotNone(self.fake_device.last_airplay_uuid)
         self.assertEqual(self.no_of_sleeps, 2)  # playback + idle = 3
 
         await session.close()


### PR DESCRIPTION
This should make it possible to play a URL again.