### PR TITLE
Add start of fake device script

### DIFF
--- a/scripts/fake_device.py
+++ b/scripts/fake_device.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Set up a fake device.
+
+Currently only supports MRP.
+"""
+import sys
+import os
+import socket
+import asyncio
+import logging
+import argparse
+
+from aiozeroconf import Zeroconf, ServiceInfo
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)) + "/..")  # noqa
+
+from tests.mrp.fake_mrp_atv import FakeAppleTV
+
+_LOGGER = logging.getLogger(__name__)
+
+DEVICE_NAME = "FakeMRP"
+AIRPLAY_IDENTIFIER = "4D797FD3-3538-427E-A47B-A32FC6CF3A6A"
+
+SERVER_IDENTIFIER = "6D797FD3-3538-427E-A47B-A32FC6CF3A69"
+
+
+async def publish_zeroconf(zconf, ip_address, port):
+    """Publish zeroconf service for ATV proxy instance."""
+    props = {
+        b"ModelName": "Apple TV",
+        b"AllowPairing": b"YES",
+        b"macAddress": b"40:cb:c0:12:34:56",
+        b"BluetoothAddress": False,
+        b"Name": DEVICE_NAME.encode(),
+        b"UniqueIdentifier": SERVER_IDENTIFIER.encode(),
+        b"SystemBuildVersion": b"17K499",
+        b"LocalAirPlayReceiverPairingIdentity": AIRPLAY_IDENTIFIER.encode(),
+    }
+
+    service = ServiceInfo(
+        "_mediaremotetv._tcp.local.",
+        DEVICE_NAME + "._mediaremotetv._tcp.local.",
+        address=socket.inet_aton(ip_address),
+        port=port,
+        weight=0,
+        priority=0,
+        properties=props,
+    )
+    await zconf.register_service(service)
+    _LOGGER.debug("Published zeroconf service: %s", service)
+
+    return service
+
+
+async def appstart(loop):
+    """Script starts here."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local-ip", default="127.0.0.1", help="local IP address")
+    parser.add_argument(
+        "-d", "--debug", default=False, action="store_true", help="enable debug logs"
+    )
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.debug else logging.WARNING
+    logging.basicConfig(level=level, stream=sys.stdout)
+
+    zconf = Zeroconf(loop)
+    server = await loop.create_server(lambda: FakeAppleTV(loop), "0.0.0.0")
+    port = server.sockets[0].getsockname()[1]
+    _LOGGER.info("Started fake MRP device at port %d", port)
+
+    service = await publish_zeroconf(zconf, args.local_ip, port)
+
+    print("Press ENTER to quit")
+    await loop.run_in_executor(None, sys.stdin.readline)
+
+    await zconf.unregister_service(service)
+
+    return 0
+
+
+def main():
+    """Application start here."""
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(appstart(loop))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/airplay/fake_airplay_device.py
+++ b/tests/airplay/fake_airplay_device.py
@@ -39,7 +39,7 @@ AirPlayPlaybackResponse = namedtuple("AirPlayPlaybackResponse", "code content")
 
 
 class FakeAirPlayDevice:
-    def __init__(self, testcase):
+    def __init__(self):
         self.responses = {}
         self.responses["airplay_playback"] = []
         self.has_authenticated = True
@@ -49,7 +49,6 @@ class FakeAirPlayDevice:
         self.last_airplay_uuid = None
         self.play_count = 0
         self.injected_play_fails = 0
-        self.tc = testcase
         self.app = web.Application()
 
         self.app.router.add_post("/play", self.handle_airplay_play)
@@ -86,8 +85,8 @@ class FakeAirPlayDevice:
         headers = request.headers
 
         # Verify headers first
-        self.tc.assertEqual(headers["User-Agent"], "MediaControl/1.0")
-        self.tc.assertEqual(headers["Content-Type"], "application/x-apple-binary-plist")
+        assert headers["User-Agent"] == "MediaControl/1.0"
+        assert headers["Content-Type"] == "application/x-apple-binary-plist"
 
         body = await request.read()
         parsed = plistlib.loads(body)

