### PR TITLE
udns: Verify address in any local subnet

### DIFF
--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -226,13 +226,13 @@ class ZeroconfScanner(BaseScanner):
 class UnicastMdnsScanner(BaseScanner):
     &#34;&#34;&#34;Service discovery based on unicast MDNS.&#34;&#34;&#34;
 
-    def __init__(self, hosts, loop):
+    def __init__(self, hosts: List[str], loop: asyncio.AbstractEventLoop):
         &#34;&#34;&#34;Initialize a new UnicastMdnsScanner.&#34;&#34;&#34;
         super().__init__()
         self.hosts = hosts
         self.loop = loop
 
-    async def discover(self, timeout):
+    async def discover(self, timeout: int):
         &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
         results = await asyncio.gather(
             *[self._get_services(host, timeout) for host in self.hosts]
@@ -242,8 +242,8 @@ class UnicastMdnsScanner(BaseScanner):
                 self._handle_response(host, response)
         return self._found_devices
 
-    async def _get_services(self, host, timeout):
-        port = os.environ.get(&#34;PYATV_UDNS_PORT&#34;, 5353)  # For testing purposes
+    async def _get_services(self, host: str, timeout: int):
+        port = int(os.environ.get(&#34;PYATV_UDNS_PORT&#34;, 5353))  # For testing purposes
         services = [s[0:-1] for s in ALL_SERVICES]
         try:
             response = await udns.request(
@@ -253,7 +253,7 @@ class UnicastMdnsScanner(BaseScanner):
             response = None
         return host, response
 
-    def _handle_response(self, host, response):
+    def _handle_response(self, host: int, response: udns.DnsMessage):
         for resource in response.resources:
             if resource.qtype != udns.QTYPE_TXT:
                 continue

--- a/docs/api/pyatv/exceptions.html
+++ b/docs/api/pyatv/exceptions.html
@@ -48,6 +48,9 @@ link_group: api
 <h4><code><a title="pyatv.exceptions.NoServiceError" href="#pyatv.exceptions.NoServiceError">NoServiceError</a></code></h4>
 </li>
 <li>
+<h4><code><a title="pyatv.exceptions.NonLocalSubnetError" href="#pyatv.exceptions.NonLocalSubnetError">NonLocalSubnetError</a></code></h4>
+</li>
+<li>
 <h4><code><a title="pyatv.exceptions.NotSupportedError" href="#pyatv.exceptions.NotSupportedError">NotSupportedError</a></code></h4>
 </li>
 <li>
@@ -143,7 +146,11 @@ class PlaybackError(Exception):
 
 
 class CommandError(Exception):
-    &#34;&#34;&#34;Thrown when a command (e.g. play or pause) failed.&#34;&#34;&#34;</code></pre>
+    &#34;&#34;&#34;Thrown when a command (e.g. play or pause) failed.&#34;&#34;&#34;
+
+
+class NonLocalSubnetError(Exception):
+    &#34;&#34;&#34;Thrown when address it not in any local subnet.&#34;&#34;&#34;</code></pre>
 </details>
 </section>
 <section>
@@ -338,6 +345,25 @@ class CommandError(Exception):
 </summary>
 <pre><code class="python">class NoServiceError(Exception):
     &#34;&#34;&#34;Thrown when connecting to a device with no usable service.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="pyatv.exceptions.NonLocalSubnetError"><code class="flex name class">
+<span>class <span class="ident">NonLocalSubnetError</span></span>
+<span>(</span><span>...)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Thrown when address it not in any local subnet.</p></section>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NonLocalSubnetError(Exception):
+    &#34;&#34;&#34;Thrown when address it not in any local subnet.&#34;&#34;&#34;</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -93,7 +93,9 @@ please see [atvremote](../atvremote/).
 Please note that unicast scanning does not work across different network as the Apple TV will ignore
 packets from a different subnet. This is according to the multicast DNS specification (see chapter 5.5
 in RFC 6762 [here](https://tools.ietf.org/html/rfc6762#section-5.5) in case you are interested) and is
-not something that can be fixed in `pyatv`.
+not something that can be fixed in `pyatv`. To make this more clear, {% include api i="pyatv.scan" %}
+will raise {% include api i="pyatv.exceptions.NonLocalSubnetError" %} if an address that is outside of
+all local subnets is scanned.
 
 ## Pairing
 

--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -185,13 +185,13 @@ class ZeroconfScanner(BaseScanner):
 class UnicastMdnsScanner(BaseScanner):
     """Service discovery based on unicast MDNS."""
 
-    def __init__(self, hosts, loop):
+    def __init__(self, hosts: List[str], loop: asyncio.AbstractEventLoop):
         """Initialize a new UnicastMdnsScanner."""
         super().__init__()
         self.hosts = hosts
         self.loop = loop
 
-    async def discover(self, timeout):
+    async def discover(self, timeout: int):
         """Start discovery of devices and services."""
         results = await asyncio.gather(
             *[self._get_services(host, timeout) for host in self.hosts]
@@ -201,8 +201,8 @@ class UnicastMdnsScanner(BaseScanner):
                 self._handle_response(host, response)
         return self._found_devices
 
-    async def _get_services(self, host, timeout):
-        port = os.environ.get("PYATV_UDNS_PORT", 5353)  # For testing purposes
+    async def _get_services(self, host: str, timeout: int):
+        port = int(os.environ.get("PYATV_UDNS_PORT", 5353))  # For testing purposes
         services = [s[0:-1] for s in ALL_SERVICES]
         try:
             response = await udns.request(
@@ -212,7 +212,7 @@ class UnicastMdnsScanner(BaseScanner):
             response = None
         return host, response
 
-    def _handle_response(self, host, response):
+    def _handle_response(self, host: int, response: udns.DnsMessage):
         for resource in response.resources:
             if resource.qtype != udns.QTYPE_TXT:
                 continue

--- a/pyatv/exceptions.py
+++ b/pyatv/exceptions.py
@@ -63,3 +63,7 @@ class PlaybackError(Exception):
 
 class CommandError(Exception):
     """Thrown when a command (e.g. play or pause) failed."""
+
+
+class NonLocalSubnetError(Exception):
+    """Thrown when address it not in any local subnet."""

--- a/pyatv/scripts/__init__.py
+++ b/pyatv/scripts/__init__.py
@@ -24,13 +24,14 @@ class TransformProtocol(argparse.Action):
 
 
 # pylint: disable=too-few-public-methods
-class TransformScanHosts(argparse.Action):
+class VerifyScanHosts(argparse.Action):
     """Transform scan hosts into array."""
 
     def __call__(self, parser, namespace, values, option_string=None):
         """Split hosts and save as array."""
-        ips = [ip_address(ip) for ip in values.split(",")]
-        setattr(namespace, self.dest, ips)
+        ip_split = values.split(",")
+        [ip_address(ip) for ip in ip_split]
+        setattr(namespace, self.dest, ip_split)
 
 
 # pylint: disable=too-few-public-methods

--- a/pyatv/scripts/atvremote.py
+++ b/pyatv/scripts/atvremote.py
@@ -14,7 +14,7 @@ from pyatv.const import Protocol, ShuffleState, RepeatState
 from pyatv.dmap import tag_definitions
 from pyatv.dmap.parser import pprint
 from pyatv.interface import retrieve_commands
-from pyatv.scripts import TransformProtocol, TransformScanHosts
+from pyatv.scripts import TransformProtocol, VerifyScanHosts
 
 
 def _print_commands(title, api):
@@ -358,7 +358,7 @@ async def cli_handler(loop):
         help="scan specific hosts",
         dest="scan_hosts",
         default=None,
-        action=TransformScanHosts,
+        action=VerifyScanHosts,
     )
     parser.add_argument(
         "--version",

--- a/pyatv/scripts/atvscript.py
+++ b/pyatv/scripts/atvscript.py
@@ -21,7 +21,7 @@ from pyatv.interface import (
     DeviceListener,
     retrieve_commands,
 )
-from pyatv.scripts import TransformProtocol, TransformScanHosts, TransformOutput
+from pyatv.scripts import TransformProtocol, VerifyScanHosts, TransformOutput
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -244,7 +244,7 @@ async def appstart(loop):
         help="scan specific hosts",
         dest="scan_hosts",
         default=None,
-        action=TransformScanHosts,
+        action=VerifyScanHosts,
     )
     parser.add_argument(
         "--output",


### PR DESCRIPTION
Unicast scanning only works when the target address is in the same
subnet as the host. Now an exception is raised if unicast scanning is
performed on an address outside of any local subnet.

Fixes #581.