### PR TITLE
Use content id as hash in MRP

### DIFF
--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -267,6 +267,11 @@ class MrpPlaying(Playing):
 
         return RepeatState.All
 
+    @property
+    def hash(self):
+        """Create a unique hash for what is currently playing."""
+        return self._state.item_identifier or super().hash
+
 
 class MrpMetadata(Metadata):
     """Implementation of API for retrieving metadata."""
@@ -309,10 +314,7 @@ class MrpMetadata(Metadata):
     @property
     def artwork_id(self):
         """Return a unique identifier for current artwork."""
-        metadata = self.psm.playing.metadata
-        if metadata and metadata.artworkAvailable:
-            return metadata.artworkIdentifier
-        return None
+        return self.psm.playing.metadata_field('artworkIdentifier')
 
     async def playing(self):
         """Return what is currently playing."""

--- a/pyatv/mrp/player_state.py
+++ b/pyatv/mrp/player_state.py
@@ -42,6 +42,13 @@ class PlayerState:
             return self.items[self.location].metadata
         return None
 
+    @property
+    def item_identifier(self):
+        """Return identifier of current item in queue."""
+        if len(self.items) >= (self.location + 1):
+            return self.items[self.location].identifier
+        return None
+
     def metadata_field(self, field):
         """Return a specific metadata field or None if missing."""
         metadata = self.metadata

--- a/tests/mrp/fake_mrp_atv.py
+++ b/tests/mrp/fake_mrp_atv.py
@@ -200,14 +200,15 @@ class FakeAppleTV(FakeAirPlayDevice, MrpServerAuth, asyncio.Protocol):
         return self.states[identifier]
 
     def set_active_player(self, identifier):
-        if identifier not in self.states:
+        if identifier is not None and identifier not in self.states:
             raise Exception('invalid player: %s', identifier)
 
         self.active_player = identifier
         now_playing = messages.create(
             protobuf.SET_NOW_PLAYING_CLIENT_MESSAGE)
         client = now_playing.inner().client
-        client.bundleIdentifier = identifier
+        if identifier:
+            client.bundleIdentifier = identifier
         self.send(now_playing)
 
     def item_update(self, metadata, identifier):
@@ -352,7 +353,7 @@ class AppleTVUseCases(AirPlayUseCases):
 
     def nothing_playing(self):
         """Call this method to put device in idle state."""
-        pass
+        self.device.set_active_player(None)
 
     def example_video(self, **kwargs):
         """Play some example video."""


### PR DESCRIPTION
This identifier is certain to be unique as it is generated by the
device. But fallback in case it is not available.

Fixes #327.