--- a/tests/airplay/test_airplay.py
+++ b/tests/airplay/test_airplay.py
@@ -33,7 +33,7 @@ class AirPlayPlayerTest(AioHTTPTestCase):
         await self.session.close()
 
     async def get_application(self, loop=None):
-        self.fake_device = FakeAirPlayDevice(self)
+        self.fake_device = FakeAirPlayDevice()
         self.usecase = AirPlayUseCases(self.fake_device)
         return self.fake_device.app
 

--- a/tests/airplay/test_airplay_auth.py
+++ b/tests/airplay/test_airplay_auth.py
@@ -28,7 +28,7 @@ class AirPlayAuthTest(AioHTTPTestCase):
         await self.session.close()
 
     async def get_application(self, loop=None):
-        self.fake_atv = FakeAirPlayDevice(self)
+        self.fake_atv = FakeAirPlayDevice()
         return self.fake_atv.app
 
     @unittest_run_loop

--- a/tests/airplay/test_airplay_pair.py
+++ b/tests/airplay/test_airplay_pair.py
@@ -39,7 +39,7 @@ class PairFunctionalTest(AioHTTPTestCase):
         await super().tearDownAsync()
 
     async def get_application(self, loop=None):
-        self.fake_atv = FakeAirPlayDevice(self)
+        self.fake_atv = FakeAirPlayDevice()
         self.usecase = AirPlayUseCases(self.fake_atv)
         return self.fake_atv.app
 

--- a/tests/dmap/fake_dmap_atv.py
+++ b/tests/dmap/fake_dmap_atv.py
@@ -60,9 +60,9 @@ class PlayingResponse:
 class FakeAppleTV(FakeAirPlayDevice):
     """Implementation of a fake DMAP Apple TV."""
 
-    def __init__(self, hsgid, pairing_guid, session_id, testcase):
+    def __init__(self, hsgid, pairing_guid, session_id):
         """Initialize a new FakeAppleTV."""
-        super().__init__(testcase)
+        super().__init__()
 
         self.responses["login"] = [LoginResponse(session_id, 200)]
         self.responses["artwork"] = []
@@ -249,19 +249,17 @@ class FakeAppleTV(FakeAirPlayDevice):
 
         # Verify content returned in pairingresponse
         parsed = parser.parse(data, tag_definitions.lookup_tag)
-        self.tc.assertEqual(parser.first(parsed, "cmpa", "cmpg"), 1)
-        self.tc.assertEqual(
-            parser.first(parsed, "cmpa", "cmnm"), pairing_response.remote_name
-        )
-        self.tc.assertEqual(parser.first(parsed, "cmpa", "cmty"), "iPhone")
+        assert parser.first(parsed, "cmpa", "cmpg") == 1
+        assert parser.first(parsed, "cmpa", "cmnm") == pairing_response.remote_name
+        assert parser.first(parsed, "cmpa", "cmty") == "iPhone"
 
     # Verifies that all needed headers are included in the request. Should be
     # checked in all requests, but that seems a bit too much and not that
     # necessary.
     def _verify_headers(self, request):
         for header in EXPECTED_HEADERS:
-            self.tc.assertIn(header, request.headers)
-            self.tc.assertEqual(request.headers[header], EXPECTED_HEADERS[header])
+            assert header in request.headers
+            assert request.headers[header] == EXPECTED_HEADERS[header]
 
     # This method makes sure that the correct login id and/or session id is
     # included in the GET-parameters. As this is extremely important for
@@ -274,22 +272,18 @@ class FakeAppleTV(FakeAirPlayDevice):
         # Either hsgid or pairing-guid should be present
         if check_login_id:
             if "hsgid" in params:
-                self.tc.assertEqual(
-                    params["hsgid"], self.hsgid, msg="hsgid does not match"
-                )
+                assert params["hsgid"] == self.hsgid, "hsgid does not match"
             elif "pairing-guid" in params:
-                self.tc.assertEqual(
-                    params["pairing-guid"],
-                    self.pairing_guid,
-                    msg="pairing-guid does not match",
-                )
+                assert (
+                    params["pairing-guid"] == self.pairing_guid
+                ), "pairing-guid does not match"
             else:
