### PR TITLE
Add timestamp to debug log in atvremote

### DIFF
--- a/pyatv/__main__.py
+++ b/pyatv/__main__.py
@@ -370,7 +370,8 @@ async def cli_handler(loop):
         loglevel = logging.DEBUG
 
     logging.basicConfig(level=loglevel,
-                        format='%(levelname)s: %(message)s')
+                        datefmt='%Y-%m-%d %H:%M:%S',
+                        format='%(asctime)s %(levelname)s: %(message)s')
     logging.getLogger('requests').setLevel(logging.WARNING)
 
     cmds = retrieve_commands(GlobalCommands)


### PR DESCRIPTION
It's really hard to know how much time things take without any concept
of absolute time in the logs. From now on timestamps will be added if
--debug is used.