### PR TITLE
mrp: Add fallback for play_pause

### DIFF
--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -87,6 +87,7 @@ link_group: api
 <ul class="">
 <li><code><a title="pyatv.interface.Features.all_features" href="#pyatv.interface.Features.all_features">all_features</a></code></li>
 <li><code><a title="pyatv.interface.Features.get_feature" href="#pyatv.interface.Features.get_feature">get_feature</a></code></li>
+<li><code><a title="pyatv.interface.Features.in_state" href="#pyatv.interface.Features.in_state">in_state</a></code></li>
 </ul>
 </li>
 <li>
@@ -223,7 +224,17 @@ all its features.
 import re
 import inspect
 import hashlib
-from typing import Any, Dict, Optional, NamedTuple, Callable, TypeVar, Tuple
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    NamedTuple,
+    Callable,
+    TypeVar,
+    Tuple,
+    Union,
+    List,
+)
 import weakref
 
 from abc import ABC, abstractmethod
@@ -973,6 +984,24 @@ class Features(ABC):
             if feature.state != FeatureState.Unsupported or include_unsupported:
                 features[name] = feature
         return features
+
+    def in_state(
+        self,
+        states: Union[List[FeatureState], FeatureState],
+        *feature_names: FeatureName
+    ):
+        &#34;&#34;&#34;Return if features are in a specific state.
+
+        This method will return True if all given features are in the state specified
+        by &#34;states&#34;. If &#34;states&#34; is a list of states, it is enough for the feature to be
+        in one of the listed states.
+        &#34;&#34;&#34;
+        for name in feature_names:
+            feature = self.get_feature(name)
+            expected_states = states if isinstance(states, list) else [states]
+            if feature.state not in expected_states:
+                return False
+        return True
 
 
 class AppleTV(ABC, StateProducer):
@@ -1771,7 +1800,25 @@ def connection_lost(self, exception: Exception) -&gt; None:
             feature = self.get_feature(name)
             if feature.state != FeatureState.Unsupported or include_unsupported:
                 features[name] = feature
-        return features</code></pre>
+        return features
+
+    def in_state(
+        self,
+        states: Union[List[FeatureState], FeatureState],
+        *feature_names: FeatureName
+    ):
+        &#34;&#34;&#34;Return if features are in a specific state.
+
+        This method will return True if all given features are in the state specified
+        by &#34;states&#34;. If &#34;states&#34; is a list of states, it is enough for the feature to be
+        in one of the listed states.
+        &#34;&#34;&#34;
+        for name in feature_names:
+            feature = self.get_feature(name)
+            expected_states = states if isinstance(states, list) else [states]
+            if feature.state not in expected_states:
+                return False
+        return True</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -1816,6 +1863,37 @@ def connection_lost(self, exception: Exception) -&gt; None:
 def get_feature(self, feature: FeatureName) -&gt; FeatureInfo:
     &#34;&#34;&#34;Return current state of a feature.&#34;&#34;&#34;
     raise NotImplementedError()</code></pre>
+</details>
+</dd>
+<dt id="pyatv.interface.Features.in_state"><code class="name flex">
+<span>def <span class="ident">in_state</span></span>(<span>self, states: Union[List[pyatv.const.FeatureState], pyatv.const.FeatureState], *feature_names: <a title="pyatv.const.FeatureName" href="const#pyatv.const.FeatureName">FeatureName</a>)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Return if features are in a specific state.</p>
+<p>This method will return True if all given features are in the state specified
+by "states". If "states" is a list of states, it is enough for the feature to be
+in one of the listed states.</p></section>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def in_state(
+    self,
+    states: Union[List[FeatureState], FeatureState],
+    *feature_names: FeatureName
+):
+    &#34;&#34;&#34;Return if features are in a specific state.
+
+    This method will return True if all given features are in the state specified
+    by &#34;states&#34;. If &#34;states&#34; is a list of states, it is enough for the feature to be
+    in one of the listed states.
+    &#34;&#34;&#34;
+    for name in feature_names:
+        feature = self.get_feature(name)
+        expected_states = states if isinstance(states, list) else [states]
+        if feature.state not in expected_states:
+            return False
+    return True</code></pre>
 </details>
 </dd>
 </dl>