-                self.tc.assertTrue(False, "hsgid or pairing-guid not found")
+                assert False, "hsgid or pairing-guid not found"
 
         if check_session:
-            self.tc.assertEqual(
-                int(params["session-id"]), self.session, msg="session id does not match"
-            )
+            assert (
+                int(params["session-id"]) == self.session
+            ), "session id does not match"
 
 
 class AppleTVUseCases(AirPlayUseCases):

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -67,7 +67,7 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         await super().tearDownAsync()
 
     async def get_application(self, loop=None):
-        self.fake_atv = FakeAppleTV(HSGID, PAIRING_GUID, SESSION_ID, self)
+        self.fake_atv = FakeAppleTV(HSGID, PAIRING_GUID, SESSION_ID)
         self.usecase = AppleTVUseCases(self.fake_atv)
         return self.fake_atv.app
 

--- a/tests/dmap/test_dmap_pair.py
+++ b/tests/dmap/test_dmap_pair.py
@@ -42,7 +42,7 @@ class DmapPairFunctionalTest(AioHTTPTestCase):
         await super().tearDownAsync()
 
     async def get_application(self, loop=None):
-        self.fake_atv = FakeAppleTV(HSGID, PAIRING_GUID, SESSION_ID, self)
+        self.fake_atv = FakeAppleTV(HSGID, PAIRING_GUID, SESSION_ID)
         self.usecase = AppleTVUseCases(self.fake_atv)
         return self.fake_atv.app
 

--- a/tests/mrp/fake_mrp_atv.py
+++ b/tests/mrp/fake_mrp_atv.py
@@ -151,8 +151,8 @@ class PlayingMetadata:
 class FakeAppleTV(FakeAirPlayDevice, MrpServerAuth, asyncio.Protocol):
     """Implementation of a fake MRP Apple TV."""
 
-    def __init__(self, testcase, loop):
-        FakeAirPlayDevice.__init__(self, testcase)
+    def __init__(self, loop):
+        FakeAirPlayDevice.__init__(self)
         MrpServerAuth.__init__(self, self, DEVICE_NAME)
         self.loop = loop
         self.app.on_startup.append(self.start)

--- a/tests/mrp/test_mrp_auth.py
+++ b/tests/mrp/test_mrp_auth.py
@@ -23,7 +23,7 @@ class MrpAuthFunctionalTest(AioHTTPTestCase):
         await super().tearDownAsync()
 
     async def get_application(self, loop=None):
-        self.fake_atv = FakeAppleTV(self, self.loop)
+        self.fake_atv = FakeAppleTV(self.loop)
         self.usecase = AppleTVUseCases(self.fake_atv)
         return self.fake_atv.app
 

--- a/tests/mrp/test_mrp_functional.py
+++ b/tests/mrp/test_mrp_functional.py
@@ -44,7 +44,7 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         await super().tearDownAsync()
 
     async def get_application(self, loop=None):
-        self.fake_atv = FakeAppleTV(self, self.loop)
+        self.fake_atv = FakeAppleTV(self.loop)
         self.usecase = AppleTVUseCases(self.fake_atv)
         return self.fake_atv.app
 

--- a/tests/scripts/script_env.py
+++ b/tests/scripts/script_env.py
@@ -78,7 +78,7 @@ class ScriptTest(AioHTTPTestCase):
         self.usecase.airplay_playback_idle()
 
     async def get_application(self, loop=None):
-        self.fake_atv = FakeAppleTV(self, self.loop)
+        self.fake_atv = FakeAppleTV(self.loop)
         self.usecase = AppleTVUseCases(self.fake_atv)
         self.fake_udns = fake_udns.FakeUdns(self.loop)
         return self.fake_atv.app


### PR DESCRIPTION
This script will set up a fake device called FakeMRP at localhost. It
will be in idle state, but supports pairing and all commands that the
fake device implements. Most things are just logged so nothing really
happens.

A new instance is created for each connection to make sure encryption
works properly. Verified to work with the Home Assistant component.

Start of #518. I will write a page in the developer documentation about this.