### PR TITLE
Move more functional tests to common

### DIFF
--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -44,3 +44,11 @@ class RepeatState(Enum):
     Off = 0
     Track = 1
     All = 2
+
+
+class ShuffleState(Enum):
+    """All supported shuffle states."""
+
+    Off = 0
+    Albums = 1
+    Songs = 2

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -193,13 +193,13 @@ class RemoteControl:  # pylint: disable=too-many-public-methods
         raise exceptions.NotSupportedError
 
     @abstractmethod
-    def set_shuffle(self, is_on):
+    def set_shuffle(self, shuffle_state):
         """Change shuffle mode to on or off."""
         raise exceptions.NotSupportedError
 
     @abstractmethod
-    def set_repeat(self, repeat_mode):
-        """Change repeat mode."""
+    def set_repeat(self, repeat_state):
+        """Change repeat state."""
         raise exceptions.NotSupportedError
 
 

--- a/pyatv/mrp/messages.py
+++ b/pyatv/mrp/messages.py
@@ -2,6 +2,7 @@
 
 import binascii
 
+from pyatv import const
 from pyatv.mrp import protobuf
 from pyatv.mrp import tlv8
 
@@ -162,18 +163,26 @@ def command(cmd):
 
 def repeat(mode):
     """Change repeat mode of current player."""
-    message = command(protobuf.CommandInfo_pb2.ChangeShuffleMode)
+    message = command(protobuf.CommandInfo_pb2.ChangeRepeatMode)
     send_command = message.inner()
     send_command.options.externalPlayerCommand = True
-    send_command.options.repeatMode = mode
+    if mode == const.RepeatState.Track:
+        send_command.options.repeatMode = protobuf.CommandInfo.One
+    elif mode == const.RepeatState.All:
+        send_command.options.repeatMode = protobuf.CommandInfo.All
     return message
 
 
-def shuffle(enable):
+def shuffle(state):
     """Change shuffle mode of current player."""
     message = command(protobuf.CommandInfo_pb2.ChangeShuffleMode)
-    send_command = message.inner()
-    send_command.options.shuffleMode = 3 if enable else 1
+    options = message.inner().options
+    if state == const.ShuffleState.Off:
+        options.shuffleMode = protobuf.CommandInfo.Off
+    elif state == const.ShuffleState.Albums:
+        options.shuffleMode = protobuf.CommandInfo.Albums
+    else:
+        options.shuffleMode = protobuf.CommandInfo.Songs
     return message
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -2,7 +2,7 @@
 reports=no
 extension-pkg-whitelist=netifaces
 ignore=pyatv/mrp/protobuf
-ignored-classes=ProtocolMessage,SetConnectionStateMessage,SetStateMessage,ContentItemMetadata
+ignored-classes=ProtocolMessage,SetConnectionStateMessage,SetStateMessage,ContentItemMetadata,CommandInfo
 
 disable=
   locally-disabled,

--- a/tests/mrp/test_mrp_functional.py
+++ b/tests/mrp/test_mrp_functional.py
@@ -3,6 +3,7 @@
 from aiohttp.test_utils import unittest_run_loop
 
 import pyatv
+from pyatv.const import ShuffleState
 from pyatv.conf import (AirPlayService, MrpService, AppleTV)
 
 from tests import common_functional_tests
@@ -58,3 +59,17 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
     async def test_button_wakeup(self):
         await self.atv.remote_control.wakeup()
         await until(lambda: self.fake_atv.last_button_pressed == 'wakeup')
+
+    @unittest_run_loop
+    async def test_shuffle_state_albums(self):
+        self.usecase.example_video(shuffle=ShuffleState.Albums)
+        playing = await self.playing(shuffle=ShuffleState.Albums)
+        self.assertEqual(playing.shuffle, ShuffleState.Albums)
+
+    @unittest_run_loop
+    async def test_set_shuffle_albums(self):
+        self.usecase.example_video()
+
+        await self.atv.remote_control.set_shuffle(ShuffleState.Albums)
+        playing = await self.playing(shuffle=ShuffleState.Albums)
+        self.assertEqual(playing.shuffle, ShuffleState.Albums)


### PR DESCRIPTION
Most tests have now been moved to common, mostly some metadata tests
left. This commit fixes the previously broken API for shuffle and
repeat. They now respect the pyatv interface, but MRP implementation
has not yet been tested with real device. So there might be some
integration issues there. Will deal with that later.

Code is quite messy and lots of duplication. I will clean this up soon,
when more things are done.