### PR TITLE
Initial clean-up of pairing and auth exceptions

### DIFF
--- a/docs/development/scan_pair_and_connect.md
+++ b/docs/development/scan_pair_and_connect.md
@@ -97,7 +97,7 @@ to succeed (or timeout), in order to know when to call `finish`. This is only ap
 to the case when `device_provides_pin` is False. Now you have to poll `has_paired` or
 just require that pairing succeeds within a time frame.
 
-If an error occurs, e.g. incorrect PIN, `exceptions.DeviceAuthenticationError` is raised.
+If an error occurs, e.g. incorrect PIN, `exceptions.PairingError` is raised.
 
 Translating the flow above into code looks like this:
 

--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -235,7 +235,7 @@ async def connect(config, loop, protocol=None, session=None):
 
     implementation = supported_implementations.get(service.protocol, None)
     if not implementation:
-        raise exceptions.UnsupportedProtocolError()
+        raise exceptions.UnsupportedProtocolError(str(service.protocol))
 
     # If no session is given, create a default one
     if session is None:
@@ -264,7 +264,7 @@ async def pair(config, protocol, loop, session=None, **kwargs):
 
     handler = protocol_handlers.get(protocol, None)
     if handler is None:
-        raise exceptions.UnsupportedProtocolError()
+        raise exceptions.UnsupportedProtocolError(str(protocol))
 
     if session is None:
         session = await net.create_session(loop)

--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -44,14 +44,15 @@ async def _scan_for_device(args, timeout, loop, protocol=None):
         options['hosts'] = args.scan_hosts
 
     atvs = await scan(loop, **options)
-    if not atvs:
-        logging.error('Could not find any Apple TV on current network')
-        return None
 
     if args.name:
         devices = [atv for atv in atvs if atv.name == args.name]
     else:
         devices = atvs
