### PR TITLE
Disable IPv6 for now

### DIFF
--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from ipaddress import ip_address
 
+import netifaces
 from aiozeroconf import ServiceBrowser, Zeroconf
 
 from pyatv import (conf, const, exceptions, net)
@@ -108,7 +109,7 @@ class _ServiceListener:
 async def scan(loop, timeout=5, identifier=None, protocol=None):
     """Scan for Apple TVs using zeroconf (bonjour) and returns them."""
     listener = _ServiceListener(loop)
-    zeroconf = Zeroconf(loop)
+    zeroconf = Zeroconf(loop, address_family=[netifaces.AF_INET])
     try:
         ServiceBrowser(zeroconf, HOMESHARING_SERVICE, listener)
         ServiceBrowser(zeroconf, DEVICE_SERVICE, listener)

--- a/pyatv/dmap/pairing.py
+++ b/pyatv/dmap/pairing.py
@@ -48,7 +48,8 @@ class DmapPairingHandler(PairingHandler):  # pylint: disable=too-many-instance-a
         """Initialize a new instance."""
         super().__init__(session, config.get_service(const.PROTOCOL_DMAP))
         self._loop = loop
-        self._zeroconf = kwargs.get('zeroconf', Zeroconf(loop))
+        self._zeroconf = kwargs.get(
+            'zeroconf', Zeroconf(loop, address_family=[netifaces.AF_INET]))
         self._name = kwargs.get('name', 'pyatv')
         self._web_server = None
         self._server = None

--- a/tests/zeroconf_stub.py
+++ b/tests/zeroconf_stub.py
@@ -106,6 +106,6 @@ class ZeroconfStub:
 def stub(module, *services):
     """Stub a module using zeroconf."""
     instance = ZeroconfStub(list(services))
-    module.Zeroconf = lambda loop: instance
+    module.Zeroconf = lambda loop, address_family=None: instance
     module.ServiceBrowser = ServiceBrowserStub
     return instance


### PR DESCRIPTION
Seems to cause issues in some setups when IPv6 is disabled. Since I
don't officially support it, this is not really an issue currently.

Fixes #286.