### PR TITLE
Use generic pair function for all protocols

### DIFF
--- a/examples/manual_connect.py
+++ b/examples/manual_connect.py
@@ -15,13 +15,13 @@ LOOP = asyncio.get_event_loop()
 async def print_what_is_playing(loop):
     """Connect to device and print what is playing."""
     config = conf.AppleTV(ADDRESS, NAME)
-    config.add_service(conf.DmapService(None, HSGID))
+    config.add_service(conf.DmapService('some_id', HSGID))
 
-    print('Connecting to {}'.format(config.address))
+    print('Connecting to {0}'.format(config.address))
     atv = await pyatv.connect(config, loop)
 
     try:
-        print((await atv.metadata.playing()))
+        print(await atv.metadata.playing())
     finally:
         # Do not forget to logout
         await atv.logout()

--- a/examples/scan_and_connect.py
+++ b/examples/scan_and_connect.py
@@ -1,4 +1,4 @@
-"""Simple example that connects to a device with autodiscover."""
+"""Simple example that scans for devices and connects to first one found."""
 
 import sys
 import asyncio
@@ -14,7 +14,7 @@ async def print_what_is_playing(loop):
     atvs = await pyatv.scan(loop, timeout=5)
 
     if not atvs:
-        print('no device found', file=sys.stderr)
+        print('No device found', file=sys.stderr)
         return
 
     print('Connecting to {0}'.format(atvs[0].address))

--- a/pyatv/airplay/__init__.py
+++ b/pyatv/airplay/__init__.py
@@ -6,13 +6,13 @@ import binascii
 from pyatv import const
 from pyatv.interface import AirPlay
 
-from pyatv.airplay.srp import (SRPAuthHandler, new_credentials)
-from pyatv.airplay.auth import (AuthenticationVerifier, DeviceAuthenticator)
+from pyatv.airplay.srp import SRPAuthHandler
+from pyatv.airplay.auth import AuthenticationVerifier
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class AirPlayAPI(AirPlay):
+class AirPlayAPI(AirPlay):  # pylint: disable=too-few-public-methods
     """Implementation of API for AirPlay support."""
 
     def __init__(self, config, http, airplay_player):
@@ -22,13 +22,12 @@ class AirPlayAPI(AirPlay):
         self.identifier = None
         self.srp = SRPAuthHandler()
         self.verifier = AuthenticationVerifier(http, self.srp)
-        self.auther = DeviceAuthenticator(http, self.srp)
         self._load_credentials()
 
     def _load_credentials(self):
         service = self.config.get_service(const.PROTOCOL_AIRPLAY)
         if service.credentials is None:
-            _LOGGER.debug('No AirPlay credentisls loaded')
+            _LOGGER.debug('No AirPlay credentials loaded')
             return
 
         split = service.credentials.split(':')
@@ -38,34 +37,9 @@ class AirPlayAPI(AirPlay):
             'Loaded AirPlay credentials: %s',
             service.credentials)
 
-    async def generate_credentials(self):
-        """Create new credentials for authentication.
-
-        Credentials that have been authenticated shall be saved and loaded with
-        load_credentials before playing anything. If credentials are lost,
-        authentication must be performed again.
-        """
-        identifier, seed = new_credentials()
-        return '{0}:{1}'.format(identifier, seed.decode().upper())
-
-    async def load_credentials(self, credentials):
-        """Load existing credentials."""
-        split = credentials.split(':')
-        self.identifier = split[0]
-        self.srp.initialize(binascii.unhexlify(split[1]))
-        _LOGGER.debug('Loaded AirPlay credentials: %s', credentials)
-
-    def verify_authenticated(self):
+    def _verify_authenticated(self):
         """Check if loaded credentials are verified."""
         return self.verifier.verify_authed()
-
-    def start_authentication(self):
-        """Begin authentication proces (show PIN on screen)."""
-        return self.auther.start_authentication()
-
-    def finish_authentication(self, pin):
-        """End authentication process with PIN code."""
-        return self.auther.finish_authentication(self.identifier, pin)
 
     async def play_url(self, url, **kwargs):
         """Play media from an URL on the device.
@@ -76,7 +50,7 @@ class AirPlayAPI(AirPlay):
         """
         # If credentials have been loaded, do device verification first
         if self.identifier:
-            await self.verify_authenticated()
+            await self._verify_authenticated()
 
-        position = 0 if 'position' not in kwargs else int(kwargs['position'])
+        position = int(kwargs.get('position', 0))
         return await self.player.play_url(url, position)

--- a/pyatv/airplay/pairing.py
+++ b/pyatv/airplay/pairing.py
@@ -1,0 +1,75 @@
+"""Device pairing and derivation of encryption keys."""
+
+import logging
+import binascii
+from collections import namedtuple
+
+from pyatv import const, exceptions, net
+from pyatv.interface import PairingHandler
+from pyatv.airplay.srp import (SRPAuthHandler, new_credentials)
+from pyatv.airplay.auth import DeviceAuthenticator
+
+_LOGGER = logging.getLogger(__name__)
+
+AuthData = namedtuple('AuthData', 'identifier seed credentials')
+
+
+class AirPlayPairingHandler(PairingHandler):
+    """Base class for API used to pair with an Apple TV."""
+
+    def __init__(self, config, session, _):
+        """Initialize a new MrpPairingHandler."""
+        super().__init__(session)
+        self.service = service = config.get_service(const.PROTOCOL_AIRPLAY)
+        self.srp = SRPAuthHandler()
+        self.http = net.HttpSession(
+            session, 'http://{0}:{1}/'.format(config.address, service.port))
+        self.auther = DeviceAuthenticator(self.http, self.srp)
+        self.auth_data = self._setup_credentials()
+        self.srp.initialize(binascii.unhexlify(self.auth_data.seed))
+        self.pairing_complete = False
+        self.pin_code = None
+
+    def _setup_credentials(self):
+        credentials = self.service.credentials
+
+        # If service has credentials, use those. Otherwise generate new.
+        if self.service.credentials is None:
+            identifier, seed = new_credentials()
+            credentials = '{0}:{1}'.format(identifier, seed.decode().upper())
+        else:
+            split = credentials.split(':')
+            identifier = split[0]
+            seed = split[1]
+        return AuthData(identifier, seed, credentials)
+
+    @property
+    def has_paired(self):
+        """If a successful pairing has been performed."""
+        return self.pairing_complete
+
+    async def begin(self):
+        """Start pairing process."""
+        _LOGGER.debug('Starting AirPlay pairing with credentials %s',
+                      self.auth_data.credentials)
+        self.pairing_complete = False
+        return await self.auther.start_authentication()
+
+    async def finish(self):
+        """Stop pairing process."""
+        if not self.pin_code:
+            raise exceptions.DeviceAuthenticationError('no pin given')
+
+        if await self.auther.finish_authentication(self.auth_data.identifier,
+                                                   self.pin_code):
+            self.service.credentials = self.auth_data.credentials
+            self.pairing_complete = True
+
+    def pin(self, pin):
+        """Pin code used for pairing."""
+        self.pin_code = pin
+
+    @property
+    def device_provides_pin(self):
+        """Return True if remote device presents PIN code, else False."""
+        return True

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -2,8 +2,6 @@
 from pyatv import (convert, exceptions)
 from pyatv.const import (PROTOCOL_MRP, PROTOCOL_DMAP, PROTOCOL_AIRPLAY)
 
-_SUPPORTED_PROTOCOLS = [PROTOCOL_MRP, PROTOCOL_DMAP]
-
 
 class AppleTV:
     """Representation of an Apple TV configuration.
@@ -13,14 +11,12 @@ class AppleTV:
     AirPlay.
     """
 
-    def __init__(self, address, name, **kwargs):
+    def __init__(self, address, name):
         """Initialize a new AppleTV."""
         self.address = address
         self.name = name
         self._services = {}
         self._identifier = None
-        self._supported_protocols = \
-            kwargs.get('supported_services', _SUPPORTED_PROTOCOLS)
 
     @property
     def identifier(self):

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -3,8 +3,8 @@
 import logging
 import asyncio
 
