### PR TITLE
Add wakeup command to RemoteControl

### DIFF
--- a/docs/documentation/atvremote.md
+++ b/docs/documentation/atvremote.md
@@ -135,6 +135,7 @@ called `commands`, as it will present a list of availble commands:
      - up - Press key up
      - volume_down - Press key volume down
      - volume_up - Press key volume up
+     - wakeup - Wake up the device
 
     Metadata commands:
      - artwork - Return artwork for what is currently playing (or None)

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -70,6 +70,7 @@ class BaseDmapAppleTV:
         return self.daap.post(cmd_url)
 
 
+# pylint: disable=too-many-public-methods
 class DmapRemoteControl(RemoteControl):
     """Implementation of API for controlling an Apple TV."""
 
@@ -184,9 +185,13 @@ class DmapRemoteControl(RemoteControl):
         # DMAP support unknown
         raise exceptions.NotSupportedError
 
-    async def suspend(self):
+    def suspend(self):
         """Suspend the device."""
         # Not supported by DMAP
+        raise exceptions.NotSupportedError
+
+    def wakeup(self):
+        """Wake up the device."""
         raise exceptions.NotSupportedError
 
     def set_position(self, pos):

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -91,7 +91,7 @@ class PairingHandler:
         raise exceptions.NotSupportedError
 
 
-class RemoteControl:
+class RemoteControl:  # pylint: disable=too-many-public-methods
     """Base class for API used to control an Apple TV."""
 
     __metaclass__ = ABCMeta
@@ -180,6 +180,11 @@ class RemoteControl:
     @abstractmethod
     def suspend(self):
         """Suspend the device."""
+        raise exceptions.NotSupportedError
+
+    @abstractmethod
+    def wakeup(self):
+        """Wake up the device."""
         raise exceptions.NotSupportedError
 
     @abstractmethod

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -33,6 +33,7 @@ _KEY_LOOKUP = {
     'home': [12, 0x40, 0],
     'home_hold': [12, 0x40, 1],
     'suspend': [1, 0x82, 0],
+    'wakeup': [1, 0x83, 0],
     'volume_up': [12, 0xE9, 0],
     'volume_down': [12, 0xEA, 0],
 
@@ -40,6 +41,7 @@ _KEY_LOOKUP = {
 }
 
 
+# pylint: disable=too-many-public-methods
 class MrpRemoteControl(RemoteControl):
     """Implementation of API for controlling an Apple TV."""
 
@@ -127,6 +129,10 @@ class MrpRemoteControl(RemoteControl):
     def suspend(self):
         """Suspend the device."""
         return self._press_key('suspend')
+
+    def wakeup(self):
+        """Wake up the device."""
+        return self._press_key('wakeup')
 
     def set_position(self, pos):
         """Seek in the current playing media."""


### PR DESCRIPTION
Wakes up device from standby. Is not supported by DMAP (but could be simulated via a key press, maybe).