### PR TITLE
mrp: Change topmenu to go to main menu

### DIFF
--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -61,7 +61,7 @@ _KEY_LOOKUP = {
     "previous": [12, 0xB6, 0],
     "select": [1, 0x89, 0],
     "menu": [1, 0x86, 0],
-    "topmenu": [12, 0x60, 0],
+    "topmenu": [1, 0x86, 1],
     "home": [12, 0x40, 1],
     "suspend": [1, 0x82, 0],
     "wakeup": [1, 0x83, 0],
@@ -225,7 +225,7 @@ class MrpRemoteControl(RemoteControl):
 
     async def top_menu(self) -> None:
         """Go to main menu (long press menu)."""
-        await self._press_key("topmenu")
+        await self._press_key("topmenu", hold=True)
 
     @deprecated
     async def suspend(self) -> None:

--- a/tests/common_functional_tests.py
+++ b/tests/common_functional_tests.py
@@ -182,11 +182,6 @@ class CommonFunctionalTests(AioHTTPTestCase):
         await until(lambda: self.state.last_button_pressed == "menu")
 
     @unittest_run_loop
-    async def test_button_top_menu(self):
-        await self.atv.remote_control.top_menu()
-        await until(lambda: self.state.last_button_pressed == "topmenu")
-
-    @unittest_run_loop
     async def test_button_play(self):
         await self.atv.remote_control.play()
         await until(lambda: self.state.last_button_pressed == "play")

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -21,6 +21,7 @@ from tests.fake_device import FakeAppleTV
 from tests.fake_device.airplay import DEVICE_CREDENTIALS
 from tests import zeroconf_stub, common_functional_tests
 from tests.common_functional_tests import DummyDeviceListener
+from tests.utils import until
 
 HSGID = "12345678-6789-1111-2222-012345678911"
 PAIRING_GUID = "0x0000000000000001"
@@ -146,6 +147,11 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         for button in buttons:
             with self.assertRaises(exceptions.NotSupportedError):
                 await getattr(self.atv.remote_control, button)()
+
+    @unittest_run_loop
+    async def test_button_top_menu(self):
+        await self.atv.remote_control.top_menu()
+        await until(lambda: self.state.last_button_pressed == "topmenu")
 
     @unittest_run_loop
     async def test_shuffle_state_albums(self):


### PR DESCRIPTION
No tests are present for this yet as I need to re-work the button
handling quite a bit (same situation as for home_hold). Will leave that
for later.

This will take care of #522 once pyatv has been bumped in the HA component.