-from pyatv import (const, exceptions, convert)
-from pyatv.dmap import (pairing, parser, tags)
+from pyatv import (const, exceptions, convert, net)
+from pyatv.dmap import (parser, tags)
 from pyatv.dmap.daap import DaapRequester
 from pyatv.net import HttpSession
 from pyatv.interface import (AppleTV, RemoteControl, Metadata,
@@ -367,7 +367,6 @@ class DmapAppleTV(AppleTV):
         self._dmap_remote = DmapRemoteControl(self._apple_tv)
         self._dmap_metadata = DmapMetadata(config.identifier, self._apple_tv)
         self._dmap_push_updater = DmapPushUpdater(loop, self._apple_tv)
-        self._dmap_pairing = pairing.DmapPairingHandler(loop)
         self._airplay = airplay
 
     def login(self):
@@ -382,17 +381,13 @@ class DmapAppleTV(AppleTV):
 
         Must be done when session is no longer needed to not leak resources.
         """
-        await self._session.close()
+        if net.is_custom_session(self._session):
+            await self._session.close()
 
     @property
     def service(self):
         """Return service used to connect to the Apple TV.."""
         return self._dmap_service
-
-    @property
-    def pairing(self):
-        """Return API for pairing with the Apple TV."""
-        return self._dmap_pairing
 
     @property
     def remote_control(self):

--- a/pyatv/exceptions.py
+++ b/pyatv/exceptions.py
@@ -5,6 +5,10 @@ class NoServiceError(Exception):
     """Thrown when connecting to a device with no usable service."""
 
 
+class UnsupportedProtocolError(Exception):
+    """Thrown when an unsupported protocol was requested."""
+
+
 class AuthenticationError(Exception):
     """Thrown when login fails."""
 

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -6,7 +6,7 @@ import hashlib
 
 from abc import (ABCMeta, abstractmethod, abstractproperty)
 
-from pyatv import (convert, exceptions)
+from pyatv import (convert, exceptions, net)
 
 
 # TODO: make these methods more pretty and safe
@@ -44,6 +44,15 @@ class PairingHandler:
 
     __metaclass__ = ABCMeta
 
+    def __init__(self, session):
+        """Initialize a new instance of PairingHandler."""
+        self.session = session
+
+    async def close(self):
+        """Call to free allocated resources after pairing."""
+        if net.is_custom_session(self.session):
+            await self.session.close()
+
     @abstractmethod
     def pin(self, pin):
         """Pin code used for pairing."""
@@ -62,18 +71,13 @@ class PairingHandler:
         """
         raise exceptions.NotSupportedError
 
-    @abstractproperty
-    def credentials(self):
-        """Credentials that were generated during pairing."""
-        raise exceptions.NotSupportedError
-
     @abstractmethod
-    def start(self, **kwargs):
+    async def begin(self):
         """Start pairing process."""
         raise exceptions.NotSupportedError
 
     @abstractmethod
-    def stop(self, **kwargs):
+    async def finish(self):
         """Stop pairing process."""
         raise exceptions.NotSupportedError
 
@@ -340,40 +344,10 @@ class PushUpdater:
         raise exceptions.NotSupportedError
 
 
-class AirPlay:
+class AirPlay:  # pylint: disable=too-few-public-methods
     """Base class for AirPlay functionality."""
 
     __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def generate_credentials(self):
-        """Create new credentials for authentication.
-
-        Credentials that have been authenticated shall be saved and loaded with
-        load_credentials before playing anything. If credentials are lost,
-        authentication must be performed again.
-        """
-        raise exceptions.NotSupportedError
-
-    @abstractmethod
-    def load_credentials(self, credentials):
-        """Load existing credentials."""
-        raise exceptions.NotSupportedError
-
-    @abstractmethod
-    def verify_authenticated(self):
-        """Check if loaded credentials are verified."""
-        raise exceptions.NotSupportedError
-
-    @abstractmethod
-    def start_authentication(self):
-        """Begin authentication proces (show PIN on screen)."""
-        raise exceptions.NotSupportedError
-
-    @abstractmethod
-    def finish_authentication(self, pin):
-        """End authentication process with PIN code."""
-        raise exceptions.NotSupportedError
 
     @abstractmethod
     def play_url(self, url, **kwargs):
@@ -404,12 +378,7 @@ class AppleTV:
 
     @abstractproperty
     def service(self):
-        """Return service used to connect to the Apple TV.."""
-        raise exceptions.NotSupportedError
-
-    @abstractproperty
-    def pairing(self):
-        """Return API for pairing with the Apple TV."""
+        """Return service used to connect to the Apple TV."""
         raise exceptions.NotSupportedError
 
     @abstractproperty

--- a/pyatv/mrp/auth.py
+++ b/pyatv/mrp/auth.py
@@ -1,0 +1,121 @@
+"""Device pairing and derivation of encryption keys."""
+
+import logging
+
+from pyatv.log import log_binary
+from pyatv.mrp import (tlv8, messages)
+from pyatv.mrp.protobuf import CryptoPairingMessage_pb2 as CryptoPairingMessage
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _get_pairing_data(resp):
+    pairing_message = CryptoPairingMessage.cryptoPairingMessage
+    return tlv8.read_tlv(resp.Extensions[pairing_message].pairingData)
+
+
+class MrpPairingProcedure:
+    """Perform pairing and return new credentials."""
+
+    def __init__(self, protocol, srp):
+        """Initialize a new MrpPairingHandler."""
+        self.protocol = protocol
+        self.srp = srp
+        self._atv_salt = None
+        self._atv_pub_key = None
+
+    async def start_pairing(self):
+        """Start pairing procedure."""
+        self.srp.initialize()
+
+        msg = messages.crypto_pairing(
+            {tlv8.TLV_METHOD: b'\x00',
+             tlv8.TLV_SEQ_NO: b'\x01'},
+            is_pairing=True)
+        resp = await self.protocol.send_and_receive(
+            msg, generate_identifier=False)
+
+        pairing_data = _get_pairing_data(resp)
+
+        if tlv8.TLV_BACK_OFF in pairing_data:
+            time = int.from_bytes(
+                pairing_data[tlv8.TLV_BACK_OFF], byteorder='big')
+            raise Exception('back off {0}s'.format(time))
+
+        self._atv_salt = pairing_data[tlv8.TLV_SALT]
+        self._atv_pub_key = pairing_data[tlv8.TLV_PUBLIC_KEY]
+
+    async def finish_pairing(self, pin):
+        """Finish pairing process."""
+        self.srp.step1(pin)
+
+        pub_key, proof = self.srp.step2(self._atv_pub_key, self._atv_salt)
+
+        msg = messages.crypto_pairing({
+            tlv8.TLV_SEQ_NO: b'\x03',
+            tlv8.TLV_PUBLIC_KEY: pub_key,
+            tlv8.TLV_PROOF: proof})
+        resp = await self.protocol.send_and_receive(
+            msg, generate_identifier=False)
+
+        pairing_data = _get_pairing_data(resp)
+        atv_proof = pairing_data[tlv8.TLV_PROOF]
+        log_binary(_LOGGER, 'Device', Proof=atv_proof)
+
+        encrypted_data = self.srp.step3()
+        msg = messages.crypto_pairing({
+            tlv8.TLV_SEQ_NO: b'\x05',
+            tlv8.TLV_ENCRYPTED_DATA: encrypted_data})
+        resp = await self.protocol.send_and_receive(
+            msg, generate_identifier=False)
+
+        pairing_data = _get_pairing_data(resp)
+        encrypted_data = pairing_data[tlv8.TLV_ENCRYPTED_DATA]
+
+        return self.srp.step4(encrypted_data)
+
+
+class MrpPairingVerifier:
+    """Verify credentials and derive new encryption keys."""
+
+    def __init__(self, protocol, srp, credentials):
+        """Initialize a new MrpPairingVerifier."""
+        self.protocol = protocol
+        self.srp = srp
+        self.credentials = credentials
+        self._output_key = None
+        self._input_key = None
+
+    async def verify_credentials(self):
+        """Verify credentials with device."""
+        _, public_key = self.srp.initialize()
+
+        msg = messages.crypto_pairing({
+            tlv8.TLV_SEQ_NO: b'\x01',
+            tlv8.TLV_PUBLIC_KEY: public_key})
+        resp = await self.protocol.send_and_receive(
+            msg, generate_identifier=False)
+
+        resp = _get_pairing_data(resp)
+        session_pub_key = resp[tlv8.TLV_PUBLIC_KEY]
+        encrypted = resp[tlv8.TLV_ENCRYPTED_DATA]
+        log_binary(_LOGGER,
+                   'Device',
+                   Public=self.credentials.ltpk,
+                   Encrypted=encrypted)
+
+        encrypted_data = self.srp.verify1(
+            self.credentials, session_pub_key, encrypted)
+        msg = messages.crypto_pairing({
+            tlv8.TLV_SEQ_NO: b'\x03',
+            tlv8.TLV_ENCRYPTED_DATA: encrypted_data})
+        resp = await self.protocol.send_and_receive(
+            msg, generate_identifier=False)
+
+        # TODO: check status code
+
+        self._output_key, self._input_key = self.srp.verify2()
+
+    def encryption_keys(self):
+        """Return derived encryption keys."""
+        return self._output_key, self._input_key

--- a/pyatv/mrp/pairing.py
+++ b/pyatv/mrp/pairing.py
@@ -2,120 +2,54 @@
 
 import logging
 
-from pyatv.log import log_binary
-from pyatv.mrp import (tlv8, messages)
-from pyatv.mrp.protobuf import CryptoPairingMessage_pb2 as CryptoPairingMessage
+from pyatv import const, exceptions
+from pyatv.interface import PairingHandler
+from pyatv.mrp.auth import MrpPairingProcedure
+from pyatv.mrp.srp import SRPAuthHandler
+from pyatv.mrp.protocol import MrpProtocol
+from pyatv.mrp.connection import MrpConnection
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _get_pairing_data(resp):
-    pairing_message = CryptoPairingMessage.cryptoPairingMessage
-    return tlv8.read_tlv(resp.Extensions[pairing_message].pairingData)
+class MrpPairingHandler(PairingHandler):
+    """Base class for API used to pair with an Apple TV."""
 
-
-class MrpPairingProcedure:
-    """Perform pairing and return new credentials."""
-
-    def __init__(self, protocol, srp):
+    def __init__(self, config, session, loop):
         """Initialize a new MrpPairingHandler."""
-        self.protocol = protocol
-        self.srp = srp
-        self._atv_salt = None
-        self._atv_pub_key = None
+        super().__init__(session)
+        self.service = service = config.get_service(const.PROTOCOL_MRP)
+        self.connection = MrpConnection(
+            config.address, self.service.port, loop)
+        self.srp = SRPAuthHandler()
+        self.protocol = MrpProtocol(
+            loop, self.connection, self.srp, service)
+        self.pairing_procedure = MrpPairingProcedure(
+            self.protocol, self.srp)
+        self.pin_code = None
 
-    async def start_pairing(self):
-        """Start pairing procedure."""
-        self.srp.initialize()
+    @property
+    def has_paired(self):
+        """If a successful pairing has been performed."""
+        return self.service.credentials is not None
 
-        msg = messages.crypto_pairing(
-            {tlv8.TLV_METHOD: b'\x00',
-             tlv8.TLV_SEQ_NO: b'\x01'},
-            is_pairing=True)
-        resp = await self.protocol.send_and_receive(
-            msg, generate_identifier=False)
+    async def begin(self):
+        """Start pairing process."""
+        await self.pairing_procedure.start_pairing()
 
-        pairing_data = _get_pairing_data(resp)
+    async def finish(self):
+        """Stop pairing process."""
+        if not self.pin_code:
+            raise exceptions.DeviceAuthenticationError('no pin given')
 
-        if tlv8.TLV_BACK_OFF in pairing_data:
-            time = int.from_bytes(
-                pairing_data[tlv8.TLV_BACK_OFF], byteorder='big')
-            raise Exception('back off {0}s'.format(time))
+        self.service.credentials = \
+            await self.pairing_procedure.finish_pairing(self.pin_code)
 
-        self._atv_salt = pairing_data[tlv8.TLV_SALT]
-        self._atv_pub_key = pairing_data[tlv8.TLV_PUBLIC_KEY]
+    @property
+    def device_provides_pin(self):
+        """Return True if remote device presents PIN code, else False."""
+        return True
 
-    async def finish_pairing(self, pin):
-        """Finish pairing process."""
-        self.srp.step1(pin)
-
-        pub_key, proof = self.srp.step2(self._atv_pub_key, self._atv_salt)
-
-        msg = messages.crypto_pairing({
-            tlv8.TLV_SEQ_NO: b'\x03',
-            tlv8.TLV_PUBLIC_KEY: pub_key,
-            tlv8.TLV_PROOF: proof})
-        resp = await self.protocol.send_and_receive(
-            msg, generate_identifier=False)
-
-        pairing_data = _get_pairing_data(resp)
-        atv_proof = pairing_data[tlv8.TLV_PROOF]
-        log_binary(_LOGGER, 'Device', Proof=atv_proof)
-
-        encrypted_data = self.srp.step3()
-        msg = messages.crypto_pairing({
-            tlv8.TLV_SEQ_NO: b'\x05',
-            tlv8.TLV_ENCRYPTED_DATA: encrypted_data})
-        resp = await self.protocol.send_and_receive(
-            msg, generate_identifier=False)
-
-        pairing_data = _get_pairing_data(resp)
-        encrypted_data = pairing_data[tlv8.TLV_ENCRYPTED_DATA]
-
-        return self.srp.step4(encrypted_data)
-
-
-class MrpPairingVerifier:
-    """Verify credentials and derive new encryption keys."""
-
-    def __init__(self, protocol, srp, credentials):
-        """Initialize a new MrpPairingVerifier."""
-        self.protocol = protocol
-        self.srp = srp
-        self.credentials = credentials
-        self._output_key = None
-        self._input_key = None
-
-    async def verify_credentials(self):
-        """Verify credentials with device."""
-        _, public_key = self.srp.initialize()
-
-        msg = messages.crypto_pairing({
-            tlv8.TLV_SEQ_NO: b'\x01',
-            tlv8.TLV_PUBLIC_KEY: public_key})
-        resp = await self.protocol.send_and_receive(
-            msg, generate_identifier=False)
-
-        resp = _get_pairing_data(resp)
-        session_pub_key = resp[tlv8.TLV_PUBLIC_KEY]
-        encrypted = resp[tlv8.TLV_ENCRYPTED_DATA]
-        log_binary(_LOGGER,
-                   'Device',
-                   Public=self.credentials.ltpk,
-                   Encrypted=encrypted)
-
-        encrypted_data = self.srp.verify1(
-            self.credentials, session_pub_key, encrypted)
-        msg = messages.crypto_pairing({
-            tlv8.TLV_SEQ_NO: b'\x03',
-            tlv8.TLV_ENCRYPTED_DATA: encrypted_data})
-        resp = await self.protocol.send_and_receive(
-            msg, generate_identifier=False)
-
-        # TODO: check status code
-
-        self._output_key, self._input_key = self.srp.verify2()
-
-    def encryption_keys(self):
-        """Return derived encryption keys."""
-        return self._output_key, self._input_key
+    def pin(self, pin):
+        """Pin code used for pairing."""
+        self.pin_code = pin

--- a/pyatv/mrp/protobuf/CommandInfo.proto
+++ b/pyatv/mrp/protobuf/CommandInfo.proto
@@ -53,6 +53,19 @@ enum Command {
 }
 
 message CommandInfo {
+  enum RepeatMode {
+    Unknown = 0;
+    One = 1;
+    All = 2;
+  }
+
+  enum ShuffleMode {
+    Unkown = 0;
+    Off = 1;
+    Albums = 2;
+    Songs = 3;
+  }
+
   optional Command command = 1;
   optional bool enabled = 2;
   optional bool active = 3;
@@ -62,8 +75,8 @@ message CommandInfo {
   optional float maximumRating = 7;
   repeated float supportedRates = 8;
   optional string localizedShortTitle = 9;
-  optional int32 repeatMode = 10;
-  optional int32 shuffleMode = 11;
+  optional RepeatMode repeatMode = 10;
+  optional ShuffleMode shuffleMode = 11;
   optional int32 presentationStyle = 12;
   optional int32 skipInterval = 13;
   optional int32 numAvailableSkips = 14;

--- a/pyatv/mrp/protobuf/CommandInfo_pb2.py
+++ b/pyatv/mrp/protobuf/CommandInfo_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto2',
   serialized_options=None,
-  serialized_pb=_b('\n$pyatv/mrp/protobuf/CommandInfo.proto\"\x8e\x04\n\x0b\x43ommandInfo\x12\x19\n\x07\x63ommand\x18\x01 \x01(\x0e\x32\x08.Command\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\x12\x0e\n\x06\x61\x63tive\x18\x03 \x01(\x08\x12\x1a\n\x12preferredIntervals\x18\x04 \x03(\x01\x12\x16\n\x0elocalizedTitle\x18\x05 \x01(\t\x12\x15\n\rminimumRating\x18\x06 \x01(\x02\x12\x15\n\rmaximumRating\x18\x07 \x01(\x02\x12\x16\n\x0esupportedRates\x18\x08 \x03(\x02\x12\x1b\n\x13localizedShortTitle\x18\t \x01(\t\x12\x12\n\nrepeatMode\x18\n \x01(\x05\x12\x13\n\x0bshuffleMode\x18\x0b \x01(\x05\x12\x19\n\x11presentationStyle\x18\x0c \x01(\x05\x12\x14\n\x0cskipInterval\x18\r \x01(\x05\x12\x19\n\x11numAvailableSkips\x18\x0e \x01(\x05\x12\x15\n\rskipFrequency\x18\x0f \x01(\x05\x12\x10\n\x08\x63\x61nScrub\x18\x10 \x01(\x05\x12#\n\x1bsupportedPlaybackQueueTypes\x18\x11 \x03(\x05\x12\'\n\x1fsupportedCustomQueueIdentifiers\x18\x12 \x03(\t\x12#\n\x1bsupportedInsertionPositions\x18\x13 \x03(\x05\x12\x1b\n\x13supportsSharedQueue\x18\x14 \x01(\x08*\x8b\x08\n\x07\x43ommand\x12\x0b\n\x07Unknown\x10\x00\x12\x08\n\x04Play\x10\x01\x12\t\n\x05Pause\x10\x02\x12\x13\n\x0fTogglePlayPause\x10\x03\x12\x08\n\x04Stop\x10\x04\x12\r\n\tNextTrack\x10\x05\x12\x11\n\rPreviousTrack\x10\x06\x12\x16\n\x12\x41\x64vanceShuffleMode\x10\x07\x12\x15\n\x11\x41\x64vanceRepeatMode\x10\x08\x12\x14\n\x10\x42\x65ginFastForward\x10\t\x12\x12\n\x0e\x45ndFastForward\x10\n\x12\x0f\n\x0b\x42\x65ginRewind\x10\x0b\x12\r\n\tEndRewind\x10\x0c\x12\x13\n\x0fRewind15Seconds\x10\r\x12\x18\n\x14\x46\x61stForward15Seconds\x10\x0e\x12\x13\n\x0fRewind30Seconds\x10\x0f\x12\x18\n\x14\x46\x61stForward30Seconds\x10\x10\x12\x0f\n\x0bSkipForward\x10\x12\x12\x10\n\x0cSkipBackward\x10\x13\x12\x16\n\x12\x43hangePlaybackRate\x10\x14\x12\r\n\tRateTrack\x10\x15\x12\r\n\tLikeTrack\x10\x16\x12\x10\n\x0c\x44islikeTrack\x10\x17\x12\x11\n\rBookmarkTrack\x10\x18\x12\x1a\n\x16SeekToPlaybackPosition\x10-\x12\x14\n\x10\x43hangeRepeatMode\x10.\x12\x15\n\x11\x43hangeShuffleMode\x10/\x12\x18\n\x14\x45nableLanguageOption\x10\x35\x12\x19\n\x15\x44isableLanguageOption\x10\x36\x12\x0f\n\x0bNextChapter\x10\x19\x12\x13\n\x0fPreviousChapter\x10\x1a\x12\r\n\tNextAlbum\x10\x1b\x12\x11\n\rPreviousAlbum\x10\x1c\x12\x10\n\x0cNextPlaylist\x10\x1d\x12\x14\n\x10PreviousPlaylist\x10\x1e\x12\x0c\n\x08\x42\x61nTrack\x10\x1f\x12\x16\n\x12\x41\x64\x64TrackToWishList\x10 \x12\x1b\n\x17RemoveTrackFromWishList\x10!\x12\x11\n\rNextInContext\x10\"\x12\x15\n\x11PreviousInContext\x10#\x12\x18\n\x14ResetPlaybackTimeout\x10)\x12\x14\n\x10SetPlaybackQueue\x10\x30\x12\x1e\n\x1a\x41\x64\x64NowPlayingItemToLibrary\x10\x31\x12\x16\n\x12\x43reateRadioStation\x10\x32\x12\x14\n\x10\x41\x64\x64ItemToLibrary\x10\x33\x12\x1b\n\x17InsertIntoPlaybackQueue\x10\x34\x12\x18\n\x14ReorderPlaybackQueue\x10\x37\x12\x1b\n\x17RemoveFromPlaybackQueue\x10\x38\x12\x1b\n\x17PlayItemInPlaybackQueue\x10\x39')
+  serialized_pb=_b('\n$pyatv/mrp/protobuf/CommandInfo.proto\"\xa9\x05\n\x0b\x43ommandInfo\x12\x19\n\x07\x63ommand\x18\x01 \x01(\x0e\x32\x08.Command\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\x12\x0e\n\x06\x61\x63tive\x18\x03 \x01(\x08\x12\x1a\n\x12preferredIntervals\x18\x04 \x03(\x01\x12\x16\n\x0elocalizedTitle\x18\x05 \x01(\t\x12\x15\n\rminimumRating\x18\x06 \x01(\x02\x12\x15\n\rmaximumRating\x18\x07 \x01(\x02\x12\x16\n\x0esupportedRates\x18\x08 \x03(\x02\x12\x1b\n\x13localizedShortTitle\x18\t \x01(\t\x12+\n\nrepeatMode\x18\n \x01(\x0e\x32\x17.CommandInfo.RepeatMode\x12-\n\x0bshuffleMode\x18\x0b \x01(\x0e\x32\x18.CommandInfo.ShuffleMode\x12\x19\n\x11presentationStyle\x18\x0c \x01(\x05\x12\x14\n\x0cskipInterval\x18\r \x01(\x05\x12\x19\n\x11numAvailableSkips\x18\x0e \x01(\x05\x12\x15\n\rskipFrequency\x18\x0f \x01(\x05\x12\x10\n\x08\x63\x61nScrub\x18\x10 \x01(\x05\x12#\n\x1bsupportedPlaybackQueueTypes\x18\x11 \x03(\x05\x12\'\n\x1fsupportedCustomQueueIdentifiers\x18\x12 \x03(\t\x12#\n\x1bsupportedInsertionPositions\x18\x13 \x03(\x05\x12\x1b\n\x13supportsSharedQueue\x18\x14 \x01(\x08\"+\n\nRepeatMode\x12\x0b\n\x07Unknown\x10\x00\x12\x07\n\x03One\x10\x01\x12\x07\n\x03\x41ll\x10\x02\"9\n\x0bShuffleMode\x12\n\n\x06Unkown\x10\x00\x12\x07\n\x03Off\x10\x01\x12\n\n\x06\x41lbums\x10\x02\x12\t\n\x05Songs\x10\x03*\x8b\x08\n\x07\x43ommand\x12\x0b\n\x07Unknown\x10\x00\x12\x08\n\x04Play\x10\x01\x12\t\n\x05Pause\x10\x02\x12\x13\n\x0fTogglePlayPause\x10\x03\x12\x08\n\x04Stop\x10\x04\x12\r\n\tNextTrack\x10\x05\x12\x11\n\rPreviousTrack\x10\x06\x12\x16\n\x12\x41\x64vanceShuffleMode\x10\x07\x12\x15\n\x11\x41\x64vanceRepeatMode\x10\x08\x12\x14\n\x10\x42\x65ginFastForward\x10\t\x12\x12\n\x0e\x45ndFastForward\x10\n\x12\x0f\n\x0b\x42\x65ginRewind\x10\x0b\x12\r\n\tEndRewind\x10\x0c\x12\x13\n\x0fRewind15Seconds\x10\r\x12\x18\n\x14\x46\x61stForward15Seconds\x10\x0e\x12\x13\n\x0fRewind30Seconds\x10\x0f\x12\x18\n\x14\x46\x61stForward30Seconds\x10\x10\x12\x0f\n\x0bSkipForward\x10\x12\x12\x10\n\x0cSkipBackward\x10\x13\x12\x16\n\x12\x43hangePlaybackRate\x10\x14\x12\r\n\tRateTrack\x10\x15\x12\r\n\tLikeTrack\x10\x16\x12\x10\n\x0c\x44islikeTrack\x10\x17\x12\x11\n\rBookmarkTrack\x10\x18\x12\x1a\n\x16SeekToPlaybackPosition\x10-\x12\x14\n\x10\x43hangeRepeatMode\x10.\x12\x15\n\x11\x43hangeShuffleMode\x10/\x12\x18\n\x14\x45nableLanguageOption\x10\x35\x12\x19\n\x15\x44isableLanguageOption\x10\x36\x12\x0f\n\x0bNextChapter\x10\x19\x12\x13\n\x0fPreviousChapter\x10\x1a\x12\r\n\tNextAlbum\x10\x1b\x12\x11\n\rPreviousAlbum\x10\x1c\x12\x10\n\x0cNextPlaylist\x10\x1d\x12\x14\n\x10PreviousPlaylist\x10\x1e\x12\x0c\n\x08\x42\x61nTrack\x10\x1f\x12\x16\n\x12\x41\x64\x64TrackToWishList\x10 \x12\x1b\n\x17RemoveTrackFromWishList\x10!\x12\x11\n\rNextInContext\x10\"\x12\x15\n\x11PreviousInContext\x10#\x12\x18\n\x14ResetPlaybackTimeout\x10)\x12\x14\n\x10SetPlaybackQueue\x10\x30\x12\x1e\n\x1a\x41\x64\x64NowPlayingItemToLibrary\x10\x31\x12\x16\n\x12\x43reateRadioStation\x10\x32\x12\x14\n\x10\x41\x64\x64ItemToLibrary\x10\x33\x12\x1b\n\x17InsertIntoPlaybackQueue\x10\x34\x12\x18\n\x14ReorderPlaybackQueue\x10\x37\x12\x1b\n\x17RemoveFromPlaybackQueue\x10\x38\x12\x1b\n\x17PlayItemInPlaybackQueue\x10\x39')
 )
 
 _COMMAND = _descriptor.EnumDescriptor(
@@ -229,8 +229,8 @@ _COMMAND = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=570,
-  serialized_end=1605,
+  serialized_start=725,
+  serialized_end=1760,
 )
 _sym_db.RegisterEnumDescriptor(_COMMAND)
 
@@ -285,6 +285,62 @@ ReorderPlaybackQueue = 55
 RemoveFromPlaybackQueue = 56
 PlayItemInPlaybackQueue = 57
 
+
+_COMMANDINFO_REPEATMODE = _descriptor.EnumDescriptor(
+  name='RepeatMode',
+  full_name='CommandInfo.RepeatMode',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='Unknown', index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='One', index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='All', index=2, number=2,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=620,
+  serialized_end=663,
+)
+_sym_db.RegisterEnumDescriptor(_COMMANDINFO_REPEATMODE)
+
+_COMMANDINFO_SHUFFLEMODE = _descriptor.EnumDescriptor(
+  name='ShuffleMode',
+  full_name='CommandInfo.ShuffleMode',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='Unkown', index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Off', index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Albums', index=2, number=2,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Songs', index=3, number=3,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=665,
+  serialized_end=722,
+)
+_sym_db.RegisterEnumDescriptor(_COMMANDINFO_SHUFFLEMODE)
 
 
 _COMMANDINFO = _descriptor.Descriptor(
@@ -359,14 +415,14 @@ _COMMANDINFO = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='repeatMode', full_name='CommandInfo.repeatMode', index=9,
-      number=10, type=5, cpp_type=1, label=1,
+      number=10, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='shuffleMode', full_name='CommandInfo.shuffleMode', index=10,
-      number=11, type=5, cpp_type=1, label=1,
+      number=11, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -439,6 +495,8 @@ _COMMANDINFO = _descriptor.Descriptor(
   ],
   nested_types=[],
   enum_types=[
+    _COMMANDINFO_REPEATMODE,
+    _COMMANDINFO_SHUFFLEMODE,
   ],
   serialized_options=None,
   is_extendable=False,
@@ -447,10 +505,14 @@ _COMMANDINFO = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=41,
-  serialized_end=567,
+  serialized_end=722,
 )
 
 _COMMANDINFO.fields_by_name['command'].enum_type = _COMMAND
+_COMMANDINFO.fields_by_name['repeatMode'].enum_type = _COMMANDINFO_REPEATMODE
+_COMMANDINFO.fields_by_name['shuffleMode'].enum_type = _COMMANDINFO_SHUFFLEMODE
+_COMMANDINFO_REPEATMODE.containing_type = _COMMANDINFO
+_COMMANDINFO_SHUFFLEMODE.containing_type = _COMMANDINFO
 DESCRIPTOR.message_types_by_name['CommandInfo'] = _COMMANDINFO
 DESCRIPTOR.enum_types_by_name['Command'] = _COMMAND
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)

--- a/pyatv/mrp/protobuf/CommandInfo_pb2.pyi
+++ b/pyatv/mrp/protobuf/CommandInfo_pb2.pyi
@@ -140,6 +140,46 @@ PlayItemInPlaybackQueue = typing___cast(Command, 57)
 
 class CommandInfo(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+    class RepeatMode(int):
+        DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
+        @classmethod
+        def Name(cls, number: int) -> str: ...
+        @classmethod
+        def Value(cls, name: str) -> CommandInfo.RepeatMode: ...
+        @classmethod
+        def keys(cls) -> typing___List[str]: ...
+        @classmethod
+        def values(cls) -> typing___List[CommandInfo.RepeatMode]: ...
+        @classmethod
+        def items(cls) -> typing___List[typing___Tuple[str, CommandInfo.RepeatMode]]: ...
+        Unknown = typing___cast(CommandInfo.RepeatMode, 0)
+        One = typing___cast(CommandInfo.RepeatMode, 1)
+        All = typing___cast(CommandInfo.RepeatMode, 2)
+    Unknown = typing___cast(CommandInfo.RepeatMode, 0)
+    One = typing___cast(CommandInfo.RepeatMode, 1)
+    All = typing___cast(CommandInfo.RepeatMode, 2)
+
+    class ShuffleMode(int):
+        DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
+        @classmethod
+        def Name(cls, number: int) -> str: ...
+        @classmethod
+        def Value(cls, name: str) -> CommandInfo.ShuffleMode: ...
+        @classmethod
+        def keys(cls) -> typing___List[str]: ...
+        @classmethod
+        def values(cls) -> typing___List[CommandInfo.ShuffleMode]: ...
+        @classmethod
+        def items(cls) -> typing___List[typing___Tuple[str, CommandInfo.ShuffleMode]]: ...
+        Unkown = typing___cast(CommandInfo.ShuffleMode, 0)
+        Off = typing___cast(CommandInfo.ShuffleMode, 1)
+        Albums = typing___cast(CommandInfo.ShuffleMode, 2)
+        Songs = typing___cast(CommandInfo.ShuffleMode, 3)
+    Unkown = typing___cast(CommandInfo.ShuffleMode, 0)
+    Off = typing___cast(CommandInfo.ShuffleMode, 1)
+    Albums = typing___cast(CommandInfo.ShuffleMode, 2)
+    Songs = typing___cast(CommandInfo.ShuffleMode, 3)
+
     command = ... # type: Command
     enabled = ... # type: bool
     active = ... # type: bool
@@ -149,8 +189,8 @@ class CommandInfo(google___protobuf___message___Message):
     maximumRating = ... # type: float
     supportedRates = ... # type: google___protobuf___internal___containers___RepeatedScalarFieldContainer[float]
     localizedShortTitle = ... # type: typing___Text
-    repeatMode = ... # type: int
-    shuffleMode = ... # type: int
+    repeatMode = ... # type: CommandInfo.RepeatMode
+    shuffleMode = ... # type: CommandInfo.ShuffleMode
     presentationStyle = ... # type: int
     skipInterval = ... # type: int
     numAvailableSkips = ... # type: int
@@ -172,8 +212,8 @@ class CommandInfo(google___protobuf___message___Message):
         maximumRating : typing___Optional[float] = None,
         supportedRates : typing___Optional[typing___Iterable[float]] = None,
         localizedShortTitle : typing___Optional[typing___Text] = None,
-        repeatMode : typing___Optional[int] = None,
-        shuffleMode : typing___Optional[int] = None,
+        repeatMode : typing___Optional[CommandInfo.RepeatMode] = None,
+        shuffleMode : typing___Optional[CommandInfo.ShuffleMode] = None,
         presentationStyle : typing___Optional[int] = None,
         skipInterval : typing___Optional[int] = None,
         numAvailableSkips : typing___Optional[int] = None,

--- a/pyatv/mrp/protobuf/CommandOptions.proto
+++ b/pyatv/mrp/protobuf/CommandOptions.proto
@@ -1,6 +1,19 @@
 syntax = "proto2";
 
 message CommandOptions {
+  enum RepeatMode {
+    Unknown = 0;
+    One = 1;
+    All = 2;
+  }
+
+  enum ShuffleMode {
+    Unkown = 0;
+    Off = 1;
+    Albums = 2;
+    Songs = 3;
+  }
+
   optional string sourceId = 2;
   optional string mediaType = 3;
   optional bool externalPlayerCommand = 4;
@@ -9,8 +22,8 @@ message CommandOptions {
   optional float rating = 7;
   optional bool negative = 8;
   optional double playbackPosition = 9;
-  optional int32 repeatMode = 10;
-  optional int32 shuffleMode = 11;
+  optional RepeatMode repeatMode = 10;
+  optional ShuffleMode shuffleMode = 11;
   optional uint64 trackID = 12;
   optional int64 radioStationID = 13;
   optional string radioStationHash = 14;

--- a/pyatv/mrp/protobuf/CommandOptions_pb2.py
+++ b/pyatv/mrp/protobuf/CommandOptions_pb2.py
@@ -20,10 +20,66 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto2',
   serialized_options=None,
-  serialized_pb=_b('\n\'pyatv/mrp/protobuf/CommandOptions.proto\"\xbc\x06\n\x0e\x43ommandOptions\x12\x10\n\x08sourceId\x18\x02 \x01(\t\x12\x11\n\tmediaType\x18\x03 \x01(\t\x12\x1d\n\x15\x65xternalPlayerCommand\x18\x04 \x01(\x08\x12\x14\n\x0cskipInterval\x18\x05 \x01(\x02\x12\x14\n\x0cplaybackRate\x18\x06 \x01(\x02\x12\x0e\n\x06rating\x18\x07 \x01(\x02\x12\x10\n\x08negative\x18\x08 \x01(\x08\x12\x18\n\x10playbackPosition\x18\t \x01(\x01\x12\x12\n\nrepeatMode\x18\n \x01(\x05\x12\x13\n\x0bshuffleMode\x18\x0b \x01(\x05\x12\x0f\n\x07trackID\x18\x0c \x01(\x04\x12\x16\n\x0eradioStationID\x18\r \x01(\x03\x12\x18\n\x10radioStationHash\x18\x0e \x01(\t\x12\"\n\x1asystemAppPlaybackQueueData\x18\x0f \x01(\x0c\x12\x1f\n\x17\x64\x65stinationAppDisplayID\x18\x10 \x01(\t\x12\x13\n\x0bsendOptions\x18\x11 \x01(\r\x12/\n\'requestDefermentToPlaybackQueuePosition\x18\x12 \x01(\x08\x12\x11\n\tcontextID\x18\x13 \x01(\t\x12*\n\"shouldOverrideManuallyCuratedQueue\x18\x14 \x01(\x08\x12\x12\n\nstationURL\x18\x15 \x01(\t\x12 \n\x18shouldBeginRadioPlayback\x18\x16 \x01(\x08\x12&\n\x1eplaybackQueueInsertionPosition\x18\x17 \x01(\x05\x12\x15\n\rcontentItemID\x18\x18 \x01(\t\x12\x1b\n\x13playbackQueueOffset\x18\x19 \x01(\x05\x12&\n\x1eplaybackQueueDestinationOffset\x18\x1a \x01(\x05\x12\x16\n\x0elanguageOption\x18\x1b \x01(\x0c\x12\x1c\n\x14playbackQueueContext\x18\x1c \x01(\x0c\x12 \n\x18insertAfterContentItemID\x18\x1d \x01(\t\x12\x1f\n\x17nowPlayingContentItemID\x18\x1e \x01(\t\x12\x15\n\rreplaceIntent\x18\x1f \x01(\x05')
+  serialized_pb=_b('\n\'pyatv/mrp/protobuf/CommandOptions.proto\"\xdd\x07\n\x0e\x43ommandOptions\x12\x10\n\x08sourceId\x18\x02 \x01(\t\x12\x11\n\tmediaType\x18\x03 \x01(\t\x12\x1d\n\x15\x65xternalPlayerCommand\x18\x04 \x01(\x08\x12\x14\n\x0cskipInterval\x18\x05 \x01(\x02\x12\x14\n\x0cplaybackRate\x18\x06 \x01(\x02\x12\x0e\n\x06rating\x18\x07 \x01(\x02\x12\x10\n\x08negative\x18\x08 \x01(\x08\x12\x18\n\x10playbackPosition\x18\t \x01(\x01\x12.\n\nrepeatMode\x18\n \x01(\x0e\x32\x1a.CommandOptions.RepeatMode\x12\x30\n\x0bshuffleMode\x18\x0b \x01(\x0e\x32\x1b.CommandOptions.ShuffleMode\x12\x0f\n\x07trackID\x18\x0c \x01(\x04\x12\x16\n\x0eradioStationID\x18\r \x01(\x03\x12\x18\n\x10radioStationHash\x18\x0e \x01(\t\x12\"\n\x1asystemAppPlaybackQueueData\x18\x0f \x01(\x0c\x12\x1f\n\x17\x64\x65stinationAppDisplayID\x18\x10 \x01(\t\x12\x13\n\x0bsendOptions\x18\x11 \x01(\r\x12/\n\'requestDefermentToPlaybackQueuePosition\x18\x12 \x01(\x08\x12\x11\n\tcontextID\x18\x13 \x01(\t\x12*\n\"shouldOverrideManuallyCuratedQueue\x18\x14 \x01(\x08\x12\x12\n\nstationURL\x18\x15 \x01(\t\x12 \n\x18shouldBeginRadioPlayback\x18\x16 \x01(\x08\x12&\n\x1eplaybackQueueInsertionPosition\x18\x17 \x01(\x05\x12\x15\n\rcontentItemID\x18\x18 \x01(\t\x12\x1b\n\x13playbackQueueOffset\x18\x19 \x01(\x05\x12&\n\x1eplaybackQueueDestinationOffset\x18\x1a \x01(\x05\x12\x16\n\x0elanguageOption\x18\x1b \x01(\x0c\x12\x1c\n\x14playbackQueueContext\x18\x1c \x01(\x0c\x12 \n\x18insertAfterContentItemID\x18\x1d \x01(\t\x12\x1f\n\x17nowPlayingContentItemID\x18\x1e \x01(\t\x12\x15\n\rreplaceIntent\x18\x1f \x01(\x05\"+\n\nRepeatMode\x12\x0b\n\x07Unknown\x10\x00\x12\x07\n\x03One\x10\x01\x12\x07\n\x03\x41ll\x10\x02\"9\n\x0bShuffleMode\x12\n\n\x06Unkown\x10\x00\x12\x07\n\x03Off\x10\x01\x12\n\n\x06\x41lbums\x10\x02\x12\t\n\x05Songs\x10\x03')
 )
 
 
+
+_COMMANDOPTIONS_REPEATMODE = _descriptor.EnumDescriptor(
+  name='RepeatMode',
+  full_name='CommandOptions.RepeatMode',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='Unknown', index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='One', index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='All', index=2, number=2,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=931,
+  serialized_end=974,
+)
+_sym_db.RegisterEnumDescriptor(_COMMANDOPTIONS_REPEATMODE)
+
+_COMMANDOPTIONS_SHUFFLEMODE = _descriptor.EnumDescriptor(
+  name='ShuffleMode',
+  full_name='CommandOptions.ShuffleMode',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='Unkown', index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Off', index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Albums', index=2, number=2,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Songs', index=3, number=3,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=976,
+  serialized_end=1033,
+)
+_sym_db.RegisterEnumDescriptor(_COMMANDOPTIONS_SHUFFLEMODE)
 
 
 _COMMANDOPTIONS = _descriptor.Descriptor(
@@ -91,14 +147,14 @@ _COMMANDOPTIONS = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='repeatMode', full_name='CommandOptions.repeatMode', index=8,
-      number=10, type=5, cpp_type=1, label=1,
+      number=10, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='shuffleMode', full_name='CommandOptions.shuffleMode', index=9,
-      number=11, type=5, cpp_type=1, label=1,
+      number=11, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -248,6 +304,8 @@ _COMMANDOPTIONS = _descriptor.Descriptor(
   ],
   nested_types=[],
   enum_types=[
+    _COMMANDOPTIONS_REPEATMODE,
+    _COMMANDOPTIONS_SHUFFLEMODE,
   ],
   serialized_options=None,
   is_extendable=False,
@@ -256,9 +314,13 @@ _COMMANDOPTIONS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=44,
-  serialized_end=872,
+  serialized_end=1033,
 )
 
+_COMMANDOPTIONS.fields_by_name['repeatMode'].enum_type = _COMMANDOPTIONS_REPEATMODE
+_COMMANDOPTIONS.fields_by_name['shuffleMode'].enum_type = _COMMANDOPTIONS_SHUFFLEMODE
+_COMMANDOPTIONS_REPEATMODE.containing_type = _COMMANDOPTIONS
+_COMMANDOPTIONS_SHUFFLEMODE.containing_type = _COMMANDOPTIONS
 DESCRIPTOR.message_types_by_name['CommandOptions'] = _COMMANDOPTIONS
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 

--- a/pyatv/mrp/protobuf/CommandOptions_pb2.pyi
+++ b/pyatv/mrp/protobuf/CommandOptions_pb2.pyi
@@ -2,6 +2,7 @@
 import sys
 from google.protobuf.descriptor import (
     Descriptor as google___protobuf___descriptor___Descriptor,
+    EnumDescriptor as google___protobuf___descriptor___EnumDescriptor,
 )
 
 from google.protobuf.message import (
@@ -9,8 +10,11 @@ from google.protobuf.message import (
 )
 
 from typing import (
+    List as typing___List,
     Optional as typing___Optional,
     Text as typing___Text,
+    Tuple as typing___Tuple,
+    cast as typing___cast,
 )
 
 from typing_extensions import (
@@ -20,6 +24,46 @@ from typing_extensions import (
 
 class CommandOptions(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+    class RepeatMode(int):
+        DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
+        @classmethod
+        def Name(cls, number: int) -> str: ...
+        @classmethod
+        def Value(cls, name: str) -> CommandOptions.RepeatMode: ...
+        @classmethod
+        def keys(cls) -> typing___List[str]: ...
+        @classmethod
+        def values(cls) -> typing___List[CommandOptions.RepeatMode]: ...
+        @classmethod
+        def items(cls) -> typing___List[typing___Tuple[str, CommandOptions.RepeatMode]]: ...
+        Unknown = typing___cast(CommandOptions.RepeatMode, 0)
+        One = typing___cast(CommandOptions.RepeatMode, 1)
+        All = typing___cast(CommandOptions.RepeatMode, 2)
+    Unknown = typing___cast(CommandOptions.RepeatMode, 0)
+    One = typing___cast(CommandOptions.RepeatMode, 1)
+    All = typing___cast(CommandOptions.RepeatMode, 2)
+
+    class ShuffleMode(int):
+        DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
+        @classmethod
+        def Name(cls, number: int) -> str: ...
+        @classmethod
+        def Value(cls, name: str) -> CommandOptions.ShuffleMode: ...
+        @classmethod
+        def keys(cls) -> typing___List[str]: ...
+        @classmethod
+        def values(cls) -> typing___List[CommandOptions.ShuffleMode]: ...
+        @classmethod
+        def items(cls) -> typing___List[typing___Tuple[str, CommandOptions.ShuffleMode]]: ...
+        Unkown = typing___cast(CommandOptions.ShuffleMode, 0)
+        Off = typing___cast(CommandOptions.ShuffleMode, 1)
+        Albums = typing___cast(CommandOptions.ShuffleMode, 2)
+        Songs = typing___cast(CommandOptions.ShuffleMode, 3)
+    Unkown = typing___cast(CommandOptions.ShuffleMode, 0)
+    Off = typing___cast(CommandOptions.ShuffleMode, 1)
+    Albums = typing___cast(CommandOptions.ShuffleMode, 2)
+    Songs = typing___cast(CommandOptions.ShuffleMode, 3)
+
     sourceId = ... # type: typing___Text
     mediaType = ... # type: typing___Text
     externalPlayerCommand = ... # type: bool
@@ -28,8 +72,8 @@ class CommandOptions(google___protobuf___message___Message):
     rating = ... # type: float
     negative = ... # type: bool
     playbackPosition = ... # type: float
-    repeatMode = ... # type: int
-    shuffleMode = ... # type: int
+    repeatMode = ... # type: CommandOptions.RepeatMode
+    shuffleMode = ... # type: CommandOptions.ShuffleMode
     trackID = ... # type: int
     radioStationID = ... # type: int
     radioStationHash = ... # type: typing___Text
@@ -61,8 +105,8 @@ class CommandOptions(google___protobuf___message___Message):
         rating : typing___Optional[float] = None,
         negative : typing___Optional[bool] = None,
         playbackPosition : typing___Optional[float] = None,
-        repeatMode : typing___Optional[int] = None,
-        shuffleMode : typing___Optional[int] = None,
+        repeatMode : typing___Optional[CommandOptions.RepeatMode] = None,
+        shuffleMode : typing___Optional[CommandOptions.ShuffleMode] = None,
         trackID : typing___Optional[int] = None,
         radioStationID : typing___Optional[int] = None,
         radioStationHash : typing___Optional[typing___Text] = None,

--- a/pyatv/mrp/protobuf/NowPlayingInfo.proto
+++ b/pyatv/mrp/protobuf/NowPlayingInfo.proto
@@ -1,13 +1,26 @@
 syntax = "proto2";
 
 message NowPlayingInfo {
+  enum RepeatMode {
+    Unknown = 0;
+    One = 1;
+    All = 2;
+  }
+
+  enum ShuffleMode {
+    Unkown = 0;
+    Off = 1;
+    Albums = 2;
+    Songs = 3;
+  }
+
   optional string album = 1;
   optional string artist = 2;
   optional double duration = 3;
   optional double elapsedTime = 4;
   optional float playbackRate = 5;
-  optional int32 repeatMode = 6;
-  optional int32 shuffleMode = 7;
+  optional RepeatMode repeatMode = 6;
+  optional ShuffleMode shuffleMode = 7;
   optional double timestamp = 8;
   optional string title = 9;
   optional uint64 uniqueIdentifier = 10;

--- a/pyatv/mrp/protobuf/NowPlayingInfo_pb2.py
+++ b/pyatv/mrp/protobuf/NowPlayingInfo_pb2.py
@@ -20,10 +20,66 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto2',
   serialized_options=None,
-  serialized_pb=_b('\n\'pyatv/mrp/protobuf/NowPlayingInfo.proto\"\x9c\x03\n\x0eNowPlayingInfo\x12\r\n\x05\x61lbum\x18\x01 \x01(\t\x12\x0e\n\x06\x61rtist\x18\x02 \x01(\t\x12\x10\n\x08\x64uration\x18\x03 \x01(\x01\x12\x13\n\x0b\x65lapsedTime\x18\x04 \x01(\x01\x12\x14\n\x0cplaybackRate\x18\x05 \x01(\x02\x12\x12\n\nrepeatMode\x18\x06 \x01(\x05\x12\x13\n\x0bshuffleMode\x18\x07 \x01(\x05\x12\x11\n\ttimestamp\x18\x08 \x01(\x01\x12\r\n\x05title\x18\t \x01(\t\x12\x18\n\x10uniqueIdentifier\x18\n \x01(\x04\x12\x17\n\x0fisExplicitTrack\x18\x0b \x01(\x08\x12\x12\n\nisMusicApp\x18\x0c \x01(\x08\x12\x1e\n\x16radioStationIdentifier\x18\r \x01(\x03\x12\x18\n\x10radioStationHash\x18\x0e \x01(\t\x12\x18\n\x10radioStationName\x18\x0f \x01(\t\x12\x19\n\x11\x61rtworkDataDigest\x18\x10 \x01(\x0c\x12\x14\n\x0cisAlwaysLive\x18\x11 \x01(\x08\x12\x17\n\x0fisAdvertisement\x18\x12 \x01(\x08')
+  serialized_pb=_b('\n\'pyatv/mrp/protobuf/NowPlayingInfo.proto\"\xbd\x04\n\x0eNowPlayingInfo\x12\r\n\x05\x61lbum\x18\x01 \x01(\t\x12\x0e\n\x06\x61rtist\x18\x02 \x01(\t\x12\x10\n\x08\x64uration\x18\x03 \x01(\x01\x12\x13\n\x0b\x65lapsedTime\x18\x04 \x01(\x01\x12\x14\n\x0cplaybackRate\x18\x05 \x01(\x02\x12.\n\nrepeatMode\x18\x06 \x01(\x0e\x32\x1a.NowPlayingInfo.RepeatMode\x12\x30\n\x0bshuffleMode\x18\x07 \x01(\x0e\x32\x1b.NowPlayingInfo.ShuffleMode\x12\x11\n\ttimestamp\x18\x08 \x01(\x01\x12\r\n\x05title\x18\t \x01(\t\x12\x18\n\x10uniqueIdentifier\x18\n \x01(\x04\x12\x17\n\x0fisExplicitTrack\x18\x0b \x01(\x08\x12\x12\n\nisMusicApp\x18\x0c \x01(\x08\x12\x1e\n\x16radioStationIdentifier\x18\r \x01(\x03\x12\x18\n\x10radioStationHash\x18\x0e \x01(\t\x12\x18\n\x10radioStationName\x18\x0f \x01(\t\x12\x19\n\x11\x61rtworkDataDigest\x18\x10 \x01(\x0c\x12\x14\n\x0cisAlwaysLive\x18\x11 \x01(\x08\x12\x17\n\x0fisAdvertisement\x18\x12 \x01(\x08\"+\n\nRepeatMode\x12\x0b\n\x07Unknown\x10\x00\x12\x07\n\x03One\x10\x01\x12\x07\n\x03\x41ll\x10\x02\"9\n\x0bShuffleMode\x12\n\n\x06Unkown\x10\x00\x12\x07\n\x03Off\x10\x01\x12\n\n\x06\x41lbums\x10\x02\x12\t\n\x05Songs\x10\x03')
 )
 
 
+
+_NOWPLAYINGINFO_REPEATMODE = _descriptor.EnumDescriptor(
+  name='RepeatMode',
+  full_name='NowPlayingInfo.RepeatMode',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='Unknown', index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='One', index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='All', index=2, number=2,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=515,
+  serialized_end=558,
+)
+_sym_db.RegisterEnumDescriptor(_NOWPLAYINGINFO_REPEATMODE)
+
+_NOWPLAYINGINFO_SHUFFLEMODE = _descriptor.EnumDescriptor(
+  name='ShuffleMode',
+  full_name='NowPlayingInfo.ShuffleMode',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='Unkown', index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Off', index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Albums', index=2, number=2,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Songs', index=3, number=3,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=560,
+  serialized_end=617,
+)
+_sym_db.RegisterEnumDescriptor(_NOWPLAYINGINFO_SHUFFLEMODE)
 
 
 _NOWPLAYINGINFO = _descriptor.Descriptor(
@@ -70,14 +126,14 @@ _NOWPLAYINGINFO = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='repeatMode', full_name='NowPlayingInfo.repeatMode', index=5,
-      number=6, type=5, cpp_type=1, label=1,
+      number=6, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='shuffleMode', full_name='NowPlayingInfo.shuffleMode', index=6,
-      number=7, type=5, cpp_type=1, label=1,
+      number=7, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -164,6 +220,8 @@ _NOWPLAYINGINFO = _descriptor.Descriptor(
   ],
   nested_types=[],
   enum_types=[
+    _NOWPLAYINGINFO_REPEATMODE,
+    _NOWPLAYINGINFO_SHUFFLEMODE,
   ],
   serialized_options=None,
   is_extendable=False,
@@ -172,9 +230,13 @@ _NOWPLAYINGINFO = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=44,
-  serialized_end=456,
+  serialized_end=617,
 )
 
+_NOWPLAYINGINFO.fields_by_name['repeatMode'].enum_type = _NOWPLAYINGINFO_REPEATMODE
+_NOWPLAYINGINFO.fields_by_name['shuffleMode'].enum_type = _NOWPLAYINGINFO_SHUFFLEMODE
+_NOWPLAYINGINFO_REPEATMODE.containing_type = _NOWPLAYINGINFO
+_NOWPLAYINGINFO_SHUFFLEMODE.containing_type = _NOWPLAYINGINFO
 DESCRIPTOR.message_types_by_name['NowPlayingInfo'] = _NOWPLAYINGINFO
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 

--- a/pyatv/mrp/protobuf/NowPlayingInfo_pb2.pyi
+++ b/pyatv/mrp/protobuf/NowPlayingInfo_pb2.pyi
@@ -2,6 +2,7 @@
 import sys
 from google.protobuf.descriptor import (
     Descriptor as google___protobuf___descriptor___Descriptor,
+    EnumDescriptor as google___protobuf___descriptor___EnumDescriptor,
 )
 
 from google.protobuf.message import (
@@ -9,8 +10,11 @@ from google.protobuf.message import (
 )
 
 from typing import (
+    List as typing___List,
     Optional as typing___Optional,
     Text as typing___Text,
+    Tuple as typing___Tuple,
+    cast as typing___cast,
 )
 
 from typing_extensions import (
@@ -20,13 +24,53 @@ from typing_extensions import (
 
 class NowPlayingInfo(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+    class RepeatMode(int):
+        DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
+        @classmethod
+        def Name(cls, number: int) -> str: ...
+        @classmethod
+        def Value(cls, name: str) -> NowPlayingInfo.RepeatMode: ...
+        @classmethod
+        def keys(cls) -> typing___List[str]: ...
+        @classmethod
+        def values(cls) -> typing___List[NowPlayingInfo.RepeatMode]: ...
+        @classmethod
+        def items(cls) -> typing___List[typing___Tuple[str, NowPlayingInfo.RepeatMode]]: ...
+        Unknown = typing___cast(NowPlayingInfo.RepeatMode, 0)
+        One = typing___cast(NowPlayingInfo.RepeatMode, 1)
+        All = typing___cast(NowPlayingInfo.RepeatMode, 2)
+    Unknown = typing___cast(NowPlayingInfo.RepeatMode, 0)
+    One = typing___cast(NowPlayingInfo.RepeatMode, 1)
+    All = typing___cast(NowPlayingInfo.RepeatMode, 2)
+
+    class ShuffleMode(int):
+        DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
+        @classmethod
+        def Name(cls, number: int) -> str: ...
+        @classmethod
+        def Value(cls, name: str) -> NowPlayingInfo.ShuffleMode: ...
+        @classmethod
+        def keys(cls) -> typing___List[str]: ...
+        @classmethod
+        def values(cls) -> typing___List[NowPlayingInfo.ShuffleMode]: ...
+        @classmethod
+        def items(cls) -> typing___List[typing___Tuple[str, NowPlayingInfo.ShuffleMode]]: ...
+        Unkown = typing___cast(NowPlayingInfo.ShuffleMode, 0)
+        Off = typing___cast(NowPlayingInfo.ShuffleMode, 1)
+        Albums = typing___cast(NowPlayingInfo.ShuffleMode, 2)
+        Songs = typing___cast(NowPlayingInfo.ShuffleMode, 3)
+    Unkown = typing___cast(NowPlayingInfo.ShuffleMode, 0)
+    Off = typing___cast(NowPlayingInfo.ShuffleMode, 1)
+    Albums = typing___cast(NowPlayingInfo.ShuffleMode, 2)
+    Songs = typing___cast(NowPlayingInfo.ShuffleMode, 3)
+
     album = ... # type: typing___Text
     artist = ... # type: typing___Text
     duration = ... # type: float
     elapsedTime = ... # type: float
     playbackRate = ... # type: float
-    repeatMode = ... # type: int
-    shuffleMode = ... # type: int
+    repeatMode = ... # type: NowPlayingInfo.RepeatMode
+    shuffleMode = ... # type: NowPlayingInfo.ShuffleMode
     timestamp = ... # type: float
     title = ... # type: typing___Text
     uniqueIdentifier = ... # type: int
@@ -46,8 +90,8 @@ class NowPlayingInfo(google___protobuf___message___Message):
         duration : typing___Optional[float] = None,
         elapsedTime : typing___Optional[float] = None,
         playbackRate : typing___Optional[float] = None,
-        repeatMode : typing___Optional[int] = None,
-        shuffleMode : typing___Optional[int] = None,
+        repeatMode : typing___Optional[NowPlayingInfo.RepeatMode] = None,
+        shuffleMode : typing___Optional[NowPlayingInfo.ShuffleMode] = None,
         timestamp : typing___Optional[float] = None,
         title : typing___Optional[typing___Text] = None,
         uniqueIdentifier : typing___Optional[int] = None,

--- a/pyatv/mrp/protocol.py
+++ b/pyatv/mrp/protocol.py
@@ -7,7 +7,7 @@ import logging
 from collections import namedtuple
 
 from pyatv.mrp import (messages, protobuf)
-from pyatv.mrp.pairing import MrpPairingVerifier
+from pyatv.mrp.auth import MrpPairingVerifier
 from pyatv.mrp.srp import Credentials
 
 _LOGGER = logging.getLogger(__name__)

--- a/pyatv/net.py
+++ b/pyatv/net.py
@@ -3,10 +3,24 @@
 import logging
 import binascii
 
+from aiohttp import ClientSession
+
 _LOGGER = logging.getLogger(__name__)
 
 
 DEFAULT_TIMEOUT = 10.0  # Seconds
+
+
+def is_custom_session(session):
+    """Return if a ClientSession was created by pyatv."""
+    return hasattr(session, '_pyatv')
+
+
+async def create_session(loop):
+    """Create aiohttp ClientSession manged by pyatv."""
+    session = ClientSession(loop=loop)
+    setattr(session, '_pyatv', True)
+    return session
 
 
 class HttpSession:

--- a/tests/airplay/test_airplay_pair.py
+++ b/tests/airplay/test_airplay_pair.py
@@ -1,0 +1,54 @@
+"""Functional pairing tests using the API with a fake AirPlay Apple TV."""
+
+from aiohttp.test_utils import (AioHTTPTestCase, unittest_run_loop)
+
+import pyatv
+from pyatv import const
+from pyatv.conf import (AirPlayService, AppleTV)
+from tests.airplay.fake_airplay_device import (
+    FakeAirPlayDevice, AirPlayUseCases, DEVICE_CREDENTIALS, DEVICE_PIN)
+
+
+class PairFunctionalTest(AioHTTPTestCase):
+
+    def setUp(self):
+        AioHTTPTestCase.setUp(self)
+        self.pairing = None
+
+        self.service = AirPlayService(
+            'airplay_id', credentials=DEVICE_CREDENTIALS,
+            port=self.server.port)
+        self.conf = AppleTV('127.0.0.1', 'Apple TV')
+        self.conf.add_service(self.service)
+
+    async def tearDownAsync(self):
+        await self.pairing.close()
+        await super().tearDownAsync()
+
+    async def get_application(self, loop=None):
+        self.fake_atv = FakeAirPlayDevice(self)
+        self.usecase = AirPlayUseCases(self.fake_atv)
+        return self.fake_atv.app
+
+    async def initiate_pairing(self):
+        self.usecase.airplay_require_authentication()
+
+        options = {}
+
+        self.pairing = await pyatv.pair(
+            self.conf, const.PROTOCOL_AIRPLAY, self.loop, **options)
+
+    @unittest_run_loop
+    async def test_pairing_with_device(self):
+        await self.initiate_pairing()
+
+        self.assertTrue(self.pairing.device_provides_pin)
+
+        await self.pairing.begin()
+        self.pairing.pin(DEVICE_PIN)
+
+        self.assertFalse(self.pairing.has_paired)
+
+        await self.pairing.finish()
+        self.assertTrue(self.pairing.has_paired)
+        self.assertEqual(self.service.credentials, DEVICE_CREDENTIALS)

--- a/tests/dmap/test_dmap_pair.py
+++ b/tests/dmap/test_dmap_pair.py
@@ -1,0 +1,81 @@
+"""Functional pairing tests using the API with a fake DMAP Apple TV."""
+
+import ipaddress
+
+from aiohttp.test_utils import (AioHTTPTestCase, unittest_run_loop)
+
+import pyatv
+from pyatv import const
+from pyatv.conf import (DmapService, AppleTV)
+from pyatv.dmap import pairing
+from tests.dmap.fake_dmap_atv import (FakeAppleTV, AppleTVUseCases)
+from tests import zeroconf_stub
+
+HSGID = '12345-6789-0'
+PAIRING_GUID = '0x0000000000000001'
+SESSION_ID = 5555
+REMOTE_NAME = 'pyatv remote'
+PIN_CODE = 1234
+
+# This is valid for the PAIR in the pairing module and pin 1234
+# (extracted form a real device)
+PAIRINGCODE = '690E6FF61E0D7C747654A42AED17047D'
+
+
+class PairFunctionalTest(AioHTTPTestCase):
+
+    def setUp(self):
+        AioHTTPTestCase.setUp(self)
+        self.pairing = None
+
+        self.service = DmapService(
+            'dmap_id', PAIRING_GUID, port=self.server.port)
+        self.conf = AppleTV('127.0.0.1', 'Apple TV')
+        self.conf.add_service(self.service)
+
+        # TODO: currently stubs internal method, should provide stub
+        # for netifaces later
+        pairing._get_private_ip_addresses = \
+            lambda: [ipaddress.ip_address('10.0.0.1')]
+
+        self.zeroconf = zeroconf_stub.stub(pyatv.dmap.pairing)
+
+    async def tearDownAsync(self):
+        await self.pairing.close()
+        await super().tearDownAsync()
+
+    async def get_application(self, loop=None):
+        self.fake_atv = FakeAppleTV(
+            HSGID, PAIRING_GUID, SESSION_ID, self)
+        self.usecase = AppleTVUseCases(self.fake_atv)
+        return self.fake_atv.app
+
+    async def initiate_pairing(self,
+                               name=REMOTE_NAME,
+                               pairing_guid=PAIRING_GUID):
+        self.usecase.pairing_response(REMOTE_NAME, PAIRINGCODE)
+
+        options = {
+            'zeroconf': self.zeroconf,
+            'name': name,
+            'pairing_guid': pairing_guid,
+        }
+
+        self.pairing = await pyatv.pair(
+            self.conf, const.PROTOCOL_DMAP, self.loop, **options)
+
+    @unittest_run_loop
+    async def test_pairing_with_device(self):
+        await self.initiate_pairing()
+
+        self.assertFalse(self.pairing.device_provides_pin)
+
+        await self.pairing.begin()
+        self.pairing.pin(PIN_CODE)
+
+        await self.usecase.act_on_bonjour_services(self.zeroconf)
+
+        await self.pairing.finish()
+
+        self.assertTrue(self.pairing.has_paired)
+        self.assertEqual(self.service.credentials, PAIRING_GUID)


### PR DESCRIPTION
Pairing interface has moved to its own function call and pairing (no matter protocol) is not initiated via pyatv.pair. This simplifies a lot of things. Tests are however not that well structured now and probably need an oversight.

This fixes #240.