### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,81 @@
 # CHANGES
 
+## 0.5.0 (2020-03-19)
+
+*Changes:*
+
+* Add power interface
+* Add device information interface
+* Add playing app interface
+* New scripts: atvscript and atvproxy
+* External interface now has type hints
+* Pure AirPlay devices are no longer returned by scan
+* Files have been moved around and the public interface
+  is now well-defined
+* Documentation has moved to pyatv.dev
+
+*Breaking Changes:*
+
+* suspend and wakeup in the remote control interface are now
+  deprecated. They did not work very well. Use the power interface
+  instead.
+* Black is now used for linting and black does not support
+  python 3.5, so support for python 3.5 has been dropped.
+* helpers.auto_connect is now a coroutine
+
+*Notes:*
+
+* Lots of updates to documentation and tests have been made
+* An API reference is now available at pyatv.dev
+
+*All changes:*
+
+```
+0cf6689 mrp: Support volume control features
+11b59f1 protobuf: Workaround for older versions
+9398768 docs: Minor fixes
+947bb04 tests: Make push updates test more robust
+40a45ea tests: Add initial tests for atvscript
+e3af8fc tests: Break out script test environment
+fae8525 tests: Fix broken sleep stub
+865483a scan: Wait for pending tasks
+365ae6d scripts: Add atvscript
+10af6e9 scripts: Add atvproxy
+b96098e scripts: Move atvremote
+0f8e5cd build(deps): bump codecov from 2.0.16 to 2.0.21
+a2143d5 build(deps): bump pytest from 5.3.5 to 5.4.1
+f45f879 test: Migrate from asynctest to pytest-asyncio
+b3fa547 docs: Add links to API reference
+f41cc11 docs: Add documentation for app support
+b91f5d5 mrp: Add app support
+0dbe373 if: Add interface for app
+bdc01f3 docs: Fix relative links
+5661c36 docs: Fix baseurl
+e3bcb7a docs: Change domain to pyatv.dev
+e8e364c Create CNAME
+3917092 build(deps): bump mypy from 0.761 to 0.770
+766b438 docs: Clean up and improve documentation
+3c99ae6 features: Add tests for features
+364ac39 atvremote: Add support for features
+6a97526 docs: Add documentation for features
+a63ed69 mrp: Add basic support for features
+1cee19c dmap: Add basic support for features
+a025cdd if: Add interface for supported features
+dbc75fa protobuf: Update messages
+86cecad docs: Add API documentation
+1912891 mrp: Subscribe to volume updates
+778257f cq: Add typing hints to public interface
+6bf74e7 cq: Handle invalid credentials
+5a6c8de cq: Remove need for ed25519
+b2b8e58 cq: Remove need for curve25519-donna
+18d3894 cq: Remove need for tlslite-ng
+cf3048d if: Add support for play_pause
+181adc9 cq: Move internal modules to support directory
+eaf5176 cq: Move from pylint to black for linting
+5e056f1 if: Deprecate suspend and wakeup
+08b0b37 scan: Do not include pure AirPlay devices
+```
+
 ## 0.4.1a1 (2020-03-02)
 
 *Changes:*

--- a/docs/api/pyatv/const.html
+++ b/docs/api/pyatv/const.html
@@ -157,8 +157,8 @@ from enum import Enum
 
 
 MAJOR_VERSION = &#34;0&#34;
-MINOR_VERSION = &#34;4&#34;
-PATCH_VERSION = &#34;1a1&#34;
+MINOR_VERSION = &#34;5&#34;
+PATCH_VERSION = &#34;0&#34;
 __short_version__ = &#34;{}.{}&#34;.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = &#34;{}.{}&#34;.format(__short_version__, PATCH_VERSION)
 

--- a/docs/support/migration.md
+++ b/docs/support/migration.md
@@ -12,6 +12,22 @@ and might be incomplete or missing some details. If you find something
 to be unclear, please help out by writing an issue or creating a pull
 request.
 
