### PR TITLE
cq: Improvements to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ python =
   3.8: clean, py38, generated, lint, typing, report
 
 [testenv]
+usedevelop = True
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 setenv =
     LANG=en_US.UTF-8
@@ -28,8 +29,8 @@ commands = coverage erase
 
 [testenv:generated]
 deps =
+     {[testenv]deps}
      -r{toxinidir}/requirements_docs.txt
-     -r{toxinidir}/requirements_test.txt
 commands =
     python scripts/protobuf.py --download verify
     python scripts/api.py verify
@@ -42,10 +43,8 @@ commands =
      pydocstyle -v --match='(?!test_).*[^pb2]\.py' pyatv examples scripts
 
 [testenv:typing]
-deps =
-     -r{toxinidir}/requirements_test.txt
 commands =
-         mypy --ignore-missing-imports --follow-imports=skip pyatv
+     mypy --ignore-missing-imports --follow-imports=skip pyatv
 
 [testenv:report]
 deps = coverage


### PR DESCRIPTION
Avoid packaging and installing pyatv every time something is run. This
change alone cuts runtime by around 50%. Also some other minor fixes.