### PR TITLE
Clean up tox and switch from coveralls to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,35 @@
+codecov:
+  branch: master
+
+coverage:
+  range: "80..100"
+
+  status:
+    project: no
+
+flags:
+  library:
+    paths:
+    - pyatv/
+  examples:
+    paths:
+    - examples/
+  configs:
+    paths:
+    - ".git*"
+    - "*.yml"
+  changelog:
+    - CHANGES/
+    - CHANGES.rst
+  docs:
+    paths:
+    - docs/
+    - "*.md"
+    - "*.rst"
+    - "*.txt"
+  scripts:
+    paths:
+    - scripts/
+  tests:
+    paths:
+    - tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,12 @@
-sudo: false
-matrix:
-  fast_finish: true
-  include:
-    - python: "3.5"
-      env: TOXENV=py35
-    - python: "3.5"
-      env: TOXENV=lint
-    - python: "3.6"
-      env: TOXENV=py36
-    - python: "3.6"
-      env: TOXENV=lint
-    - python: "3.7"
-      env: TOXENV=py37
-    - python: "3.7"
-      env: TOXENV=lint
-    - python: "3.8"
-      env: TOXENV=py38
-#    - python: "3.8"
-#      env: TOXENV=lint
-
 cache:
   directories:
     - $HOME/.cache/pip
-install: pip install -U tox coveralls
 language: python
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+install: pip install tox-travis codecov
 script: tox
-after_success: coveralls
+after_success: codecov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A python client library for the Apple TV
 ========================================
 [![Build Status](https://travis-ci.org/postlund/pyatv.svg?branch=master)](https://travis-ci.org/postlund/pyatv)
-[![Coverage Status](https://img.shields.io/coveralls/postlund/pyatv.svg)](https://coveralls.io/r/postlund/pyatv?branch=master)
+[![codecov](https://codecov.io/gh/postlund/pyatv/branch/master/graph/badge.svg)](https://codecov.io/gh/postlund/pyatv)
 [![PyPi Package](https://badge.fury.io/py/pyatv.svg)](https://badge.fury.io/py/pyatv)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/postlund/pyatv.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/postlund/pyatv/context:python)
 [![Downloads](https://pepy.tech/badge/pyatv)](https://pepy.tech/project/pyatv)

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -5,8 +5,8 @@ import inspect
 import logging
 import binascii
 import asyncio
-
 import argparse
+import traceback
 
 from pyatv import (const, exceptions, interface, scan, connect, pair)
 from pyatv.conf import (
@@ -205,7 +205,8 @@ class DeviceCommands:
             command = await _read_input(self.loop, 'pyatv> ')
             if command.lower() == 'exit':
                 break
-            elif command == 'cli':
+
+            if command == 'cli':
                 print('Command not availble here')
                 continue
 
@@ -544,8 +545,6 @@ async def appstart(loop):
             pass  # sys.exit() was used - do nothing
 
         except Exception:  # pylint: disable=broad-except  # noqa
-            import traceback
-
             traceback.print_exc(file=sys.stderr)
             sys.stderr.writelines(
                 '\n>>> An error occurred, full stack trace above\n')

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -328,7 +328,7 @@ class DmapPushUpdater(PushUpdater):
         """
         if self.listener is None:
             raise exceptions.NoAsyncListenerError
-        elif self._future is not None:
+        if self._future is not None:
             return None
 
         # Always start with 0 to trigger an immediate response for the

--- a/pyatv/mrp/srp.py
+++ b/pyatv/mrp/srp.py
@@ -10,6 +10,10 @@ import curve25519
 from srptools import (SRPContext, SRPClientSession, constants)
 from ed25519.keys import SigningKey, VerifyingKey
 
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.backends import default_backend
+
 from pyatv import exceptions
 from pyatv.log import log_binary
 from pyatv.mrp import (tlv8, chacha20)
@@ -52,9 +56,6 @@ class Credentials:
 
 def hkdf_expand(salt, info, shared_secret):
     """Derive encryption keys from shared secret."""
-    from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-    from cryptography.hazmat.backends import default_backend
     hkdf = HKDF(
         algorithm=hashes.SHA512(),
         length=32,

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,13 +1,12 @@
 asynctest==0.13.0
 flake8==3.7.8
-pylint==2.2.3
-coveralls==1.8.2
-pytest==5.1.2
-pytest-cov==2.7.1
+pylint==2.4.4
+codecov==2.0.15
+pytest==5.3.2
+pytest-cov==2.8.1
 pytest-timeout==1.3.3
 pytest-aiohttp==0.3.0
 pydocstyle==4.0.1
 mypy==0.730
 mypy-protobuf==1.15
-Sphinx==2.2.0
 typed-ast==1.4.0

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -22,7 +22,7 @@ fi
 echo "-> Using python: $found_version"
 
 echo "-> Creating python virtual environment..."
-virtualenv -p $found_version .
+$found_version -m venv .
 
 echo "-> Activating virtual environment..."
 source bin/activate

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,33 @@
 [tox]
-envlist = py35, py36, py37, py38, lint, typing
+envlist = clean, py{35,36,37,38}, lint, typing, report
 skip_missing_interpreters = True
 
+[travis]
+python =
+  3.5: clean, py35, lint, typing, report
+  3.6: clean, py36, lint, typing, report
+  3.7: clean, py37, lint, typing, report
+  3.8: clean, py38, lint, typing, report
+
 [testenv]
+passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}/pyatv
-commands =
-     py.test --log-level=debug -v --timeout=30 --durations=10 --cov --cov-report=html {posargs}
+depends =
+    {py35,py36,py37,py38}: clean
+    report: py35,py36,py37,py38
 deps =
      -r{toxinidir}/requirements_test.txt
+commands =
+     pytest --log-level=debug -v --timeout=30 --durations=10 --cov --cov-append --cov-report=term-missing {posargs}
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
 
 [testenv:lint]
-basepython = python3
 ignore_errors = True
 commands =
      flake8 --exclude=pyatv/mrp/protobuf pyatv tests examples scripts
@@ -20,8 +35,14 @@ commands =
      pydocstyle -v --match='(?!test_).*[^pb2]\.py' pyatv examples scripts
 
 [testenv:typing]
-basepython = python3
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
          mypy --ignore-missing-imports --follow-imports=skip pyatv
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
+    coverage html


### PR DESCRIPTION
Switch from coveralls to codecov, enable linting for python 3.8 and clean up tox.