### PR TITLE
mrp: Make connection listener into weakref

### DIFF
--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -3398,6 +3398,7 @@ async def wakeup(self) -&gt; None:
 <li><a title="pyatv.interface.AppleTV" href="#pyatv.interface.AppleTV">AppleTV</a></li>
 <li><a title="pyatv.interface.Power" href="#pyatv.interface.Power">Power</a></li>
 <li><a title="pyatv.interface.PushUpdater" href="#pyatv.interface.PushUpdater">PushUpdater</a></li>
+<li>pyatv.mrp.connection.MrpConnection</li>
 </ul>
 <h3>Instance variables</h3>
 <dl>


### PR DESCRIPTION
MrpConnection and MrpProtocol depends on each other because, so a weak
reference should be used to be more helpful to the garbage collector.