### PR TITLE
Assumes protocol if none given

### DIFF
--- a/docs/documentation/atvremote.md
+++ b/docs/documentation/atvremote.md
@@ -69,6 +69,7 @@ Which protocols a device supports can be seen with `scan`. But in general you ne
 either `mrp` (devices running tvOS) or `dmap` (Apple TV 3 and earlier). If you also want to
 stream video, you can pair `airplay` as well. The procedure is the same for all of them, just
 change the argument provided to `--protocol`.
+If no protocol is specified, it will assume `mrp` (devices running tvOS) or `dmap` (Apple TV 3 and earlier) first, or AirPlay if that's the only one available.
 
 ### Credentials
 

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -121,12 +121,9 @@ class GlobalCommands:
 
         if self.args.protocol is None:
             logging.warning('No protocol specified')
-            try:
-                print('Assuming protocol {0}'.format(
-                    convert.protocol_str(apple_tv.get_services()[0])))
-                self.args.protocol = apple_tv.get_services()[0]
-            except Exception:
-                return 1
+            print('Assuming protocol {0}'.format(
+                convert.protocol_str(apple_tv.get_services()[0])))
+            self.args.protocol = apple_tv.get_services()[0]
 
         options = {}
 

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -123,8 +123,8 @@ class GlobalCommands:
             logging.warning('No protocol specified')
             try:
                 print('Assuming protocol {0}'.format(
-                    convert.protocol_str(next(iter(apple_tv._services)))))
-                self.args.protocol = next(iter(apple_tv._services))
+                    convert.protocol_str(apple_tv.get_services()[0])))
+                self.args.protocol = apple_tv.get_services()[0]
             except Exception:
                 return 1
 

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -9,7 +9,7 @@ import asyncio
 import argparse
 from argparse import ArgumentTypeError
 
-from pyatv import (const, exceptions, interface, scan, connect, pair)
+from pyatv import (const, convert, exceptions, interface, scan, connect, pair)
 from pyatv.conf import (
     AppleTV, DmapService, MrpService, AirPlayService)
 from pyatv.dmap import tag_definitions
@@ -113,14 +113,19 @@ class GlobalCommands:
 
     async def pair(self):
         """Pair pyatv as a remote control with an Apple TV."""
-        if self.args.protocol is None:
-            logging.error('No protocol specified')
-            return 1
-
         apple_tv = await _scan_for_device(
             self.args, self.args.scan_timeout, self.loop)
+
         if not apple_tv:
             return 2
+        if self.args.protocol is None:
+            logging.warning('No protocol specified')
+            try:
+                print('Assuming protocol {0}'.format(
+                    convert.protocol_str(next(iter(apple_tv._services)))))
+                self.args.protocol = next(iter(apple_tv._services))
+            except:
+                return 1
 
         options = {}
 

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -118,13 +118,14 @@ class GlobalCommands:
 
         if not apple_tv:
             return 2
+
         if self.args.protocol is None:
             logging.warning('No protocol specified')
             try:
                 print('Assuming protocol {0}'.format(
                     convert.protocol_str(next(iter(apple_tv._services)))))
                 self.args.protocol = next(iter(apple_tv._services))
-            except:
+            except Exception:
                 return 1
 
         options = {}

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -57,6 +57,7 @@ class AppleTV:
         return self._services.get(protocol, None)
 
     def get_services(self):
+        """returns numbered list of services"""
         return list(self._services)
 
     @property

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -57,7 +57,7 @@ class AppleTV:
         return self._services.get(protocol, None)
 
     def get_services(self):
-        """returns numbered list of services"""
+        """Return numbered list of services."""
         return list(self._services)
 
     @property

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -58,7 +58,7 @@ class AppleTV:
 
     def get_services(self):
         """Return numbered list of services."""
-        return list(self._services)
+        return sorted(list(self._services))
 
     @property
     def services(self):

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -56,6 +56,9 @@ class AppleTV:
 
         return self._services.get(protocol, None)
 
+    def get_services(self):
+        return list(self._services)
+
     @property
     def services(self):
         """Return all supported services."""


### PR DESCRIPTION
Seems like a simple addition.  Right now, if the user tries to pair without a protocol, it will immediately exit.  Now, it will at least try to guess one, and if not it'll exit—giving the same result as before.

The way this ends up working out is that it prefers remotes to airplay.  Since protocol 1 is mutex to 2, don't need to worry about preferring one of those.  And if it has 2 and 3, it'll default to the remote.  If it has just 3, it'll use just 3, etc.