### PR TITLE
Do not re-use ClientSession for AirPlay

### DIFF
--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -7,9 +7,7 @@ from ipaddress import ip_address
 from aiozeroconf import ServiceBrowser, Zeroconf
 
 from pyatv import (conf, const, exceptions, net)
-from pyatv.airplay import player
 from pyatv.airplay import AirPlayAPI
-from pyatv.net import HttpSession
 
 from pyatv.dmap import DmapAppleTV
 from pyatv.dmap.pairing import DmapPairingHandler
@@ -155,21 +153,11 @@ async def connect(config, loop, protocol=None, session=None):
         session = await net.create_session(loop=loop)
 
     # AirPlay service is the same for both DMAP and MRP
-    airplay = _setup_airplay(loop, session, config)
+    airplay = AirPlayAPI(config, loop)
 
     atv = implementation(loop, session, config, airplay)
     await atv.connect()
     return atv
-
-
-def _setup_airplay(loop, session, config):
-    airplay_service = config.get_service(const.PROTOCOL_AIRPLAY)
-    airplay_player = player.AirPlayPlayer(
-        loop, session, config.address, airplay_service.port)
-    airplay_http = HttpSession(
-        session, 'http://{0}:{1}/'.format(
-            config.address, airplay_service.port))
-    return AirPlayAPI(config, airplay_http, airplay_player)
 
 
 async def pair(config, protocol, loop, session=None, **kwargs):


### PR DESCRIPTION
This hack creates a new ClientSession every time something is played
with AirPlay. Otherwise the connection will hang, so a spinning wheel
keeps appearing on the screen.

Hopefully this is all that is needed for #266, but it must be verified first.