### PR TITLE
release: Use current commit instead of master

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -83,7 +83,7 @@ def create_branch(version):
 
     branch_name = "release_" + version.replace(".", "_")
     _LOGGER.info("Checking out new branch %s", branch_name)
-    call("git checkout -b {0} origin/master", branch_name)
+    call("git checkout -b {0}", branch_name)
 
 
 def install_dependencies():


### PR DESCRIPTION
Instead of basing the release branch of master, use the current commit
as the simplifies when creating minor releases.