### PR TITLE
Add support for skip_forward and skip_backward

### DIFF
--- a/docs/api/pyatv/const.html
+++ b/docs/api/pyatv/const.html
@@ -66,6 +66,8 @@ link_group: api
 <li><code><a title="pyatv.const.FeatureName.SetRepeat" href="#pyatv.const.FeatureName.SetRepeat">SetRepeat</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.SetShuffle" href="#pyatv.const.FeatureName.SetShuffle">SetShuffle</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.Shuffle" href="#pyatv.const.FeatureName.Shuffle">Shuffle</a></code></li>
+<li><code><a title="pyatv.const.FeatureName.SkipBackward" href="#pyatv.const.FeatureName.SkipBackward">SkipBackward</a></code></li>
+<li><code><a title="pyatv.const.FeatureName.SkipForward" href="#pyatv.const.FeatureName.SkipForward">SkipForward</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.Stop" href="#pyatv.const.FeatureName.Stop">Stop</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.Suspend" href="#pyatv.const.FeatureName.Suspend">Suspend</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.Title" href="#pyatv.const.FeatureName.Title">Title</a></code></li>
@@ -369,6 +371,12 @@ class FeatureName(Enum):
     WakeUp = 18
     &#34;&#34;&#34;Wake up device (deprecated; use Power.turn_on).&#34;&#34;&#34;
 
+    SkipForward = 36
+    &#34;&#34;&#34;Skip forward a time interval.&#34;&#34;&#34;
+
+    SkipBackward = 37
+    &#34;&#34;&#34;Skip backwards a time interval.&#34;&#34;&#34;
+
     SetPosition = 19
     &#34;&#34;&#34;Seek to position.&#34;&#34;&#34;
 
@@ -619,6 +627,12 @@ class FeatureName(Enum):
     WakeUp = 18
     &#34;&#34;&#34;Wake up device (deprecated; use Power.turn_on).&#34;&#34;&#34;
 
+    SkipForward = 36
+    &#34;&#34;&#34;Skip forward a time interval.&#34;&#34;&#34;
+
+    SkipBackward = 37
+    &#34;&#34;&#34;Skip backwards a time interval.&#34;&#34;&#34;
+
     SetPosition = 19
     &#34;&#34;&#34;Seek to position.&#34;&#34;&#34;
 
@@ -775,6 +789,14 @@ class FeatureName(Enum):
 <dt id="pyatv.const.FeatureName.Shuffle"><code class="name">var <span class="ident">Shuffle</span></code></dt>
 <dd>
 <section class="desc"><p>Shuffle stat.e</p></section>
+</dd>
+<dt id="pyatv.const.FeatureName.SkipBackward"><code class="name">var <span class="ident">SkipBackward</span></code></dt>
+<dd>
+<section class="desc"><p>Skip backwards a time interval.</p></section>
+</dd>
+<dt id="pyatv.const.FeatureName.SkipForward"><code class="name">var <span class="ident">SkipForward</span></code></dt>
+<dd>
+<section class="desc"><p>Skip forward a time interval.</p></section>
 </dd>
 <dt id="pyatv.const.FeatureName.Stop"><code class="name">var <span class="ident">Stop</span></code></dt>
 <dd>

--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -177,6 +177,8 @@ link_group: api
 <li><code><a title="pyatv.interface.RemoteControl.set_position" href="#pyatv.interface.RemoteControl.set_position">set_position</a></code></li>
 <li><code><a title="pyatv.interface.RemoteControl.set_repeat" href="#pyatv.interface.RemoteControl.set_repeat">set_repeat</a></code></li>
 <li><code><a title="pyatv.interface.RemoteControl.set_shuffle" href="#pyatv.interface.RemoteControl.set_shuffle">set_shuffle</a></code></li>
