### PR TITLE
Add interface to report device disconnects

### DIFF
--- a/docs/development/listeners.md
+++ b/docs/development/listeners.md
@@ -38,3 +38,31 @@ continue to be delivered after an error has happened. The paramater
 "trying to deliver updates again", but it might also be ignored if it is
 deemed not necessary. The reason for its existence is purly to provide a
 way to not hammer the device in case of errors.
+
+## Device Updates
+
+It is possible to get callbacks whenever a device loses its connection. Two methods
+are used: one for expected loss, e.g. manually disconnecting and one for unexpected
+loss, e.g. a crash or network problem. The API is defined by the
+`interface.DeviceLister` interface and works similarily to how push updates works.
+
+Here is a simple example:
+
+```python
+class DeviceListener:
+
+    def connection_lost(self, exception):
+        print("Lost connection:", str(exception))
+
+    def connection_closed(self):
+        print("Connection closed!")
+
+
+atv.listener = DeviceListener()
+```
+
+A small note here about this API. For `MRP` this works fine as that protocol
+is connection oriented. It's another case for `DMAP`, since that protocol is
+request based. For now, this interface is implemented by the push updates
+API (to be clear: for `DMAP`). So when the push updates API failes to establish
+a connection, the callbacks in this interface will be called.

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -348,10 +348,7 @@ class PushUpdater:
         - playstatus_error(updater, exception)
 
         The first method is called when a new update happens and the second one
-        is called if an error occurs. Please note that if an error happens,
-        push updates will be stopped. So they will need to be enabled again,
-        e.g. from the error method. A delay should preferably be passed to
-        start() to avoid an infinite error-loop.
+        is called if an error occurs.
         """
         self.__listener = listener
 
@@ -365,7 +362,7 @@ class PushUpdater:
 
     @abstractmethod
     def stop(self):
-        """No longer listen for updates."""
+        """No longer forward updates to listener."""
         raise exceptions.NotSupportedError
 
 
@@ -380,21 +377,52 @@ class AirPlay:  # pylint: disable=too-few-public-methods
         raise exceptions.NotSupportedError
 
 
+class DeviceListener:
+    """Listener interface for generic device updates."""
+
+    @abstractmethod
+    def connection_lost(self, exception):
+        """Device was unexpectedly disconnected."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def connection_closed(self):
+        """Device connection was (intentionally) closed."""
+        raise NotImplementedError()
+
+
 class AppleTV:
     """Base class representing an Apple TV."""
 
     __metaclass__ = ABCMeta
 
+    def __init__(self):
+        """Initialize a new AppleTV."""
+        self.__listener = None
+
+    @property
+    def listener(self):
+        """Object receiving generic device updates.
+
+        Must be an object conforming to DeviceListener.
+        """
+        return self.__listener
+
+    @listener.setter
+    def listener(self, target):
+        """Change object receiving generic device updates."""
+        self.__listener = target
+
     @abstractmethod
-    def connect(self):
+    async def connect(self):
         """Initiate connection to device.
 
-        Not needed as it is performed automatically.
+        No need to call it yourself, it's done automatically.
         """
         raise exceptions.NotSupportedError
 
     @abstractmethod
-    def close(self):
+    async def close(self):
         """Close connection and release allocated resources."""
         raise exceptions.NotSupportedError
 


### PR DESCRIPTION
The new interface (DeviceListener) has two methods:

  * connection_lost
  * connection_closed

In case of a problem, e.g. server closes connection, connection_lost is called. In case of a controlled shutdown (e.g. user calls close), connection_closed is called instead.

This implementation should be complete for MRP, but I'm not entirely sure with DMAP. There might be situations where I miss a disconnect. But we'll see where it leads.

This is a start in order to support #273.