### PR TITLE
Fix relative links in documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,6 +18,7 @@ email: pierre.staahl@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   a python client library for the Apple TV
 url: "https://postlund.github.io/pyatv" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: /pyatv
 twitter_username: postlund
 github_username:  postlund
 

--- a/docs/_layouts/template.html
+++ b/docs/_layouts/template.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <script async defer src="https://buttons.github.io/buttons.js"></script>
   </head>
   <body>
@@ -16,7 +16,7 @@
       <a class="github-button" href="https://github.com/sponsors/postlund" data-icon="octicon-heart" aria-label="Sponsor @postlund on GitHub">Sponsor</a>
       <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
       {% for p in site.top_pages %}
-        <a href="{{ p.link }}" class="btn">
+        <a href="{{ site.baseurl | append:"/" | append:p.link }}" class="btn">
           {% assign sub = p.link | split:"/" %}
           {% if sub[1] == page.link_group %}
             <b>{{ p.title }}</b>
@@ -35,9 +35,9 @@
       <div style="text-align: center; width: 100%">
         {% for p in site.page_links[page.link_group] %}
           {% if page.permalink == p.link %}
-            <b><a href="{{ p.link }}" style="display: inline;">{{ p.title }}</a></b>
+            <b><a href="{{ site.baseurl | append:"/" | append:p.link }}" style="display: inline;">{{ p.title }}</a></b>
           {% else %}
-            <a href="{{ p.link }}" style="display: inline;">{{ p.title }}</a>
+            <a href="{{ site.baseurl | append:"/" | append:p.link }}" style="display: inline;">{{ p.title }}</a>
           {% endif %}
           {% if p != site.page_links[page.link_group].last %}| {% endif %}
         {% endfor %}

--- a/docs/documentation/documentation.md
+++ b/docs/documentation/documentation.md
@@ -9,7 +9,7 @@ link_group: documentation
 This section covers general parts of `pyatv`, like how to install it, concepts and terminology to
 understand how it works. More or less everything that is not *how* you develop with it.
 
-Before diving into code, make sure you read and understand the [Concepts](/documentation/concepts/)
+Before diving into code, make sure you read and understand the [Concepts](documentation/concepts/)
 first.
 
 ## Installing pyatv
@@ -25,7 +25,7 @@ You might need some additional packages to compile the dependencies. On a debian
 
 ### Development version
 
-To try out the latest development verison (a.k.a. `master` on GitHub), you can install with:
+To try out the latest development version (a.k.a. `master` on GitHub), you can install with:
 
     pip install git+https://github.com/postlund/pyatv.git
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -77,7 +77,7 @@ Once you have credentials, you can start controlling the device and asking for s
     $ atvremote --id ... --mrp-credentials ... play
 
 To see all supported commands, pass `commands` as last argument. More detailed instructions
-can be found att the [atvremote](/documentation/atvremote/) page.
+can be found att the [atvremote](documentation/atvremote/) page.
 
 
 ## Writing code

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,9 @@ As pyatv is a library, it is mainly aimed for developers creating applications t
 with Apple TVs. However, pyatv ships with a powerful command line application that is useful for
 normal users as well.
 
-So, head over to [Getting started](/getting-started) to get going!
+So, head over to [Getting started](getting-started) to get going!
 
-If you need help or have questions, check out the [Support](/support) page instead.
+If you need help or have questions, check out the [Support](support) page instead.
 
 # Features
 

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -12,7 +12,7 @@ This page tries to answer some common questions.
 
 ### My device is not found when scanning?
 
-See [Troubleshooting](/support/troubleshooting/) for some hints on locating the issue.
+See [Troubleshooting](support/troubleshooting/) for some hints on locating the issue.
 
 ### Why is all or some metadata missing when I am playing some media on my device?
 
@@ -27,7 +27,7 @@ case, you should write a bug report.
 The device authentication process has now been reversed engineered and implemented
 in pyatv. In order to get rid of this message, you must perform AirPlay pairing with
 the device and use the obtained credentials with playing media. See
-[pairing with atvremote](/documentation/atvremote).
+[pairing with atvremote](documentation/atvremote).
 
 ## Technical Questions
 


### PR DESCRIPTION
Did not consider relative links correctly, which broke the links on GitHub since the page is located in a sub directory.