### PR TITLE
Some updates to the MRP proxy

### DIFF
--- a/pyatv/mrp/messages.py
+++ b/pyatv/mrp/messages.py
@@ -21,8 +21,8 @@ def device_information(name, identifier):
     info = message.inner()
     info.allowsPairing = True
     info.applicationBundleIdentifier = 'com.apple.TVRemote'
-    info.applicationBundleVersion = '273.12'
-    info.lastSupportedMessageType = 58
+    info.applicationBundleVersion = '344.28'
+    info.lastSupportedMessageType = 77
     info.localizedModelName = 'iPhone'
     info.name = name
     info.protocolVersion = 1
@@ -31,9 +31,11 @@ def device_information(name, identifier):
     info.supportsExtendedMotion = True
     info.supportsSharedQueue = True
     info.supportsSystemPairing = True
-    info.systemBuildVersion = '14G60'
+    info.systemBuildVersion = '17B111'
     info.systemMediaApplication = "com.apple.TVMusic"
     info.uniqueIdentifier = identifier
+    info.deviceClass = 1
+    info.logicalDeviceCount = 1
     return message
 
 


### PR DESCRIPTION
A new proxy instance is now created for every new client, so it is
possible to connect to the proxy multiple times. Pairing and enabling
of encryption also works as expected now and since the encryption seed
is hardcoded, there is no need to re-pair anymore. Pair once and it
will continue to work even when restarting the script. But no security
whatsoever.