### PR TITLE
if: Deprecate suspend and wakeup

### DIFF
--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -14,6 +14,8 @@ from pyatv.dmap.daap import DaapRequester
 from pyatv.net import HttpSession
 from pyatv.interface import (AppleTV, RemoteControl, Metadata,
                              Playing, PushUpdater, ArtworkInfo, Power)
+from pyatv.support import deprecated
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -191,11 +193,13 @@ class DmapRemoteControl(RemoteControl):
         # DMAP support unknown
         raise exceptions.NotSupportedError()
 
+    @deprecated
     def suspend(self):
         """Suspend the device."""
         # Not supported by DMAP
         raise exceptions.NotSupportedError()
 
+    @deprecated
     def wakeup(self):
         """Wake up the device."""
         raise exceptions.NotSupportedError()

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -18,6 +18,7 @@ from pyatv.mrp.protobuf.SetStateMessage_pb2 import SetStateMessage as ssm
 from pyatv.mrp.player_state import PlayerStateManager
 from pyatv.interface import (AppleTV, RemoteControl, Metadata,
                              Playing, PushUpdater, ArtworkInfo, Power)
+from pyatv.support import deprecated
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -147,10 +148,12 @@ class MrpRemoteControl(RemoteControl):
         """Go to main menu (long press menu)."""
         await self._press_key('topmenu')
 
+    @deprecated
     async def suspend(self):
         """Suspend the device."""
         await self._press_key('suspend')
 
+    @deprecated
     async def wakeup(self):
         """Wake up the device."""
         await self._press_key('wakeup')

--- a/pyatv/support.py
+++ b/pyatv/support.py
@@ -3,6 +3,8 @@
 import asyncio
 import logging
 import binascii
+import warnings
+import functools
 from os import environ
 
 from google.protobuf.text_format import MessageToString
@@ -58,3 +60,18 @@ def log_protobuf(logger, text, message):
         msg_str = '\n'.join([_shorten(x, line_length) for x in lines])
 
         logger.debug('%s: %s', text, msg_str)
+
+
+# https://stackoverflow.com/questions/2536307/
+#   decorators-in-the-python-standard-lib-deprecated-specifically
+def deprecated(func):
+    """Decorate functions that are deprecated."""
+    @functools.wraps(func)
+    def new_func(*args, **kwargs):
+        warnings.simplefilter('always', DeprecationWarning)  # turn off filter
+        warnings.warn("Call to deprecated function {}.".format(func.__name__),
+                      category=DeprecationWarning,
+                      stacklevel=2)
+        warnings.simplefilter('default', DeprecationWarning)  # reset filter
+        return func(*args, **kwargs)
+    return new_func


### PR DESCRIPTION
These functions does not work as intended and are replaced by the power
interface.

Fixes #478.