### PR TITLE
udns: Send UDNS request every second

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,13 @@ import pytest
 from pyatv.support.net import unused_port
 
 from tests.fake_knock import create_knock_server
+from tests.utils import stub_sleep
+
+
+@pytest.fixture(autouse=True, name="stub_sleep")
+def stub_sleep_fixture():
+    stub_sleep()
+    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
From now on the UDNS request will be resent every second until timeout
is reached. This should help when sending to a device that is waking up.

Relates to #595.