### PR TITLE
Add simple LRU cache for artwork

### DIFF
--- a/pyatv/cache.py
+++ b/pyatv/cache.py
@@ -1,0 +1,46 @@
+"""Simple LRU cache for data based on an identifier."""
+
+from collections import OrderedDict
+
+
+class Cache:
+    """Implementation of simple LRU cache."""
+
+    def __init__(self, limit=16):
+        """Initialize a new Cache instance."""
+        self.limit = limit
+        self.data = OrderedDict()
+
+    def empty(self):
+        """Return if cache is empty or not."""
+        return not self.data
+
+    def put(self, identifier, data):
+        """Put something in the cache."""
+        try:
+            self.data.pop(identifier)
+        except KeyError:
+            if len(self.data) >= self.limit:
+                self.data.popitem(last=False)
+        finally:
+            self.data[identifier] = data
+
+    def get(self, identifier):
+        """Get something from the cache."""
+        value = self.data.pop(identifier)
+        self.data[identifier] = value
+        return value
+
+    def latest(self):
+        """Return identifier of last recently used identifier."""
+        if self.empty():
+            return None
+        return list(self.data.keys())[-1]
+
+    def __contains__(self, identifier):
+        """Check if something is in the cache."""
+        return identifier in self.data
+
+    def __len__(self):
+        """Return number of elements in cache."""
+        return len(self.data)

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -328,6 +328,11 @@ class Metadata:
         """Return artwork for what is currently playing (or None)."""
         raise exceptions.NotSupportedError
 
+    @abstractproperty
+    def artwork_id(self):
+        """Return a unique identifier for current artwork."""
+        raise exceptions.NotSupportedError
+
     @abstractmethod
     def playing(self):
         """Return what is currently playing."""

--- a/tests/dmap/fake_dmap_atv.py
+++ b/tests/dmap/fake_dmap_atv.py
@@ -297,10 +297,10 @@ class AppleTVUseCases(AirPlayUseCases):
         else:
             self.device.responses['login'].insert(0, response)
 
-    def change_artwork(self, artwork, mimetype):
+    def change_artwork(self, artwork, mimetype, identifier=None):
         """Call this method to change artwork response."""
