### PR TITLE
atvremote CLI: fixed credentials reference to .service.credentials

### DIFF
--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -160,7 +160,7 @@ class GlobalCommands:
         if pairing.has_paired:
             print('Pairing seems to have succeeded, yey!')
             print('You may now use these credentials: {0}'.format(
-                pairing.credentials))
+                pairing.service.credentials))
         else:
             print('Pairing failed!')
 


### PR DESCRIPTION
Tiny tiny fix!

Was receiving this error using the example atvremote CLI to pair:
```
root@nuc:/opt/pyatv# atvremote --id 00:11:22:33:44:55 --protocol mrp pair
Enter PIN on screen: 0123
Pairing seems to have succeeded, yey!
ERROR: Pairing failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/pyatv/__main__.py", line 127, in pair
    await self._perform_pairing(pairing)
  File "/usr/local/lib/python3.7/dist-packages/pyatv/__main__.py", line 163, in _perform_pairing
    pairing.credentials))
AttributeError: 'MrpPairingHandler' object has no attribute 'credentials'
```

It needed an update to reference the correct ```PairingHandler.service.credentials``` attribute.