--- a/docs/development/features.md
+++ b/docs/development/features.md
@@ -45,7 +45,26 @@ else:
 The state of all features can be obtained via {% include api i="interface.Features.all_features" %}. By default, this method will exclude unsupported features. Pass `include_unsupported=True` when calling to include state of all features:
 
 ```python
-all_features = ft.features.all_features(include_unsupported=unsupported)
+all_features = ft.all_features(include_unsupported=unsupported)
 for name, feature in all_features.items():
     print(f"{name} = {feature.state}")
+```
+
+There's a helper method, {% include api i="interface.Features.in_state" %}, that checks if one or
+more features are in one or several states:
+
+```python
+# Check if Play is available
+if ft.in_state(FeatureState.Available, FeatureName.Play):
+    pass
+
+# Check if Play is either available or unsupported
+if ft.in_state([FeatureState.Available, FeatureState.Unsupported],
+               FeatureName.Play):
+    pass
+
+# Check if Play *and* Pause are supported
+if not ft.in_state(FeatureName.Unsupported, FeatureName.Play, FeatureName.Pause):
+    pass
+
 ```

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -7,7 +7,17 @@ all its features.
 import re
 import inspect
 import hashlib
-from typing import Any, Dict, Optional, NamedTuple, Callable, TypeVar, Tuple
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    NamedTuple,
+    Callable,
+    TypeVar,
+    Tuple,
+    Union,
+    List,
+)
 import weakref
 
 from abc import ABC, abstractmethod
@@ -757,6 +767,24 @@ class Features(ABC):
             if feature.state != FeatureState.Unsupported or include_unsupported:
                 features[name] = feature
         return features
+
+    def in_state(
+        self,
+        states: Union[List[FeatureState], FeatureState],
+        *feature_names: FeatureName
+    ):
+        """Return if features are in a specific state.
+
+        This method will return True if all given features are in the state specified
+        by "states". If "states" is a list of states, it is enough for the feature to be
+        in one of the listed states.
+        """
+        for name in feature_names:
+            feature = self.get_feature(name)
+            expected_states = states if isinstance(states, list) else [states]
+            if feature.state not in expected_states:
+                return False
+        return True
 
 
 class AppleTV(ABC, StateProducer):

--- a/tests/common_functional_tests.py
+++ b/tests/common_functional_tests.py
@@ -187,11 +187,6 @@ class CommonFunctionalTests(AioHTTPTestCase):
         await until(lambda: self.state.last_button_pressed == "play")
 
     @unittest_run_loop
-    async def test_button_play_pause(self):
-        await self.atv.remote_control.play_pause()
-        await until(lambda: self.state.last_button_pressed == "playpause")
-
-    @unittest_run_loop
     async def test_button_pause(self):
         await self.atv.remote_control.pause()
         await until(lambda: self.state.last_button_pressed == "pause")

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -154,6 +154,11 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         await until(lambda: self.state.last_button_pressed == "topmenu")
 
     @unittest_run_loop
+    async def test_button_play_pause(self):
+        await self.atv.remote_control.play_pause()
+        await until(lambda: self.state.last_button_pressed == "playpause")
+
+    @unittest_run_loop
     async def test_shuffle_state_albums(self):
         # DMAP does not support "albums" as shuffle state, so it is
         # mapped to "songs"

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,6 +1,7 @@
 """Unit tests for pyatv.interface."""
 
-import unittest
+import pytest
+from typing import Dict
 
 from pyatv import convert, exceptions, interface
 from pyatv.interface import FeatureInfo
@@ -142,174 +143,214 @@ class MetadataDummy(interface.Metadata):
 
 
 class FeaturesDummy(interface.Features):
-    def __init__(self, state):
-        self.state = state
+    def __init__(self, feature_map: Dict[FeatureName, FeatureState]):
+        self.feature_map = feature_map
 
     def get_feature(self, feature: FeatureName) -> FeatureInfo:
         """Return current state of a feature."""
