### PR TITLE
Support PINs with leading zeros in MRP

### DIFF
--- a/pyatv/mrp/pairing.py
+++ b/pyatv/mrp/pairing.py
@@ -57,4 +57,4 @@ class MrpPairingHandler(PairingHandler):
 
     def pin(self, pin):
         """Pin code used for pairing."""
-        self.pin_code = pin
+        self.pin_code = str(pin).zfill(4)


### PR DESCRIPTION
This is a quickfix, I will add better validation of PIN codes later.

Should take care of #291.