### PR TITLE
mrp: Handle artwork without identifier

### DIFF
--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -397,6 +397,7 @@ class MrpMetadata(Metadata):
                 return metadata.artworkIdentifier
             if metadata.HasField("contentIdentifier"):
                 return metadata.contentIdentifier
+            return self.psm.playing.item_identifier
         return None
 
     async def playing(self):

--- a/tests/fake_device/mrp.py
+++ b/tests/fake_device/mrp.py
@@ -92,7 +92,8 @@ def _fill_item(item, metadata):
     if metadata.artwork_mimetype:
         md.artworkAvailable = True
         md.artworkMIMEType = metadata.artwork_mimetype
-        md.artworkIdentifier = metadata.artwork_identifier
+        if metadata.artwork_identifier:
+            md.artworkIdentifier = metadata.artwork_identifier
 
 
 def _set_state_message(metadata, identifier):

--- a/tests/mrp/test_mrp_functional.py
+++ b/tests/mrp/test_mrp_functional.py
@@ -106,6 +106,14 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         self.assertEqual(self.atv.metadata.artwork_id, ARTWORK_ID)
 
     @unittest_run_loop
+    async def test_metadata_artwork_id_no_identifier(self):
+        self.usecase.example_video(identifier="some_id")
+        self.usecase.change_artwork(ARTWORK_BYTES, ARTWORK_MIMETYPE, None)
+
+        await self.playing(title="dummy")
+        self.assertEqual(self.atv.metadata.artwork_id, "some_id")
+
+    @unittest_run_loop
     async def test_item_updates(self):
         self.usecase.video_playing(
             False, "dummy", 100, 1, identifier="id", artist="some artist"


### PR DESCRIPTION
If neither artworkIdentifier or contentIdentifier are present, fall back
to queue identifier.

Fixes #550.