### PR TITLE
Remove need for unnecessary crypto libraries

### DIFF
--- a/docs/documentation/documentation.md
+++ b/docs/documentation/documentation.md
@@ -37,7 +37,6 @@ To get the work done, `pyatv` requires some other pieces of software, more speci
 - aiohttp >= 3.0.1, <4
 - aiozeroconf >= 0.1.8
 - cryptography >= 1.8.1
-- ed25519 >= 1.4
 - netifaces >= 0.10.0
 - protobuf >= 3.4.0
 - srptools >= 0.2.0

--- a/docs/documentation/documentation.md
+++ b/docs/documentation/documentation.md
@@ -42,7 +42,6 @@ To get the work done, `pyatv` requires some other pieces of software, more speci
 - netifaces >= 0.10.0
 - protobuf >= 3.4.0
 - srptools >= 0.2.0
-- tlslite-ng >= 0.7.0
 
 ### Roadmap
 

--- a/docs/documentation/documentation.md
+++ b/docs/documentation/documentation.md
@@ -37,7 +37,6 @@ To get the work done, `pyatv` requires some other pieces of software, more speci
 - aiohttp >= 3.0.1, <4
 - aiozeroconf >= 0.1.8
 - cryptography >= 1.8.1
-- curve25519-donna >= 1.3
 - ed25519 >= 1.4
 - netifaces >= 0.10.0
 - protobuf >= 3.4.0

--- a/pyatv/mrp/chacha20.py
+++ b/pyatv/mrp/chacha20.py
@@ -1,5 +1,5 @@
 """Transparent encryption layer using Chacha20_Pooly1305."""
-from tlslite.utils.chacha20_poly1305 import CHACHA20_POLY1305
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
 from pyatv import exceptions
 
@@ -9,8 +9,8 @@ class Chacha20Cipher:
 
     def __init__(self, out_key, in_key):
         """Initialize a new Chacha20Cipher."""
-        self._enc_out = CHACHA20_POLY1305(out_key, "python")
-        self._enc_in = CHACHA20_POLY1305(in_key, "python")
+        self._enc_out = ChaCha20Poly1305(out_key)
+        self._enc_in = ChaCha20Poly1305(in_key)
         self._out_counter = 0
         self._in_counter = 0
 
@@ -20,7 +20,7 @@ class Chacha20Cipher:
             nounce = self._out_counter.to_bytes(length=8, byteorder="little")
             self._out_counter += 1
 
-        return self._enc_out.seal(b"\x00\x00\x00\x00" + nounce, data, bytes())
+        return self._enc_out.encrypt(b"\x00\x00\x00\x00" + nounce, data, None)
 
     def decrypt(self, data, nounce=None):
         """Decrypt data with counter or specified nounce."""
@@ -28,7 +28,7 @@ class Chacha20Cipher:
             nounce = self._in_counter.to_bytes(length=8, byteorder="little")
             self._in_counter += 1
 
-        decrypted = self._enc_in.open(b"\x00\x00\x00\x00" + nounce, data, bytes())
+        decrypted = self._enc_in.decrypt(b"\x00\x00\x00\x00" + nounce, data, None)
 
         if not decrypted:
             raise exceptions.AuthenticationError("data decrypt failed")

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'netifaces>=0.10.0',
         'protobuf>=3.8.0',
         'srptools>=0.2.0',
-        'tlslite-ng>=0.7.0',
     ],
     test_suite='tests',
     keywords=['apple', 'tv'],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'aiohttp>=3.0.1, <4',
         'aiozeroconf>=0.1.8',
         'cryptography>=1.8.1',
-        'curve25519-donna>=1.3',
         'ed25519>=1.4',
         'netifaces>=0.10.0',
         'protobuf>=3.8.0',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'aiohttp>=3.0.1, <4',
         'aiozeroconf>=0.1.8',
         'cryptography>=1.8.1',
-        'ed25519>=1.4',
         'netifaces>=0.10.0',
         'protobuf>=3.8.0',
         'srptools>=0.2.0',


### PR DESCRIPTION
I've managed to remove the need for `curve25519-donna`, `ed25519` and `tlslite-ng` by using crypto routines in `cryptograhy` instead. So from now on, `pyatv` has **three** less dependencies! 