-        return FeatureInfo(state=self.state)
+        if feature not in self.feature_map:
+            state = FeatureState.Unsupported
+        else:
+            state = self.feature_map[feature]
+        return FeatureInfo(state=state)
 
 
-class InterfaceTest(unittest.TestCase):
-    def setUp(self):
-        self.methods = interface.retrieve_commands(TestClass)
+@pytest.fixture
+def methods():
+    yield interface.retrieve_commands(TestClass)
 
-    # COMMANDS AND HELP TEXT
 
-    def test_get_commands(self):
-        self.assertEqual(5, len(self.methods))
-        self.assertTrue("test_method" in self.methods)
-        self.assertTrue("another_method" in self.methods)
-        self.assertTrue("some_property" in self.methods)
-        self.assertTrue("abbrev_help" in self.methods)
+# COMMANDS
 
-    def test_get_first_sentence_without_leading_period_in_pydoc(self):
-        self.assertEqual("Help text", self.methods["test_method"])
-        self.assertEqual("Some other help text", self.methods["another_method"])
-        self.assertEqual("Property help", self.methods["some_property"])
 
-    def test_try_to_be_smart_with_abbreviations(self):
-        self.assertEqual("Type, e.g. a, b or c", self.methods["abbrev_help"])
-        self.assertEqual("Type, e.g. a, b or c", self.methods["abbrev_help_more_text"])
+def test_get_commands(methods):
+    assert len(methods) == 5
+    assert "test_method" in methods
+    assert "another_method" in methods
+    assert "some_property" in methods
+    assert "abbrev_help" in methods
 
-    # PLAYING STR
 
-    def test_playing_media_type_and_playstate(self):
-        out = str(PlayingDummy())
-        self.assertIn(convert.media_type_str(MediaType.Video), out)
-        self.assertIn(convert.device_state_str(DeviceState.Playing), out)
+def test_get_first_sentence_without_leading_period_in_pydoc(methods):
+    assert "Help text" == methods["test_method"]
+    assert "Some other help text" == methods["another_method"]
+    assert "Property help" == methods["some_property"]
 