-        self.device.responses['artwork'].insert(
-            0, ArtworkResponse(artwork, 200))
+        self.device.responses['artwork'].append(
+            ArtworkResponse(artwork, 200))
 
     def artwork_no_permission(self):
         """Make artwork fail with no permission.

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -111,6 +111,7 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         # Here, we are logged in and currently have a asession id. These
         # usescases will result in being logged out (HTTP 403) and forcing a
         # re-login with a new session id (1234)
+        self.usecase.example_video()
         self.usecase.force_relogin(1234)
         self.usecase.artwork_no_permission()
         self.usecase.change_artwork(ARTWORK_BYTES, ARTWORK_MIMETYPE)

--- a/tests/mrp/fake_mrp_atv.py
+++ b/tests/mrp/fake_mrp_atv.py
@@ -110,6 +110,7 @@ def _set_state_message(metadata, identifier):
     if metadata.artwork_mimetype:
         md.artworkAvailable = True
         md.artworkMIMEType = metadata.artwork_mimetype
+        md.artworkIdentifier = metadata.artwork_identifier
 
     client = inner.playerPath.client
     client.processIdentifier = 123
@@ -317,11 +318,12 @@ class AppleTVUseCases(AirPlayUseCases):
         """Initialize a new AppleTVUseCases."""
         self.device = fake_apple_tv
 
-    def change_artwork(self, artwork, mimetype):
+    def change_artwork(self, artwork, mimetype, identifier='artwork'):
         """Call this method to change artwork response."""
         metadata = self.device.get_player_state(PLAYER_IDENTIFIER)
         metadata.artwork = artwork
         metadata.artwork_mimetype = mimetype
+        metadata.artwork_identifier = identifier
         self.device.update_state(PLAYER_IDENTIFIER)
 
     def nothing_playing(self):

--- a/tests/mrp/test_mrp_functional.py
+++ b/tests/mrp/test_mrp_functional.py
@@ -13,6 +13,11 @@ from tests.mrp.fake_mrp_atv import (
 from tests.airplay.fake_airplay_device import DEVICE_CREDENTIALS
 
 
+ARTWORK_BYTES = b'1234'
+ARTWORK_MIMETYPE = 'image/png'
+ARTWORK_ID = 'artwork_id1'
+
+
 class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
 
     async def setUpAsync(self):
@@ -74,3 +79,12 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         await self.atv.remote_control.set_shuffle(ShuffleState.Albums)
         playing = await self.playing(shuffle=ShuffleState.Albums)
         self.assertEqual(playing.shuffle, ShuffleState.Albums)
+
+    @unittest_run_loop
+    async def test_metadata_artwork_id(self):
+        self.usecase.example_video()
+        self.usecase.change_artwork(
+            ARTWORK_BYTES, ARTWORK_MIMETYPE, ARTWORK_ID)
+
+        await self.playing(title='dummy')
+        self.assertEqual(self.atv.metadata.artwork_id, ARTWORK_ID)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,86 @@
+"""Unit tests for cache."""
+
+import unittest
+
+from pyatv.cache import Cache
+
+ID1 = 'id1'
+ID2 = 'id2'
+ID3 = 'id3'
+DATA1 = 123
+DATA2 = 456
+DATA3 = 789
+
+
+class CacheTest(unittest.TestCase):
+
+    def setUp(self):
+        self.cache = Cache(limit=2)
+
+    def test_cache_is_empty(self):
+        self.assertTrue(self.cache.empty())
+
+    def test_put_get_item(self):
+        self.cache.put(ID1, DATA1)
+        self.assertEqual(self.cache.get(ID1), DATA1)
+
+    def test_put_get_multiple(self):
+        self.cache.put(ID1, DATA1)
+        self.cache.put(ID2, DATA2)
+
+        self.assertEqual(self.cache.get(ID1), DATA1)
+        self.assertEqual(self.cache.get(ID2), DATA2)
+
+    def test_cache_not_empty(self):
+        self.cache.put(ID1, DATA1)
+        self.assertFalse(self.cache.empty())
+
+    def test_cache_has_item(self):
+        self.cache.put(ID1, DATA1)
+
+        self.assertTrue(ID1 in self.cache)
+        self.assertFalse(ID2 in self.cache)
+
+    def test_cache_size(self):
+        self.assertEqual(len(self.cache), 0)
+        self.cache.put(ID1, DATA1)
+        self.assertEqual(len(self.cache), 1)
+
+    def test_put_same_identifier_replaces_data(self):
+        self.cache.put(ID1, DATA1)
+        self.cache.put(ID1, DATA2)
+        self.assertEqual(self.cache.get(ID1), DATA2)
+        self.assertEqual(len(self.cache), 1)
+
+    def test_put_removes_oldest(self):
+        self.cache.put(ID1, DATA1)
+        self.cache.put(ID2, DATA2)
+        self.cache.put(ID3, DATA3)
+
+        self.assertEqual(len(self.cache), 2)
+        self.assertNotIn(ID1, self.cache)
+        self.assertIn(ID2, self.cache)
+        self.assertIn(ID3, self.cache)
+
+    def test_get_makes_data_newer(self):
+        self.cache.put(ID1, DATA1)
+        self.cache.put(ID2, DATA2)
+        self.cache.get(ID1)
+        self.cache.put(ID3, DATA3)
+
+        self.assertEqual(len(self.cache), 2)
+        self.assertIn(ID1, self.cache)
+        self.assertNotIn(ID2, self.cache)
+        self.assertIn(ID3, self.cache)
+
+    def test_get_latest_identifier(self):
+        self.assertEqual(self.cache.latest(), None)
+
+        self.cache.put(ID1, DATA1)
+        self.assertEqual(self.cache.latest(), ID1)
+
+        self.cache.put(ID2, DATA2)
+        self.assertEqual(self.cache.latest(), ID2)
+
+        self.cache.get(ID1)
+        self.assertEqual(self.cache.latest(), ID1)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -110,6 +110,10 @@ class MetadataDummy(interface.Metadata):
         """Return artwork for what is currently playing (or None)."""
         raise exceptions.NotSupportedError
 
+    def artwork_id(self):
+        """Return a unique identifier for current artwork."""
+        raise exceptions.NotSupportedError
+
     def playing(self):
         """Return what is currently playing."""
         raise exceptions.NotSupportedError
@@ -198,5 +202,7 @@ class InterfaceTest(unittest.TestCase):
 
         with self.assertRaises(exceptions.NotSupportedError):
             metadata.artwork()
+        with self.assertRaises(exceptions.NotSupportedError):
+            metadata.artwork_id()
         with self.assertRaises(exceptions.NotSupportedError):
             metadata.playing()


### PR DESCRIPTION
This commit adds the following:

* A new method in Metadata called artwork_id, which is a unique
  identifier for artwork. In case of MRP, such an identifier already
  exists so that identifier is returned. In case of DMAP, this is the
  same value as Playing.hash (not ideal but best for now).
* Simple LRU cache in cache.py
* Cache is used together with artwork_id to cache the latest four
  artworks that have been fetched.