### PR TITLE
Fix bug i TXT handling in UDNS

### DIFF
--- a/pyatv/udns.py
+++ b/pyatv/udns.py
@@ -55,7 +55,7 @@ def parse_txt_dict(data, msg):
     output = {}
     txt, _ = qname_decode(data, msg, raw=True)
     for prop in txt:
-        key, value = prop.split(b'=')
+        key, value = prop.split(b'=', 1)
         output[key] = value
     return output
 

--- a/tests/test_udns.py
+++ b/tests/test_udns.py
@@ -15,7 +15,7 @@ TEST_SERVICES = {
     port=1234,
     properties={
       'Name': 'Kitchen',
-      'foo': 'bar',
+      'foo': '=bar',
     }),
 }
 


### PR DESCRIPTION
If a property contained a =, there would be an error.

Fixes #405.