### PR TITLE
protobuf: Workaround for older versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'aiozeroconf>=0.1.8',
         'cryptography>=1.8.1',
         'netifaces>=0.10.0',
-        'protobuf>=3.8.0',
+        'protobuf>=3.6.0',
         'srptools>=0.2.0',
     ],
     test_suite='tests',


### PR DESCRIPTION
The only reason a newer version of protobuf is needed is because of
print_unknown_fields when logging. Check if this flag is supported and
use it if it is, otherwise ignore it so older versions of protobuf can
be used.