### PR TITLE
test: Migrate from asynctest to pytest-asyncio

### DIFF
--- a/docs/api/pyatv/helpers.html
+++ b/docs/api/pyatv/helpers.html
@@ -18,15 +18,16 @@ link_group: api
 <pre><code class="python">&#34;&#34;&#34;Various helper methods.&#34;&#34;&#34;
 
 import asyncio
-from typing import Callable
+from typing import Callable, Optional
 
 import pyatv
 
 
-def auto_connect(
+async def auto_connect(
     handler: Callable[[pyatv.interface.AppleTV], None],
     timeout: int = 5,
     not_found: Callable[[], None] = None,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -&gt; None:
     &#34;&#34;&#34;Connect to first discovered device.
 
@@ -37,24 +38,24 @@ def auto_connect(
 
     Note: both handler and not_found must be coroutines
     &#34;&#34;&#34;
-    # A coroutine is used so we can connect to the device while being inside
-    # the event loop
+    # Scan and do connect in the event loop
     async def _handle(loop):
         atvs = await pyatv.scan(loop, timeout=timeout)
 
         # Take the first device found
         if atvs:
             atv = await pyatv.connect(atvs[0], loop)
+
             try:
                 await handler(atv)
             finally:
-                await atv.logout()
+                await atv.close()
         else:
             if not_found is not None:
                 await not_found()
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(_handle(loop))</code></pre>
+    loop = loop or asyncio.get_event_loop()
+    await _handle(loop)</code></pre>
 </details>
 </section>
 <section>
@@ -65,7 +66,7 @@ def auto_connect(
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
 <dt id="pyatv.helpers.auto_connect"><code class="name flex">
-<span>def <span class="ident">auto_connect</span></span>(<span>handler, timeout=5, not_found=None)</span>
+<span>async def <span class="ident">auto_connect</span></span>(<span>handler, timeout=5, not_found=None, loop=None)</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Connect to first discovered device.</p>
@@ -78,10 +79,11 @@ Very inflexible in many cases, but can be handys sometimes when trying things.</
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def auto_connect(
+<pre><code class="python">async def auto_connect(
     handler: Callable[[pyatv.interface.AppleTV], None],
     timeout: int = 5,
     not_found: Callable[[], None] = None,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -&gt; None:
     &#34;&#34;&#34;Connect to first discovered device.
 
@@ -92,24 +94,24 @@ Very inflexible in many cases, but can be handys sometimes when trying things.</
 
     Note: both handler and not_found must be coroutines
     &#34;&#34;&#34;
-    # A coroutine is used so we can connect to the device while being inside
-    # the event loop
+    # Scan and do connect in the event loop
     async def _handle(loop):
         atvs = await pyatv.scan(loop, timeout=timeout)
 
         # Take the first device found
         if atvs:
             atv = await pyatv.connect(atvs[0], loop)
+
             try:
                 await handler(atv)
             finally:
-                await atv.logout()
+                await atv.close()
         else:
             if not_found is not None:
                 await not_found()
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(_handle(loop))</code></pre>
+    loop = loop or asyncio.get_event_loop()
+    await _handle(loop)</code></pre>
 </details>
 </dd>
 </dl>

--- a/examples/auto_connect.py
+++ b/examples/auto_connect.py
@@ -1,5 +1,6 @@
 """Simple example that connects to a device with autodiscover."""
 
+import asyncio
 from pyatv import helpers
 
 
@@ -11,5 +12,4 @@ async def print_what_is_playing(atv):
     print(playing)
 
 
-# logout is automatically performed by auto_connect
-helpers.auto_connect(print_what_is_playing)
+asyncio.get_event_loop().run_until_complete(helpers.auto_connect(print_what_is_playing))

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,8 @@
-asynctest==0.13.0
 black==19.10b0
 flake8==3.7.9
 codecov==2.0.16
 pytest==5.3.5
+pytest-asyncio==0.10.0
 pytest-cov==2.8.1
 pytest-timeout==1.3.4
 pytest-aiohttp==0.3.0

--- a/tests/airplay/test_airplay_pair.py
+++ b/tests/airplay/test_airplay_pair.py
@@ -1,7 +1,7 @@
 """Functional pairing tests using the API with a fake AirPlay Apple TV."""
 
 import binascii
-from asynctest.mock import patch
+from unittest.mock import patch
 
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 
@@ -70,8 +70,8 @@ class PairFunctionalTest(AioHTTPTestCase):
         with self.assertRaises(exceptions.PairingError):
             await self.do_pairing(None)
 
-    @unittest_run_loop
     @patch("os.urandom")
+    @unittest_run_loop
     async def test_pairing_with_device_new_credentials(self, rand_func):
         rand_func.side_effect = predetermined_key
         await self.do_pairing()

--- a/tests/fake_udns.py
+++ b/tests/fake_udns.py
@@ -69,16 +69,19 @@ class FakeUdns(asyncio.Protocol):
 
     async def start(self):
         _LOGGER.debug("Starting fake UDNS server")
-        self.server = await self.loop.create_datagram_endpoint(
+        self.server, _ = await self.loop.create_datagram_endpoint(
             lambda: self, local_addr=("127.0.0.1", None)
         )
+
+    def close(self):
+        self.server.close()
 
     def add_service(self, service):
         self.services[service[0]] = service[1]
 
     @property
     def port(self):
-        return self.server[0].get_extra_info("socket").getsockname()[1]
+        return self.server.get_extra_info("socket").getsockname()[1]
 
     def connection_made(self, transport):
         self.transport = transport

--- a/tests/support/test_udns.py
+++ b/tests/support/test_udns.py
@@ -1,7 +1,6 @@
 """Functional tests for unicast DNS."""
 
-import unittest
-import asynctest
+import pytest
 
 from pyatv.support import udns
 from tests import fake_udns
@@ -16,6 +15,23 @@ TEST_SERVICES = {
 }
 
 
+@pytest.fixture
+async def udns_server(event_loop):
+    server = fake_udns.FakeUdns(event_loop, TEST_SERVICES)
+    await server.start()
+    yield server
+    server.close()
+
+
+async def request(event_loop, udns_server, service_name):
+    return (
+        await udns.request(
+            event_loop, "127.0.0.1", [service_name], port=udns_server.port, timeout=1
+        ),
+        TEST_SERVICES.get(service_name),
+    )
+
+
 def get_qtype(messages, qtype):
     for message in messages:
         if message.qtype == qtype:
@@ -23,87 +39,81 @@ def get_qtype(messages, qtype):
     return None
 
 
-class UdnsTest(unittest.TestCase):
-
-    # This is a bastard test for the sake of testing labels (so I don't have to
-    # implement it in the fake UDNS server).
-    def test_qname_with_label(self):
-        # This should resolve to "label.test" when reading from \x05
-        message = b"aaaa" + b"\x04test\x00" + b"\x05label\xC0\x04\xAB\xCD"
-        ptr = message[10:]
-        ret, rest = udns.qname_decode(ptr, message)
-        self.assertEqual(ret, "label.test")
-        self.assertEqual(rest, b"\xAB\xCD")
+def test_qname_with_label():
+    # This should resolve to "label.test" when reading from \x05
+    message = b"aaaa" + b"\x04test\x00" + b"\x05label\xC0\x04\xAB\xCD"
+    ptr = message[10:]
+    ret, rest = udns.qname_decode(ptr, message)
+    assert ret == "label.test"
+    assert rest == b"\xAB\xCD"
 
 
-class UdnsFunctionalTest(asynctest.TestCase):
-    async def setUp(self):
-        self.server = fake_udns.FakeUdns(self.loop, TEST_SERVICES)
-        await self.server.start()
+@pytest.mark.asyncio
+async def test_non_existing_service(event_loop, udns_server):
+    resp, _ = await request(event_loop, udns_server, "_missing")
+    assert len(resp.questions) == 1
+    assert len(resp.answers) == 0
+    assert len(resp.resources) == 0
 
-    async def request(self, service_name):
-        return (
-            await udns.request(
-                self.loop, "127.0.0.1", [service_name], port=self.server.port, timeout=1
-            ),
-            TEST_SERVICES.get(service_name),
-        )
 
-    async def test_non_existing_service(self):
-        resp, _ = await self.request("_missing")
-        self.assertEqual(len(resp.questions), 1)
-        self.assertEqual(len(resp.answers), 0)
-        self.assertEqual(len(resp.resources), 0)
+@pytest.mark.asyncio
+async def test_service_has_expected_responses(event_loop, udns_server):
+    resp, _ = await request(event_loop, udns_server, MEDIAREMOTE_SERVICE)
+    assert len(resp.questions) == 1
+    assert len(resp.answers) == 1
+    assert len(resp.resources) == 2
 
-    async def test_service_has_expected_responses(self):
-        resp, _ = await self.request(MEDIAREMOTE_SERVICE)
-        self.assertEqual(len(resp.questions), 1)
-        self.assertEqual(len(resp.answers), 1)
-        self.assertEqual(len(resp.resources), 2)
 
-    async def test_service_has_valid_question(self):
-        resp, _ = await self.request(MEDIAREMOTE_SERVICE)
+@pytest.mark.asyncio
+async def test_service_has_valid_question(event_loop, udns_server):
+    resp, _ = await request(event_loop, udns_server, MEDIAREMOTE_SERVICE)
 
-        question = resp.questions[0]
-        self.assertEqual(question.qname, MEDIAREMOTE_SERVICE)
-        self.assertEqual(question.qtype, udns.QTYPE_ANY)
-        self.assertEqual(question.qclass, 0x8001)
+    question = resp.questions[0]
+    assert question.qname == MEDIAREMOTE_SERVICE
+    assert question.qtype == udns.QTYPE_ANY
+    assert question.qclass == 0x8001
 
-    async def test_service_has_valid_answer(self):
-        resp, data = await self.request(MEDIAREMOTE_SERVICE)
 
-        answer = resp.answers[0]
-        self.assertEqual(answer.qname, MEDIAREMOTE_SERVICE)
-        self.assertEqual(answer.qtype, udns.QTYPE_PTR)
-        self.assertEqual(answer.qclass, fake_udns.DEFAULT_QCLASS)
-        self.assertEqual(answer.ttl, fake_udns.DEFAULT_TTL)
-        self.assertEqual(answer.rd, data.name + "." + MEDIAREMOTE_SERVICE)
+@pytest.mark.asyncio
+async def test_service_has_valid_answer(event_loop, udns_server):
+    resp, data = await request(event_loop, udns_server, MEDIAREMOTE_SERVICE)
 
-    async def test_service_has_valid_srv_resource(self):
-        resp, data = await self.request(MEDIAREMOTE_SERVICE)
+    answer = resp.answers[0]
+    assert answer.qname == MEDIAREMOTE_SERVICE
+    assert answer.qtype == udns.QTYPE_PTR
+    assert answer.qclass == fake_udns.DEFAULT_QCLASS
+    assert answer.ttl == fake_udns.DEFAULT_TTL
+    assert answer.rd == data.name + "." + MEDIAREMOTE_SERVICE
 
-        srv = get_qtype(resp.resources, udns.QTYPE_SRV)
-        self.assertEqual(srv.qname, data.name + "." + MEDIAREMOTE_SERVICE)
-        self.assertEqual(srv.qtype, udns.QTYPE_SRV)
-        self.assertEqual(srv.qclass, fake_udns.DEFAULT_QCLASS)
-        self.assertEqual(srv.ttl, fake_udns.DEFAULT_TTL)
 
-        rd = srv.rd
-        self.assertEqual(rd["priority"], 0)
-        self.assertEqual(rd["weight"], 0)
-        self.assertEqual(rd["port"], data.port)
-        self.assertEqual(rd["target"], data.name + ".local")
+@pytest.mark.asyncio
+async def test_service_has_valid_srv_resource(event_loop, udns_server):
+    resp, data = await request(event_loop, udns_server, MEDIAREMOTE_SERVICE)
 
-    async def test_service_has_valid_txt_resource(self):
-        resp, data = await self.request(MEDIAREMOTE_SERVICE)
+    srv = get_qtype(resp.resources, udns.QTYPE_SRV)
+    assert srv.qname == data.name + "." + MEDIAREMOTE_SERVICE
+    assert srv.qtype == udns.QTYPE_SRV
+    assert srv.qclass == fake_udns.DEFAULT_QCLASS
+    assert srv.ttl == fake_udns.DEFAULT_TTL
 
-        srv = get_qtype(resp.resources, udns.QTYPE_TXT)
-        self.assertEqual(srv.qname, data.name + "." + MEDIAREMOTE_SERVICE)
-        self.assertEqual(srv.qtype, udns.QTYPE_TXT)
-        self.assertEqual(srv.qclass, fake_udns.DEFAULT_QCLASS)
-        self.assertEqual(srv.ttl, fake_udns.DEFAULT_TTL)
+    rd = srv.rd
+    assert rd["priority"] == 0
+    assert rd["weight"] == 0
+    assert rd["port"] == data.port
+    assert rd["target"] == data.name + ".local"
 
-        rd = srv.rd
-        self.assertEqual(len(rd), len(data.properties))
-        for k, v in data.properties.items():
-            self.assertEqual(rd[k.encode("ascii")], v.encode("ascii"))
+
+@pytest.mark.asyncio
+async def test_service_has_valid_txt_resource(event_loop, udns_server):
+    resp, data = await request(event_loop, udns_server, MEDIAREMOTE_SERVICE)
+
+    srv = get_qtype(resp.resources, udns.QTYPE_TXT)
+    assert srv.qname == data.name + "." + MEDIAREMOTE_SERVICE
+    assert srv.qtype == udns.QTYPE_TXT
+    assert srv.qclass == fake_udns.DEFAULT_QCLASS
+    assert srv.ttl == fake_udns.DEFAULT_TTL
+
+    rd = srv.rd
+    assert len(rd) == len(data.properties)
+    for k, v in data.properties.items():
+        assert rd[k.encode("ascii")] == v.encode("ascii")


### PR DESCRIPTION
Upgrading pytest resulted in all tests using asynctest to break. So I
took the opportunity to rewrite these using pytest instead. So now
asynctest is not needed anymore.