+<li><code><a title="pyatv.interface.RemoteControl.skip_backward" href="#pyatv.interface.RemoteControl.skip_backward">skip_backward</a></code></li>
+<li><code><a title="pyatv.interface.RemoteControl.skip_forward" href="#pyatv.interface.RemoteControl.skip_forward">skip_forward</a></code></li>
 <li><code><a title="pyatv.interface.RemoteControl.stop" href="#pyatv.interface.RemoteControl.stop">stop</a></code></li>
 <li><code><a title="pyatv.interface.RemoteControl.suspend" href="#pyatv.interface.RemoteControl.suspend">suspend</a></code></li>
 <li><code><a title="pyatv.interface.RemoteControl.top_menu" href="#pyatv.interface.RemoteControl.top_menu">top_menu</a></code></li>
@@ -498,6 +500,26 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
     @feature(18, &#34;WakeUp&#34;, &#34;Wake up device (deprecated; use Power.turn_on).&#34;)
     def wakeup(self) -&gt; None:
         &#34;&#34;&#34;Wake up the device.&#34;&#34;&#34;
+        raise exceptions.NotSupportedError()
+
+    @abstractmethod
+    @feature(
+        36, &#34;SkipForward&#34;, &#34;Skip forward a time interval.&#34;,
+    )
+    def skip_forward(self) -&gt; None:
+        &#34;&#34;&#34;Skip forward a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        &#34;&#34;&#34;
+        raise exceptions.NotSupportedError()
+
+    @abstractmethod
+    @feature(37, &#34;SkipBackward&#34;, &#34;Skip backwards a time interval.&#34;)
+    def skip_backward(self) -&gt; None:
+        &#34;&#34;&#34;Skip backwards a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        &#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
@@ -2958,6 +2980,26 @@ def stop(self) -&gt; None:
         raise exceptions.NotSupportedError()
 
     @abstractmethod
+    @feature(
+        36, &#34;SkipForward&#34;, &#34;Skip forward a time interval.&#34;,
+    )
+    def skip_forward(self) -&gt; None:
+        &#34;&#34;&#34;Skip forward a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        &#34;&#34;&#34;
+        raise exceptions.NotSupportedError()
+
+    @abstractmethod
+    @feature(37, &#34;SkipBackward&#34;, &#34;Skip backwards a time interval.&#34;)
+    def skip_backward(self) -&gt; None:
+        &#34;&#34;&#34;Skip backwards a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        &#34;&#34;&#34;
+        raise exceptions.NotSupportedError()
+
+    @abstractmethod
     @feature(19, &#34;SetPosition&#34;, &#34;Seek to position.&#34;)
     def set_position(self, pos) -&gt; None:
         &#34;&#34;&#34;Seek in the current playing media.&#34;&#34;&#34;
@@ -3223,6 +3265,48 @@ def set_repeat(self, repeat_state) -&gt; None:
 @feature(20, &#34;SetShuffle&#34;, &#34;Change shuffle state.&#34;)
 def set_shuffle(self, shuffle_state) -&gt; None:
     &#34;&#34;&#34;Change shuffle mode to on or off.&#34;&#34;&#34;
+    raise exceptions.NotSupportedError()</code></pre>
+</details>
+</dd>
+<dt id="pyatv.interface.RemoteControl.skip_backward"><code class="name flex">
+<span>def <span class="ident">skip_backward</span></span>(<span>self) -> NoneType</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Skip backwards a time interval.</p>
+<p>Skip interval is typically 15-30s, but is decided by the app.</p></section>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abstractmethod
+@feature(37, &#34;SkipBackward&#34;, &#34;Skip backwards a time interval.&#34;)
+def skip_backward(self) -&gt; None:
+    &#34;&#34;&#34;Skip backwards a time interval.
+
+    Skip interval is typically 15-30s, but is decided by the app.
+    &#34;&#34;&#34;
+    raise exceptions.NotSupportedError()</code></pre>
+</details>
+</dd>
+<dt id="pyatv.interface.RemoteControl.skip_forward"><code class="name flex">
+<span>def <span class="ident">skip_forward</span></span>(<span>self) -> NoneType</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Skip forward a time interval.</p>
+<p>Skip interval is typically 15-30s, but is decided by the app.</p></section>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abstractmethod
+@feature(
+    36, &#34;SkipForward&#34;, &#34;Skip forward a time interval.&#34;,
+)
+def skip_forward(self) -&gt; None:
+    &#34;&#34;&#34;Skip forward a time interval.
+
+    Skip interval is typically 15-30s, but is decided by the app.
+    &#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
 </dd>

--- a/docs/documentation/atvremote.md
+++ b/docs/documentation/atvremote.md
@@ -186,8 +186,11 @@ called `commands`, as it will present a list of available commands:
      - previous - Press key previous
      - right - Press key right
      - select - Press key select
-     - set_position - Seek in the current playing media - set_repeat - Change repeat mode
+     - set_position - Seek in the current playing media
+     - set_repeat - Change repeat state
      - set_shuffle - Change shuffle mode to on or off
+     - skip_backward - Skip backwards a time interval
+     - skip_forward - Skip forward a time interval
      - stop - Press key stop
      - suspend - Suspend the device
      - top_menu - Go to main menu (long press menu)
@@ -199,6 +202,7 @@ called `commands`, as it will present a list of available commands:
     Metadata commands:
      - app - Return information about current app playing something
      - artwork - Return artwork for what is currently playing (or None)
+     - artwork_id - Return a unique identifier for current artwork
      - device_id - Return a unique identifier for current device
      - playing - Return what is currently playing
 
@@ -210,10 +214,10 @@ called `commands`, as it will present a list of available commands:
     Playing commands:
      - album - Album of the currently playing song
      - artist - Artist of the currently playing song
+     - device_state - Device state, e.g. playing or paused
      - genre - Genre of the currently playing song
      - hash - Create a unique hash for what is currently playing
      - media_type - Type of media is currently playing, e.g. video, music
-     - device_state - Device state, e.g. playing or paused
      - position - Position in the playing media (seconds)
      - repeat - Repeat mode
      - shuffle - If shuffle is enabled or not
@@ -276,12 +280,12 @@ Perhaps see supported features:
     Down: Available
     Left: Available
     Right: Available
-    Play: Unavailable
-    PlayPause: Unavailable
-    Pause: Unavailable
-    Stop: Unavailable
-    Next: Unavailable
-    Previous: Unavailable
+    Play: Available
+    PlayPause: Available
+    Pause: Available
+    Stop: Available
+    Next: Available
+    Previous: Available
     Select: Available
     Menu: Available
     VolumeUp: Unknown
@@ -289,26 +293,31 @@ Perhaps see supported features:
     Home: Available
     HomeHold: Available
     TopMenu: Available
-    SetPosition: Unavailable
-    SetShuffle: Unavailable
-    SetRepeat: Unavailable
+    SkipForward: Unavailable
+    SkipBackward: Unavailable
+    SetPosition: Available
+    SetShuffle: Available
+    SetRepeat: Available
     Title: Available
     Artist: Available
     Album: Available
     Genre: Available
     TotalTime: Available
     Position: Available
-    Shuffle: Unavailable
-    Repeat: Unavailable
+    Shuffle: Available
+    Repeat: Available
     Artwork: Available
+    App: Available
     PlayUrl: Available
+    PowerState: Available
     TurnOn: Available
     TurnOff: Available
 
     Legend:
     -------
     Available: Supported by device and usable now
-    Unavailable: Supported by device but not usable nowUnknown: Supported by the device but availability not known
+    Unavailable: Supported by device but not usable now
+    Unknown: Supported by the device but availability not known
     Unsupported: Not supported by this device (or by pyatv)
 
 Show active app:

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -216,6 +216,12 @@ class FeatureName(Enum):
     WakeUp = 18
     """Wake up device (deprecated; use Power.turn_on)."""
 
+    SkipForward = 36
+    """Skip forward a time interval."""
+
+    SkipBackward = 37
+    """Skip backwards a time interval."""
+
     SetPosition = 19
     """Seek to position."""
 

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -268,6 +268,20 @@ class DmapRemoteControl(RemoteControl):
         """Wake up the device."""
         raise exceptions.NotSupportedError()
 
+    async def skip_forward(self) -> None:
+        """Skip forward a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        """
+        raise exceptions.NotSupportedError()
+
+    async def skip_backward(self) -> None:
+        """Skip backwards a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        """
+        raise exceptions.NotSupportedError()
+
     def set_position(self, pos):
         """Seek in the current playing media."""
         time_in_ms = int(pos) * 1000

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -291,6 +291,26 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
         raise exceptions.NotSupportedError()
 
     @abstractmethod
+    @feature(
+        36, "SkipForward", "Skip forward a time interval.",
+    )
+    def skip_forward(self) -> None:
+        """Skip forward a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        """
+        raise exceptions.NotSupportedError()
+
+    @abstractmethod
+    @feature(37, "SkipBackward", "Skip backwards a time interval.")
+    def skip_backward(self) -> None:
+        """Skip backwards a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        """
+        raise exceptions.NotSupportedError()
+
+    @abstractmethod
     @feature(19, "SetPosition", "Seek to position.")
     def set_position(self, pos) -> None:
         """Seek in the current playing media."""

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -229,6 +229,20 @@ class MrpRemoteControl(RemoteControl):
         """Wake up the device."""
         await self._press_key("wakeup")
 
+    async def skip_forward(self) -> None:
+        """Skip forward a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        """
+        raise exceptions.NotSupportedError()
+
+    async def skip_backward(self) -> None:
+        """Skip backwards a time interval.
+
+        Skip interval is typically 15-30s, but is decided by the app.
+        """
+        raise exceptions.NotSupportedError()
+
     async def set_position(self, pos):
         """Seek in the current playing media."""
         await self.protocol.send_and_receive(messages.seek_to_position(pos))

--- a/pyatv/mrp/messages.py
+++ b/pyatv/mrp/messages.py
@@ -126,21 +126,23 @@ def send_hid_event(use_page, usage, down):
     return message
 
 
-def command(cmd):
+def command(cmd, **kwargs):
     """Playback command request."""
     message = create(protobuf.SEND_COMMAND_MESSAGE)
     send_command = message.inner()
     send_command.command = cmd
+    for key, value in kwargs.items():
+        setattr(send_command.options, key, value)
     return message
 
 
 def command_result(
-    identifier, sendError=protobuf.SendCommandResultMessage.SendError.NoError
+    identifier, send_error=protobuf.SendCommandResultMessage.SendError.NoError
 ):
     """Playback command request."""
     message = create(protobuf.SEND_COMMAND_RESULT_MESSAGE, identifier=identifier)
     inner = message.inner()
-    inner.sendError = sendError
+    inner.sendError = send_error
     inner.handlerReturnStatus = (
         protobuf.SendCommandResultMessage.HandlerReturnStatus.Success
     )

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -43,6 +43,8 @@ HOMESHARING_SERVICE_2 = zeroconf_stub.homesharing_service(
     "BBBB", b"Apple TV 2", "10.0.0.2", b"bbbb"
 )
 
+SKIP_TIME = 10
+
 
 class DummyPushListener:
     @staticmethod
@@ -234,6 +236,8 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
             FeatureName.SetRepeat,
             FeatureName.SetShuffle,
             FeatureName.Stop,
+            FeatureName.SkipForward,  # Depends on SetPosition
+            FeatureName.SkipBackward,  # Depends on SetPosition
         )
 
     @unittest_run_loop
@@ -253,3 +257,18 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         self.assertFeatures(
             FeatureState.Available, FeatureName.Shuffle, FeatureName.Repeat,
         )
+
+    @unittest_run_loop
+    async def test_skip_forward_backward(self):
+        self.usecase.example_video()
+
+        prev_position = (await self.playing(title="dummy")).position
+
+        await self.atv.remote_control.skip_forward()
+        metadata = await self.playing()
+        self.assertEqual(metadata.position, prev_position + SKIP_TIME)
+        prev_position = metadata.position
+
+        await self.atv.remote_control.skip_backward()
+        metadata = await self.playing()
+        self.assertEqual(metadata.position, prev_position - SKIP_TIME)


### PR DESCRIPTION
These functions will skip forward or backwards a short time period. For `MRP` this period is defined by the running application, but is typically 10-30 seconds. `DMAP` does not natively support this but has simulated functions that retrieves current position and changes it using `set_position`. In this case it's hard coded to ten seconds.

It is currently not possible to specify skip interval manually, that is a future improvement (#472).

Fixes #345.