+
+    if not atvs:
+        logging.error('Could not find any Apple TV on current network')
+        return None
 
     if len(devices) > 1:
         logging.error(

--- a/pyatv/airplay/auth.py
+++ b/pyatv/airplay/auth.py
@@ -5,7 +5,7 @@ import plistlib
 import logging
 
 from copy import copy
-from pyatv.exceptions import DeviceAuthenticationError
+from pyatv.exceptions import AuthenticationError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class DeviceAuthenticator:
         _, code = await self.http.post_data(
             'pair-pin-start', headers=_AIRPLAY_HEADERS)
         if code != 200:
-            raise DeviceAuthenticationError('pair start failed')
+            raise AuthenticationError('pair start failed')
 
     async def finish_authentication(self, username, password):
         """Finish authentication process.
@@ -69,7 +69,7 @@ class DeviceAuthenticator:
             'pair-setup-pin',
             data=plistlib.dumps(plist, fmt=plistlib.FMT_BINARY))
         if code != 200:
-            raise DeviceAuthenticationError(
+            raise AuthenticationError(
                 '{0} failed with code {1}'.format(step, code))
         return resp
 
@@ -100,6 +100,6 @@ class AuthenticationVerifier:
         resp, code = await self.http.post_data(
             'pair-verify', data=data, headers=headers)
         if code != 200:
-            raise DeviceAuthenticationError(
+            raise AuthenticationError(
                 '{0} failed with code {1}'.format(step, code))
         return resp

--- a/pyatv/airplay/pairing.py
+++ b/pyatv/airplay/pairing.py
@@ -54,17 +54,25 @@ class AirPlayPairingHandler(PairingHandler):
         _LOGGER.debug('Starting AirPlay pairing with credentials %s',
                       self.auth_data.credentials)
         self.pairing_complete = False
-        return await self.auther.start_authentication()
+
+        try:
+            return await self.auther.start_authentication()
+        except Exception as ex:
+            raise exceptions.PairingError(str(ex)) from ex
 
     async def finish(self):
         """Stop pairing process."""
         if not self.pin_code:
-            raise exceptions.DeviceAuthenticationError('no pin given')
+            raise exceptions.PairingError('no pin given')
 
-        if await self.auther.finish_authentication(self.auth_data.identifier,
-                                                   self.pin_code):
-            self.service.credentials = self.auth_data.credentials
-            self.pairing_complete = True
+        try:
+            await self.auther.finish_authentication(
+                self.auth_data.identifier, self.pin_code)
+        except Exception as ex:
+            raise exceptions.PairingError(str(ex)) from ex
+
+        self.service.credentials = self.auth_data.credentials
+        self.pairing_complete = True
 
     def pin(self, pin):
         """Pin code used for pairing."""

--- a/pyatv/airplay/srp.py
+++ b/pyatv/airplay/srp.py
@@ -183,4 +183,4 @@ class SRPAuthHandler:
 
     def _check_initialized(self):
         if not self.seed:
-            raise NoCredentialsError()
+            raise NoCredentialsError("no credentials available")

--- a/pyatv/convert.py
+++ b/pyatv/convert.py
@@ -16,7 +16,7 @@ def media_kind(kind):
     if kind in [8, 64]:
         return MediaType.TV
 
-    raise exceptions.UnknownMediaKind('Unknown media kind: ' + str(kind))
+    raise exceptions.UnknownMediaKindError('Unknown media kind: ' + str(kind))
 
 
 def media_type_str(mediatype):
@@ -48,7 +48,7 @@ def playstate(state):
     if state in (5, 6):
         return DeviceState.Seeking
 
-    raise exceptions.UnknownPlayState('Unknown playstate: ' + str(state))
+    raise exceptions.UnknownPlayStateError('Unknown playstate: ' + str(state))
 
 
 # pylint: disable=too-many-return-statements

--- a/pyatv/exceptions.py
+++ b/pyatv/exceptions.py
@@ -9,8 +9,12 @@ class UnsupportedProtocolError(Exception):
     """Thrown when an unsupported protocol was requested."""
 
 
+class PairingError(Exception):
+    """Thrown when pairing fails."""
+
+
 class AuthenticationError(Exception):
-    """Thrown when login fails."""
+    """Thrown when authentication fails."""
 
 
 class NotSupportedError(NotImplementedError):
@@ -21,15 +25,11 @@ class InvalidDmapDataError(Exception):
     """Thrown when invalid DMAP data is parsed."""
 
 
-class UnknownServerResponseError(Exception):
-    """Thrown when somethins unknown is send back from the Apple TV."""
-
-
-class UnknownMediaKind(Exception):
+class UnknownMediaKindError(Exception):
     """Thrown when an unknown media kind is found."""
 
 
-class UnknownPlayState(Exception):
+class UnknownPlayStateError(Exception):
     """Thrown when an unknown play state is found."""
 
 
@@ -37,16 +37,12 @@ class NoAsyncListenerError(Exception):
     """Thrown when starting AsyncUpdater with no listener."""
 
 
-class AsyncUpdaterRunningError(Exception):
-    """Thrown when performing an invalid action in AsyncUpdater.."""
-
-
 class NoCredentialsError(Exception):
-    """Thrown if performing an action before initialize is called."""
+    """Thrown if credentials are missing."""
 
 
-class DeviceAuthenticationError(Exception):
-    """Thrown when device authentication fails."""
+class InvalidCredentialsError(Exception):
+    """Thrown if credentials are invalid."""
 
 
 class DeviceIdMissingError(Exception):

--- a/pyatv/mrp/chacha20.py
+++ b/pyatv/mrp/chacha20.py
@@ -1,6 +1,8 @@
 """Transparent encryption layer using Chacha20_Pooly1305."""
 from tlslite.utils.chacha20_poly1305 import CHACHA20_POLY1305
 
+from pyatv import exceptions
+
 
 class Chacha20Cipher:
     """CHACHA20 encryption/decryption layer."""
@@ -30,6 +32,6 @@ class Chacha20Cipher:
             b'\x00\x00\x00\x00' + nounce, data, bytes())
 
         if not decrypted:
-            raise Exception('data decrypt failed')  # TODO: new exception
+            raise exceptions.AuthenticationError('data decrypt failed')
 
         return bytes(decrypted)

--- a/pyatv/mrp/pairing.py
+++ b/pyatv/mrp/pairing.py
@@ -40,16 +40,22 @@ class MrpPairingHandler(PairingHandler):
 
     async def begin(self):
         """Start pairing process."""
-        await self.protocol.start(skip_initial_messages=True)
-        await self.pairing_procedure.start_pairing()
+        try:
+            await self.protocol.start(skip_initial_messages=True)
+            await self.pairing_procedure.start_pairing()
+        except Exception as ex:
+            raise exceptions.PairingError(str(ex)) from ex
 
     async def finish(self):
         """Stop pairing process."""
         if not self.pin_code:
-            raise exceptions.DeviceAuthenticationError('no pin given')
+            raise exceptions.PairingError('no pin given')
 
-        self.service.credentials = \
-            str(await self.pairing_procedure.finish_pairing(self.pin_code))
+        try:
+            self.service.credentials = str(
+                await self.pairing_procedure.finish_pairing(self.pin_code))
+        except Exception as ex:
+            raise exceptions.PairingError(str(ex)) from ex
 
     @property
     def device_provides_pin(self):

--- a/pylintrc
+++ b/pylintrc
@@ -6,6 +6,7 @@ ignored-classes=ProtocolMessage,SetConnectionStateMessage,SetStateMessage,Conten
 
 disable=
   locally-disabled,
+  duplicate-code,
   fixme
 
 [EXCEPTIONS]

--- a/tests/airplay/test_airplay_auth.py
+++ b/tests/airplay/test_airplay_auth.py
@@ -7,7 +7,7 @@ from aiohttp.test_utils import (AioHTTPTestCase, unittest_run_loop)
 
 from pyatv.airplay import srp
 from pyatv.airplay.auth import (DeviceAuthenticator, AuthenticationVerifier)
-from pyatv.exceptions import DeviceAuthenticationError
+from pyatv.exceptions import AuthenticationError
 from pyatv.net import HttpSession
 from tests.airplay.fake_airplay_device import (
     FakeAirPlayDevice, DEVICE_IDENTIFIER, DEVICE_AUTH_KEY, DEVICE_PIN)
@@ -36,7 +36,7 @@ class AirPlayAuthTest(AioHTTPTestCase):
         handler.initialize(INVALID_AUTH_KEY)
 
         verifier = AuthenticationVerifier(http, handler)
-        with self.assertRaises(DeviceAuthenticationError):
+        with self.assertRaises(AuthenticationError):
             await verifier.verify_authed()
 
     @unittest_run_loop
@@ -58,7 +58,7 @@ class AirPlayAuthTest(AioHTTPTestCase):
 
         auther = DeviceAuthenticator(http, handler)
         await auther.start_authentication()
-        with self.assertRaises(DeviceAuthenticationError):
+        with self.assertRaises(AuthenticationError):
             await auther.finish_authentication(
                 DEVICE_IDENTIFIER, DEVICE_PIN)
 

--- a/tests/airplay/test_airplay_pair.py
+++ b/tests/airplay/test_airplay_pair.py
@@ -5,7 +5,7 @@ from asynctest.mock import patch
 
 from aiohttp.test_utils import (AioHTTPTestCase, unittest_run_loop)
 
-import pyatv
+from pyatv import pair, exceptions
 from pyatv.const import Protocol
 from pyatv.conf import (AirPlayService, AppleTV)
 from tests.airplay.fake_airplay_device import (
@@ -40,22 +40,33 @@ class PairFunctionalTest(AioHTTPTestCase):
         self.usecase = AirPlayUseCases(self.fake_atv)
         return self.fake_atv.app
 
-    async def do_pairing(self):
+    async def do_pairing(self, pin=DEVICE_PIN):
         self.usecase.airplay_require_authentication()
 
-        self.pairing = await pyatv.pair(
+        self.pairing = await pair(
             self.conf, Protocol.AirPlay, self.loop)
 
         self.assertTrue(self.pairing.device_provides_pin)
 
         await self.pairing.begin()
-        self.pairing.pin(DEVICE_PIN)
+        if pin:
+            self.pairing.pin(pin)
 
         self.assertFalse(self.pairing.has_paired)
 
         await self.pairing.finish()
         self.assertTrue(self.pairing.has_paired)
         self.assertEqual(self.service.credentials, DEVICE_CREDENTIALS)
+
+    @unittest_run_loop
+    async def test_pairing_exception_invalid_pin(self):
+        with self.assertRaises(exceptions.PairingError):
+            await self.do_pairing(9999)
+
+    @unittest_run_loop
+    async def test_pairing_exception_no_pin(self):
+        with self.assertRaises(exceptions.PairingError):
+            await self.do_pairing(None)
 
     @unittest_run_loop
     @patch('os.urandom')

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -94,7 +94,7 @@ class ConvertTest(unittest.TestCase):
                          convert.media_kind(MEDIA_KIND_TVSHOW2))
 
     def test_unknown_media_kind_throws(self):
-        with self.assertRaises(exceptions.UnknownMediaKind):
+        with self.assertRaises(exceptions.UnknownMediaKindError):
             convert.media_kind(99999)
 
     def test_media_type_to_string(self):
@@ -136,7 +136,7 @@ class ConvertTest(unittest.TestCase):
                          convert.playstate(PLAY_STATE_BACKWARD))
 
     def test_unknown_playstate_throws(self):
-        with self.assertRaises(exceptions.UnknownPlayState):
+        with self.assertRaises(exceptions.UnknownPlayStateError):
             convert.playstate(99999)
 
     def test_playstate_str(self):


### PR DESCRIPTION
This begins the journey of cleaning up exceptions thrown during pairing
and authentication. It is not complete, but covers most parts. Will have
to revise later. There are some other bonus fixes as well, mostly
related to naming and consistency.