+## From 0.4.0 to 0.5.0
+
+### General Changes
+
+* None
+
+### Deprecations
+
+* Python 3.6 or later is now required
+* `suspend` and `wakeup` in {% include api i="interface.RemoteControl" %}
+  have been deprecated. Use {% include api i="interface.Power.turn_on" %}
+  and {% include api i="interface.Power.turn_off" %} instead.
+* {% include api i="helpers.auto_connect" %} is now a coroutine. The
+  [example](https://github.com/postlund/pyatv/blob/master/examples/auto_connect.py)
+  has been updated.
+
 ## From 0.3.x to 0.4.0
 
 ### General Changes

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -4,8 +4,8 @@ from enum import Enum
 
 
 MAJOR_VERSION = "0"
-MINOR_VERSION = "4"
-PATCH_VERSION = "1a1"
+MINOR_VERSION = "5"
+PATCH_VERSION = "0"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 


### PR DESCRIPTION
Next big release is up packed with updates:

**Changes**

* Add power interface
* Add device information interface
* Add playing app interface
* New scripts: atvscript and atvproxy
* External interface now has type hints
* Pure AirPlay devices are no longer returned by scan
* Files have been moved around and the public interface
  is now well-defined
* Documentation has moved to pyatv.dev

**Breaking Changes**

* suspend and wakeup in the remote control interface are now
  deprecated. They did not work very well. Use the power interface
  instead.
* Black is now used for linting and black does not support
  python 3.5, so support for python 3.5 has been dropped.
* helpers.auto_connect is now a coroutine

**Notes**

* Lots of updates to documentation and tests have been made
* An API reference is now available at pyatv.dev

**All changes**

0cf6689 mrp: Support volume control features
11b59f1 protobuf: Workaround for older versions
9398768 docs: Minor fixes
947bb04 tests: Make push updates test more robust
40a45ea tests: Add initial tests for atvscript
e3af8fc tests: Break out script test environment
fae8525 tests: Fix broken sleep stub
865483a scan: Wait for pending tasks
365ae6d scripts: Add atvscript
10af6e9 scripts: Add atvproxy
b96098e scripts: Move atvremote
0f8e5cd build(deps): bump codecov from 2.0.16 to 2.0.21
a2143d5 build(deps): bump pytest from 5.3.5 to 5.4.1
f45f879 test: Migrate from asynctest to pytest-asyncio
b3fa547 docs: Add links to API reference
f41cc11 docs: Add documentation for app support
b91f5d5 mrp: Add app support
0dbe373 if: Add interface for app
bdc01f3 docs: Fix relative links
5661c36 docs: Fix baseurl
e3bcb7a docs: Change domain to pyatv.dev
e8e364c Create CNAME
3917092 build(deps): bump mypy from 0.761 to 0.770
766b438 docs: Clean up and improve documentation
3c99ae6 features: Add tests for features
364ac39 atvremote: Add support for features
6a97526 docs: Add documentation for features
a63ed69 mrp: Add basic support for features
1cee19c dmap: Add basic support for features
a025cdd if: Add interface for supported features
dbc75fa protobuf: Update messages
86cecad docs: Add API documentation
1912891 mrp: Subscribe to volume updates
778257f cq: Add typing hints to public interface
6bf74e7 cq: Handle invalid credentials
5a6c8de cq: Remove need for ed25519
b2b8e58 cq: Remove need for curve25519-donna
18d3894 cq: Remove need for tlslite-ng
cf3048d if: Add support for play_pause
181adc9 cq: Move internal modules to support directory
eaf5176 cq: Move from pylint to black for linting
5e056f1 if: Deprecate suspend and wakeup
08b0b37 scan: Do not include pure AirPlay devices
e4f6590 devinfo: Minor clean ups
d645d5a devinfo: Add device_info to atvremote
33622b8 devinfo: Get version from osvers
e3ad40b devinfo: Add documentation
df8f6a1 devinfo: Clean up zeroconf properties
908d2ea devinfo: Add support for device info
8da7fd2 devinfo: Add helpers for extracting device info
cb8d73a if: Add interface for device information
d8624fd MRP Power State support (#458)
1f97630 if: Tidy up convert module and make it public
ce926b0 protobuf: Move pyatv imports in protobuf.py
554d965 gha: Trigger on both push and pull_request
a8ab245 gh: Run actions on pull requests
024284b mrp: Add some protobuf definitions for voice
ac3ae13 mrp: Wait for command responses
c765dbe mrp: Download protoc and verify generated code
070946f Bump codecov from 2.0.15 to 2.0.16