-    def test_playing_title_artist_album_genre(self):
-        out = str(
-            PlayingDummy(
-                title="mytitle", artist="myartist", album="myalbum", genre="mygenre"
-            )
+
+def test_try_to_be_smart_with_abbreviations(methods):
+    assert "Type, e.g. a, b or c" == methods["abbrev_help"]
+    assert "Type, e.g. a, b or c" == methods["abbrev_help_more_text"]
+
+
+# PLAYING
+
+
+def test_playing_media_type_and_playstate():
+    out = str(PlayingDummy())
+    assert convert.media_type_str(MediaType.Video) in out
+    assert convert.device_state_str(DeviceState.Playing) in out
+
+
+def test_playing_title_artist_album_genre():
+    out = str(
+        PlayingDummy(
+            title="mytitle", artist="myartist", album="myalbum", genre="mygenre"
         )
-        self.assertIn("mytitle", out)
-        self.assertIn("myartist", out)
-        self.assertIn("myalbum", out)
-        self.assertIn("mygenre", out)
-
-    def test_playing_only_position(self):
-        self.assertIn("1234", str(PlayingDummy(position=1234)))
-
-    def test_playing_only_total_time(self):
-        self.assertIn("5678", str(PlayingDummy(total_time=5678)))
-
-    def test_playing_both_position_and_total_time(self):
-        out = str(PlayingDummy(position=1234, total_time=5678))
-        self.assertIn("1234/5678", out)
-
-    def test_playing_shuffle_and_repeat(self):
-        out = str(PlayingDummy())
-        self.assertIn("Shuffle: Songs", out)
-        self.assertIn("Repeat: Track", out)
-
-    # OTHER
-
-    def test_playing_generate_same_hash(self):
-        playing = PlayingDummy(
-            title="title", artist="artist", album="album", total_time=123
-        )
-        self.assertEqual(
-            "538df531d1715629fdd87affd0c5957bcbf54cd89180778071e6535b7df4e22c",
-            playing.hash,
-        )
-
-        playing2 = PlayingDummy(
-            title="dummy", artist="test", album="none", total_time=321
-        )
-        self.assertEqual(
-            "80045c05d18382f33a5369fd5cdfc6ae42c3eb418125f638d7a31ab173b01ade",
-            playing2.hash,
-        )
-
-    # METADATA
-
-    def test_metadata_device_id(self):
-        self.assertEqual(MetadataDummy("dummy").device_id, "dummy")
-
-    # Dummy test for the sake of code coverage
-    def test_metadata_rest_not_supported(self):
-        metadata = MetadataDummy("dummy")
-
-        with self.assertRaises(exceptions.NotSupportedError):
-            metadata.artwork()
-        with self.assertRaises(exceptions.NotSupportedError):
-            metadata.artwork_id()
-        with self.assertRaises(exceptions.NotSupportedError):
-            metadata.playing()
+    )
+    assert "mytitle" in out
+    assert "myartist" in out
+    assert "myalbum" in out
+    assert "mygenre" in out
 
 
-class DeviceInfoTest(unittest.TestCase):
-    def test_fields_set(self):
-        dev_info = interface.DeviceInfo(
-            OperatingSystem.TvOS,
-            "1.2.3",
-            "19A123",
-            DeviceModel.Gen4K,
-            "aa:bb:cc:dd:ee:ff",
-        )
-
-        self.assertEqual(dev_info.operating_system, OperatingSystem.TvOS)
-        self.assertEqual(dev_info.version, "1.2.3")
-        self.assertEqual(dev_info.build_number, "19A123")
-        self.assertEqual(dev_info.model, DeviceModel.Gen4K)
-        self.assertEqual(dev_info.mac, "aa:bb:cc:dd:ee:ff")
-
-    def test_apple_tv_software_str(self):
-        dev_info = interface.DeviceInfo(
-            OperatingSystem.Legacy,
-            "2.2.3",
-            "13D333",
-            DeviceModel.Gen3,
-            "aa:bb:cc:dd:ee:ff",
-        )
-
-        self.assertEqual(str(dev_info), "3 ATV SW 2.2.3 build 13D333")
-
-    def test_tvos_str(self):
-        dev_info = interface.DeviceInfo(
-            OperatingSystem.TvOS,
-            "1.2.3",
-            "19A123",
-            DeviceModel.Gen4K,
-            "aa:bb:cc:dd:ee:ff",
-        )
-
-        self.assertEqual(str(dev_info), "4K tvOS 1.2.3 build 19A123")
-
-    def test_unknown_str(self):
-        dev_info = interface.DeviceInfo(
-            OperatingSystem.Unknown, None, None, DeviceModel.Unknown, None
-        )
-
-        self.assertEqual(str(dev_info), "Unknown Model Unknown OS")
+def test_playing_only_position():
+    assert "1234" in str(PlayingDummy(position=1234))
 
 
-class FeaturesTest(unittest.TestCase):
-    def test_all_unsupported_features(self):
-        features = FeaturesDummy(FeatureState.Unsupported)
-        self.assertFalse(features.all_features())
-
-    def test_all_include_unsupported_features(self):
-        features = FeaturesDummy(FeatureState.Unsupported)
-        all_features = features.all_features(include_unsupported=True)
-
-        self.assertEqual(set(all_features.keys()), set(FeatureName))
-        self.assertEqual(
-            set([ft.state for ft in all_features.values()]),
-            set([FeatureState.Unsupported]),
-        )
+def test_playing_only_total_time():
+    assert "5678" in str(PlayingDummy(total_time=5678))
 
 
-class AppTest(unittest.TestCase):
-    def setUp(self):
-        self.app = interface.App("name", "id")
+def test_playing_both_position_and_total_time():
+    out = str(PlayingDummy(position=1234, total_time=5678))
+    assert "1234/5678" in out
 
-    def test_app_properties(self):
-        self.assertEqual(self.app.name, "name")
-        self.assertEqual(self.app.identifier, "id")
 
-    def test_app_str(self):
-        self.assertEqual("App: name (id)", str(self.app))
+def test_playing_shuffle_and_repeat():
+    out = str(PlayingDummy())
+    assert "Shuffle: Songs" in out
+    assert "Repeat: Track" in out
+
+
+def test_playing_generate_same_hash():
+    playing = PlayingDummy(
+        title="title", artist="artist", album="album", total_time=123
+    )
+    assert (
+        "538df531d1715629fdd87affd0c5957bcbf54cd89180778071e6535b7df4e22c"
+        == playing.hash
+    )
+
+    playing2 = PlayingDummy(title="dummy", artist="test", album="none", total_time=321)
+
+    assert (
+        "80045c05d18382f33a5369fd5cdfc6ae42c3eb418125f638d7a31ab173b01ade"
+        == playing2.hash
+    )
+
+
+# METADATA
+
+
+def test_metadata_device_id():
+    assert MetadataDummy("dummy").device_id == "dummy"
+
+
+def test_metadata_rest_not_supported():
+    metadata = MetadataDummy("dummy")
+
+    with pytest.raises(exceptions.NotSupportedError):
+        metadata.artwork()
+    with pytest.raises(exceptions.NotSupportedError):
+        metadata.artwork_id()
+    with pytest.raises(exceptions.NotSupportedError):
+        metadata.playing()
+
+
+# DEVICE INFO
+
+
+def test_fields_set():
+    dev_info = interface.DeviceInfo(
+        OperatingSystem.TvOS, "1.2.3", "19A123", DeviceModel.Gen4K, "aa:bb:cc:dd:ee:ff",
+    )
+
+    assert dev_info.operating_system == OperatingSystem.TvOS
+    assert dev_info.version == "1.2.3"
+    assert dev_info.build_number == "19A123"
+    assert dev_info.model == DeviceModel.Gen4K
+    assert dev_info.mac == "aa:bb:cc:dd:ee:ff"
+
+
+def test_apple_tv_software_str():
+    dev_info = interface.DeviceInfo(
+        OperatingSystem.Legacy,
+        "2.2.3",
+        "13D333",
+        DeviceModel.Gen3,
+        "aa:bb:cc:dd:ee:ff",
+    )
+
+    assert str(dev_info) == "3 ATV SW 2.2.3 build 13D333"
+
+
+def test_tvos_str():
+    dev_info = interface.DeviceInfo(
+        OperatingSystem.TvOS, "1.2.3", "19A123", DeviceModel.Gen4K, "aa:bb:cc:dd:ee:ff",
+    )
+
+    assert str(dev_info) == "4K tvOS 1.2.3 build 19A123"
+
+
+def test_unknown_str():
+    dev_info = interface.DeviceInfo(
+        OperatingSystem.Unknown, None, None, DeviceModel.Unknown, None
+    )
+
+    assert str(dev_info) == "Unknown Model Unknown OS"
+
+
+# FEATURES
+
+
+def test_all_unsupported_features():
+    features = FeaturesDummy({FeatureName.Play: FeatureState.Unsupported})
+    assert not features.all_features()
+
+
+def test_all_include_unsupported_features():
+    features = FeaturesDummy({FeatureName.Play: FeatureState.Unsupported})
+    all_features = features.all_features(include_unsupported=True)
+
+    assert set(all_features.keys()) == set(FeatureName)
+    assert set([ft.state for ft in all_features.values()]) == set(
+        [FeatureState.Unsupported]
+    )
+
+
+def test_features_in_state():
+    features = FeaturesDummy(
+        {
+            FeatureName.Play: FeatureState.Unsupported,
+            FeatureName.Pause: FeatureState.Available,
+        }
+    )
+
+    assert not features.in_state(FeatureState.Unknown, FeatureName.Play)
+    assert not features.in_state([FeatureState.Unknown], FeatureName.Play)
+    assert features.in_state(FeatureState.Unsupported, FeatureName.Play)
+    assert features.in_state([FeatureState.Unsupported], FeatureName.Play)
+
+    assert not features.in_state(
+        [FeatureState.Unsupported], FeatureName.Play, FeatureName.Pause
+    )
+
+    assert features.in_state(
+        [FeatureState.Unsupported, FeatureState.Available],
+        FeatureName.Play,
+        FeatureName.Pause,
+    )
+
+
+# APP
+
+
+def test_app_properties():
+    app = interface.App("name", "id")
+    assert app.name == "name"
+    assert app.identifier == "id"
+
+
+def test_app_str():
+    app = interface.App("name", "id")
+    assert "App: name (id)" == str(app)


### PR DESCRIPTION
If the "play_pause" feature isn't supported by the running app, emulate
it by sending play or pause depending on device state.

Fixes #597.