### PR TITLE
cq: Add codespell for code and docs

### DIFF
--- a/docs/api/pyatv/const.html
+++ b/docs/api/pyatv/const.html
@@ -346,7 +346,7 @@ class FeatureName(Enum):
     &#34;&#34;&#34;Select current option.&#34;&#34;&#34;
 
     Menu = 11
-    &#34;&#34;&#34;Go back to previos menu.&#34;&#34;&#34;
+    &#34;&#34;&#34;Go back to previous menu.&#34;&#34;&#34;
 
     VolumeUp = 12
     &#34;&#34;&#34;Increase volume.&#34;&#34;&#34;
@@ -596,7 +596,7 @@ class FeatureName(Enum):
     &#34;&#34;&#34;Select current option.&#34;&#34;&#34;
 
     Menu = 11
-    &#34;&#34;&#34;Go back to previos menu.&#34;&#34;&#34;
+    &#34;&#34;&#34;Go back to previous menu.&#34;&#34;&#34;
 
     VolumeUp = 12
     &#34;&#34;&#34;Increase volume.&#34;&#34;&#34;
@@ -714,7 +714,7 @@ class FeatureName(Enum):
 </dd>
 <dt id="pyatv.const.FeatureName.Menu"><code class="name">var <span class="ident">Menu</span></code></dt>
 <dd>
-<section class="desc"><p>Go back to previos menu.</p></section>
+<section class="desc"><p>Go back to previous menu.</p></section>
 </dd>
 <dt id="pyatv.const.FeatureName.Next"><code class="name">var <span class="ident">Next</span></code></dt>
 <dd>

--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -453,7 +453,7 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
         raise exceptions.NotSupportedError()
 
     @abstractmethod
-    @feature(11, &#34;Menu&#34;, &#34;Go back to previos menu.&#34;)
+    @feature(11, &#34;Menu&#34;, &#34;Go back to previous menu.&#34;)
     def menu(self) -&gt; None:
         &#34;&#34;&#34;Press key menu.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
@@ -2910,7 +2910,7 @@ def stop(self) -&gt; None:
         raise exceptions.NotSupportedError()
 
     @abstractmethod
-    @feature(11, &#34;Menu&#34;, &#34;Go back to previos menu.&#34;)
+    @feature(11, &#34;Menu&#34;, &#34;Go back to previous menu.&#34;)
     def menu(self) -&gt; None:
         &#34;&#34;&#34;Press key menu.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
@@ -3060,7 +3060,7 @@ def left(self) -&gt; None:
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">@abstractmethod
-@feature(11, &#34;Menu&#34;, &#34;Go back to previos menu.&#34;)
+@feature(11, &#34;Menu&#34;, &#34;Go back to previous menu.&#34;)
 def menu(self) -&gt; None:
     &#34;&#34;&#34;Press key menu.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>

--- a/docs/development/airplay.md
+++ b/docs/development/airplay.md
@@ -26,11 +26,11 @@ to do this again. The actual feature has been available for a while but as
 opt-in, so it would have to be explicitly enabled. Now it is enabled by default
 and cannot be disabled. Devices not running tvOS (e.g. Apple TV 2nd and 3rd
 generation) are not affected, even though device authentication can be enabled
-on theses devices as well.
+on these devices as well.
 
 The device authentication process is based on the *Secure Remote Password*
 protocol (SRP), with slight modifications. All the reverse engineering required
-for this process was made by funtax (GitHub username) and has merly been ported
+for this process was made by funtax (GitHub username) and has merely been ported
 to python for usage in this library. Please see references at bottom of page
 for reference implementation.
 

--- a/docs/development/listeners.md
+++ b/docs/development/listeners.md
@@ -14,7 +14,7 @@ via callbacks using a `listener`.
 
 The push update API is based on a regular callback interface. When playstatus
 information is available, a method called ``playstatus_update`` is called.
-Similarily, ``playstatus_error`` is called if an error occur. See the
+Similarly, ``playstatus_error`` is called if an error occur. See the
 following example:
 
 ```python
@@ -33,7 +33,7 @@ atv.push_updater.start()
 ```
 
 Assuming the connection to the device is still active, push updates will
-continue to be delivered after an error has happened. The paramater
+continue to be delivered after an error has happened. The parameter
 `initial_delay` to `start` specifies the delay that should be used before
 "trying to deliver updates again", but it might also be ignored if it is
 deemed not necessary. The reason for its existence is purly to provide a
@@ -64,7 +64,7 @@ atv.listener = DeviceListener()
 A small note here about this API. For `MRP` this works fine as that protocol
 is connection oriented. It's another case for `DMAP`, since that protocol is
 request based. For now, this interface is implemented by the push updates
-API (to be clear: for `DMAP`). So when the push updates API failes to establish
+API (to be clear: for `DMAP`). So when the push updates API fails to establish
 a connection, the callbacks in this interface will be called.
 
 ## Power State Updates

--- a/docs/development/metadata.md
+++ b/docs/development/metadata.md
@@ -18,7 +18,7 @@ This is to lower the amount of device calls needed. Artwork is retrieved
 separately.
 
 When using push updates, new updates are *pushed* from the Apple TV when
-someting of interest happens. The exact same data that is available when
+something of interest happens. The exact same data that is available when
 polling, is passed to a callback provided by the API user.
 
 Push updates are described further in the [Listeners](../listeners) section.

--- a/docs/development/scan_pair_and_connect.md
+++ b/docs/development/scan_pair_and_connect.md
@@ -23,7 +23,7 @@ async def scan(loop, timeout=5, identifier=None, protocol=None, hosts=None):
 
 **identifier:** filter to scan for *one* particular device
 
-**protocol:** filter fo scan for devices with a particular protocol
+**protocol:** filter for devices with a particular protocol
 (`Protocol.DMAP`, `Protocol.MRP` or `Protocol.AirPlay`)
 
 **hosts:** list of hosts to specifically scan for, e.g. `['10.0.0.1', '10.0.0.2']`

--- a/docs/documentation/atvremote.md
+++ b/docs/documentation/atvremote.md
@@ -170,7 +170,7 @@ Or check the current power state:
 ## Working with commands
 
 Several commands are supported by the library. Easiest is just to use the command
-called `commands`, as it will present a list of availble commands:
+called `commands`, as it will present a list of available commands:
 
     $ atvremote --id 00:11:22:33:44:54 commands
     Remote control commands:
@@ -267,7 +267,7 @@ Or all device information (same as seen with `atvremote scan`):
     Model/SW: 4K tvOS 13.3.1 build 17K795
          MAC: 00:11:22:33:44:55
 
-Perhaps see suuported features:
+Perhaps see supported features:
 
     $ atvremote -n Vardagsrum -s 10.0.10.81 features
     Feature list:
@@ -334,7 +334,7 @@ If you want additional help for a specific command, use help:
 You can enable additional debugging information by specifying
 either `--verbose` or `--debug.`. By default `pyatv` will limit some log points in length,
 mainly due to an excessive amount of data might be logged otherwise. This mainly applies to
-binary data (raw protocol data) and protobuf messages. These limits can be overriden by
+binary data (raw protocol data) and protobuf messages. These limits can be overridden by
 setting the following environment variables:
 
     $ export PYATV_BINARY_MAX_LINE=1000

--- a/docs/documentation/atvscript.md
+++ b/docs/documentation/atvscript.md
@@ -21,10 +21,10 @@ the following keys pre-defined keys:
 
 | Key | Meaning |
 | --- | ------- |
-| result | `success` if command was sucessful, else `failure`.
-| datetime | Date and time (ISO8601) when event ocurred (was printed), e.g. 2020-04-06T18:51:04.758569+02:00.
-| error | An error occured and this is a well defined string representing the error. Values: `device_not_found`, `unsupported_command`.
-| exception | If an unexpected exception ocurred, this key contains the exception message.
+| result | `success` if command was successful, else `failure`.
+| datetime | Date and time (ISO8601) when event occurred (was printed), e.g. 2020-04-06T18:51:04.758569+02:00.
+| error | An error occurred and this is a well defined string representing the error. Values: `device_not_found`, `unsupported_command`.
+| exception | If an unexpected exception occurred, this key contains the exception message.
 
 `error` and `exception` will only be present if `result` is set to `failure`. Any
 additional keys not mentioned here are part of the command response.

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -42,7 +42,7 @@ In some cases it's interesting to show some more user friendly metadata, like wh
 
 ### Identifiers
 
-An important concept for `pyatv` is to be able to *uniquely* identify a device. You should be able to say: "I want to find and connect to *this* specific device" and `pyatv` should be able to do that for you. This of course means that you cannot use common identifiers, like IP-address or device name, as they can change at any time. And how many devices named "Living Room" arent' there in the world?
+An important concept for `pyatv` is to be able to *uniquely* identify a device. You should be able to say: "I want to find and connect to *this* specific device" and `pyatv` should be able to do that for you. This of course means that you cannot use common identifiers, like IP-address or device name, as they can change at any time. And how many devices named "Living Room" aren't there in the world?
 
 Instead, `pyatv` extracts *unique identifiers* from the different services it finds when scanning. You can then specify that you want to scan for a device with one of these identifiers and be sure that you find the device you expect. What is a unique identifier then? It can be anything, as long as it is unique of course. In case of `MRP`, it actually exposes a property called `UniqueIdentifer`. Looking at `AirPlay`, you can get the device MAC-address via a property called `deviceid`. In practice this means that a device has *multiple* identifiers and you can use *any* of them when scanning. There is a convencience property,  {% include api i="conf.AppleTV.identifier" %}, used to get an identifier. It just picks one from all of the available.
 

--- a/docs/documentation/protocols.md
+++ b/docs/documentation/protocols.md
@@ -20,7 +20,7 @@ focus on the technical aspects used to implement DMAP/DACP/DAAP in pyatv.
 
 At its core, DMAP is basically a HTTP server (running on port 3689) that responds to specific
 commands and streams events back to the client. Data is requested using GET and POST with
-special URLs. Data in the responses is usually in a specic binary format, but depending on
+special URLs. Data in the responses is usually in a specific binary format, but depending on
 the request it can also be something else (like a PNG file for artwork). The
 binary protocol will be explained first, as that makes it easier to understand
 the requests.

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -14,7 +14,7 @@ This page tries to answer some common questions.
 
 See [Troubleshooting](../troubleshooting/) for some hints on locating the issue.
 
-### Q2. My Apple TV turns on everytime I send a command with atvremote (it turns on my TV, receiver, etc). How do I disable that?
+### Q2. My Apple TV turns on every time I send a command with atvremote (it turns on my TV, receiver, etc). How do I disable that?
 
 You can't. The device will turn itself on whenever a request is made to it
 (and of course `atvremote` does that). It is how Apple has designed it. The only

--- a/docs/support/scanning_issues.md
+++ b/docs/support/scanning_issues.md
@@ -24,7 +24,7 @@ The latter two seems to be most common. Lets break them down.
 
 ## Timing issues
 
-Timing isssues can happen because `pyatv` only scans for a small period of time. By
+Timing issues can happen because `pyatv` only scans for a small period of time. By
 saying "scan", we actually mean sending out requests and waiting for responses. The
 wait time should be long enough to receive all responses but short enough to not be
 annoying to the user. Waiting five minutes for a scan to finish *is* annoying. By

--- a/pyatv/airplay/pairing.py
+++ b/pyatv/airplay/pairing.py
@@ -26,7 +26,7 @@ class AirPlayPairingHandler(PairingHandler):
         self.http = net.HttpSession(
             session, "http://{0}:{1}/".format(config.address, self.service.port)
         )
-        self.auther = DeviceAuthenticator(self.http, self.srp)
+        self.authenticator = DeviceAuthenticator(self.http, self.srp)
         self.auth_data = self._setup_credentials()
         self.srp.initialize(binascii.unhexlify(self.auth_data.seed))
         self.pin_code = None
@@ -56,7 +56,9 @@ class AirPlayPairingHandler(PairingHandler):
             "Starting AirPlay pairing with credentials %s", self.auth_data.credentials
         )
         self.pairing_complete = False
-        return error_handler(self.auther.start_authentication, exceptions.PairingError)
+        return error_handler(
+            self.authenticator.start_authentication, exceptions.PairingError
+        )
 
     async def finish(self):
         """Stop pairing process."""
@@ -64,7 +66,7 @@ class AirPlayPairingHandler(PairingHandler):
             raise exceptions.PairingError("no pin given")
 
         await error_handler(
-            self.auther.finish_authentication,
+            self.authenticator.finish_authentication,
             exceptions.PairingError,
             self.auth_data.identifier,
             self.pin_code,

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -193,7 +193,7 @@ class FeatureName(Enum):
     """Select current option."""
 
     Menu = 11
-    """Go back to previos menu."""
+    """Go back to previous menu."""
 
     VolumeUp = 12
     """Increase volume."""

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -86,7 +86,7 @@ class BaseDmapAppleTV:
     """Common protocol logic used to interact with an Apple TV."""
 
     def __init__(self, requester):
-        """Initialize a new Apple TV base implemenation."""
+        """Initialize a new Apple TV base implementation."""
         self.daap = requester
         self.playstatus_revision = 0
         self.latest_playing = None

--- a/pyatv/dmap/daap.py
+++ b/pyatv/dmap/daap.py
@@ -74,7 +74,7 @@ def ms_to_s(time):
 class DaapRequester:
     """Helper class that makes it easy to perform DAAP requests.
 
-    It will automatically do login and other necesarry book-keeping.
+    It will automatically do login and other necessary book-keeping.
     """
 
     def __init__(self, http, login_id):
@@ -86,7 +86,7 @@ class DaapRequester:
     async def login(self):
         """Login to Apple TV using specified login id."""
         # Do not use session.get_data(...) in login as that would end up in
-        # an infinte loop.
+        # an infinite loop.
         def _login_request():
             return self.http.get_data(
                 self._mkurl("login?[AUTH]&hasFP=1", session=False, login_id=True),

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -243,7 +243,7 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
         raise exceptions.NotSupportedError()
 
     @abstractmethod
-    @feature(11, "Menu", "Go back to previos menu.")
+    @feature(11, "Menu", "Go back to previous menu.")
     def menu(self) -> None:
         """Press key menu."""
         raise exceptions.NotSupportedError()

--- a/pyatv/mrp/protobuf/CommandInfo.proto
+++ b/pyatv/mrp/protobuf/CommandInfo.proto
@@ -62,7 +62,7 @@ message CommandInfo {
   }
 
   enum ShuffleMode {
-    Unkown = 0;
+    Unknown = 0;
     Off = 1;
     Albums = 2;
     Songs = 3;

--- a/pyatv/mrp/protobuf/CommandOptions.proto
+++ b/pyatv/mrp/protobuf/CommandOptions.proto
@@ -8,7 +8,7 @@ message CommandOptions {
   }
 
   enum ShuffleMode {
-    Unkown = 0;
+    Unknown = 0;
     Off = 1;
     Albums = 2;
     Songs = 3;

--- a/pyatv/mrp/protobuf/NowPlayingInfo.proto
+++ b/pyatv/mrp/protobuf/NowPlayingInfo.proto
@@ -8,7 +8,7 @@ message NowPlayingInfo {
   }
 
   enum ShuffleMode {
-    Unkown = 0;
+    Unknown = 0;
     Off = 1;
     Albums = 2;
     Songs = 3;

--- a/pyatv/mrp/protocol.py
+++ b/pyatv/mrp/protocol.py
@@ -124,7 +124,7 @@ class MrpProtocol:
 
         # Some messages will respond with the same identifier as used in the
         # corresponding request. Others will not and one example is the crypto
-        # message (for pairing). They will never include an identifer, but it
+        # message (for pairing). They will never include an identifier, but it
         # it is in turn only possible to have one of those message outstanding
         # at one time (i.e. it's not possible to mix up the responses). In
         # those cases, a "fake" identifier is used that includes the message
@@ -156,7 +156,7 @@ class MrpProtocol:
 
     def message_received(self, message, _):
         """Message was received from device."""
-        # If the message identifer is outstanding, then someone is
+        # If the message identifier is outstanding, then someone is
         # waiting for the respone so we save it here
         identifier = message.identifier or "type_" + str(message.type)
         if identifier in self._outstanding:

--- a/pyatv/mrp/tlv8.py
+++ b/pyatv/mrp/tlv8.py
@@ -23,7 +23,7 @@ def read_tlv(data):
     """Parse TLV8 bytes into a dict.
 
     If value is larger than 255 bytes, it is split up in multiple chunks. So
-    the same tag might occurr several times.
+    the same tag might occur several times.
     """
 
     def _parse(data, pos, size, result=None):

--- a/pyatv/scripts/atvproxy.py
+++ b/pyatv/scripts/atvproxy.py
@@ -69,7 +69,6 @@ class MrpAppleTVProxy(MrpServerAuth, asyncio.Protocol):
         """Initialize a new instance of ProxyMrpAppleTV."""
         super().__init__(self, DEVICE_NAME)
         self.loop = loop
-        self.auther = MrpServerAuth(self, DEVICE_NAME)
         self.buffer = b""
         self.transport = None
         self.chacha = None

--- a/pyatv/scripts/atvremote.py
+++ b/pyatv/scripts/atvremote.py
@@ -222,7 +222,7 @@ class DeviceCommands:
                 break
 
             if command == "cli":
-                print("Command not availble here")
+                print("Command not available here")
                 continue
 
             await _handle_device_command(self.args, command, self.atv, self.loop)

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,1 +1,2 @@
+codespell==1.16.0
 pdoc3==0.7.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 black==19.10b0
+codecov==2.0.22
 deepdiff==4.3.2
 flake8==3.7.9
-codecov==2.0.22
 pytest==5.4.1
 pytest-asyncio==0.10.0
 pytest-cov==2.8.1

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -44,9 +44,9 @@ def _api_modules():
 
     for mod in modules:
         for module_name, html in _recursive_htmls(mod):
-            splitted = module_name.split(".")
-            splitted[-1] = splitted[-1] + ".html"
-            output_file = os.path.join("docs", "api", *splitted)
+            split = module_name.split(".")
+            split[-1] = split[-1] + ".html"
+            output_file = os.path.join("docs", "api", *split)
             yield output_file, html
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -100,10 +100,10 @@ def update_version(version):
     _LOGGER.info("Updating with new version: %s", version)
 
     output = Path("pyatv/const.py").read_text()
-    splitted = version.split(".")
+    split = version.split(".")
     for i, component in enumerate(["MAJOR", "MINOR", "PATCH"]):
         output = re.sub(
-            "(" + component + "_VERSION =).*", '\\1 "' + splitted[i] + '"', output
+            "(" + component + "_VERSION =).*", '\\1 "' + split[i] + '"', output
         )
 
     with open("pyatv/const.py", "w") as wh:
@@ -111,7 +111,7 @@ def update_version(version):
 
 
 def generate_outputs():
-    """Generate ouput artifacts for pypi."""
+    """Generate output artifacts for pypi."""
     _LOGGER.info("Generating outputs")
     call("python3 setup.py sdist bdist_wheel", show_output=False)
 

--- a/tests/airplay/test_airplay_auth.py
+++ b/tests/airplay/test_airplay_auth.py
@@ -64,10 +64,10 @@ class AirPlayAuthTest(AioHTTPTestCase):
         handler = srp.SRPAuthHandler()
         handler.initialize(INVALID_AUTH_KEY)
 
-        auther = DeviceAuthenticator(http, handler)
-        await auther.start_authentication()
+        authenticator = DeviceAuthenticator(http, handler)
+        await authenticator.start_authentication()
         with self.assertRaises(AuthenticationError):
-            await auther.finish_authentication(DEVICE_IDENTIFIER, DEVICE_PIN)
+            await authenticator.finish_authentication(DEVICE_IDENTIFIER, DEVICE_PIN)
 
     @unittest_run_loop
     async def test_auth_failed(self):
@@ -77,8 +77,8 @@ class AirPlayAuthTest(AioHTTPTestCase):
         handler = srp.SRPAuthHandler()
         handler.initialize(binascii.unhexlify(DEVICE_AUTH_KEY))
 
-        auther = DeviceAuthenticator(http, handler)
-        await auther.start_authentication()
+        authenticator = DeviceAuthenticator(http, handler)
+        await authenticator.start_authentication()
         self.assertTrue(
-            (await auther.finish_authentication(DEVICE_IDENTIFIER, DEVICE_PIN))
+            (await authenticator.finish_authentication(DEVICE_IDENTIFIER, DEVICE_PIN))
         )

--- a/tests/fake_device/dmap.py
+++ b/tests/fake_device/dmap.py
@@ -404,7 +404,7 @@ class FakeDmapUseCases:
         self.state.playing = PlayingResponse(playstatus=1)
 
     def pairing_response(self, remote_name, expected_pairing_code):
-        """Reponse when a pairing request is made."""
+        """Response when a pairing request is made."""
         self.state.pairing_responses[remote_name] = expected_pairing_code
 
     async def act_on_bonjour_services(self, stubbed_zeroconf):

--- a/tests/fake_device/mrp.py
+++ b/tests/fake_device/mrp.py
@@ -426,7 +426,7 @@ class FakeMrpUseCases:
         self.state = state
 
     def change_volume_control(self, available):
-        """Change volume control availaility."""
+        """Change volume control availability."""
         self.state.volume_control(available)
 
     def change_artwork(self, artwork, mimetype, identifier="artwork"):

--- a/tests/mrp/test_mrp_functional.py
+++ b/tests/mrp/test_mrp_functional.py
@@ -122,7 +122,7 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         with faketime("pyatv", 0):
             await self.playing(title="dummy")
 
-            # Trigger update of single item by chaging title
+            # Trigger update of single item by changing title
             self.usecase.change_metadata(title="foobar", identifier="id")
             playing = await self.playing(title="foobar")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist = clean, py{36,37,38}, generated, lint, typing, report
+envlist = clean, py{36,37,38}, docs, generated, lint, typing, report
 skip_missing_interpreters = True
+pysources = pyatv examples scripts
+cs_exclude_words = cann,cant
 
 [gh-actions]
 python =
-  3.6: clean, py36, generated, lint, typing, report
-  3.7: clean, py37, generated, lint, typing, report
-  3.8: clean, py38, generated, lint, typing, report
+  3.6: clean, py36, docs, generated, lint, typing, report
+  3.7: clean, py37, docs, generated, lint, typing, report
+  3.8: clean, py38, docs, generated, lint, typing, report
 
 [testenv]
 usedevelop = True
@@ -27,20 +29,25 @@ deps = coverage
 skip_install = true
 commands = coverage erase
 
-[testenv:generated]
+[testenv:docs]
 deps =
      {[testenv]deps}
      -r{toxinidir}/requirements_docs.txt
 commands =
-    python scripts/protobuf.py --download verify
     python scripts/api.py verify
+     codespell -q 4 -L {[tox]cs_exclude_words} --skip="*.pyc,*.pyi,*~" {[tox]pysources} tests
+     codespell -q 6 -L cann,cant -S "lib,vendor,_site,api,assets,*~,.sass-cache,*.lock" docs
+
+[testenv:generated]
+commands =
+    python scripts/protobuf.py --download verify
 
 [testenv:lint]
 ignore_errors = True
 commands =
-     flake8 --exclude=pyatv/mrp/protobuf pyatv tests examples scripts
+     flake8 --exclude=pyatv/mrp/protobuf {[tox]pysources}
      black --fast --check .
-     pydocstyle -v --match='(?!test_).*[^pb2]\.py' pyatv examples scripts
+     pydocstyle -v --match='(?!test_).*[^pb2]\.py' {[tox]pysources}
 
 [testenv:typing]
 commands =


### PR DESCRIPTION
A new environment has been introduced in tox which checks spelling in
all code and documentation. Verification of API documentation
consistency has been moved here now, instead of "generated".

To verify documentation, do it with tox like this:

    $ tox -e docs

Fixes #541.