### PR TITLE
cq: Fix warnings from tests

### DIFF
--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -610,9 +610,7 @@ class MrpAppleTV(AppleTV):
             config.address, self._mrp_service.port, loop, atv=self
         )
         self._srp = SRPAuthHandler()
-        self._protocol = MrpProtocol(
-            loop, self._connection, self._srp, self._mrp_service
-        )
+        self._protocol = MrpProtocol(self._connection, self._srp, self._mrp_service)
         self._psm = PlayerStateManager(self._protocol, loop)
 
         self._mrp_remote = MrpRemoteControl(loop, self._psm, self._protocol)

--- a/pyatv/mrp/pairing.py
+++ b/pyatv/mrp/pairing.py
@@ -22,7 +22,7 @@ class MrpPairingHandler(PairingHandler):
         super().__init__(session, config.get_service(Protocol.MRP))
         self.connection = MrpConnection(config.address, self.service.port, loop)
         self.srp = SRPAuthHandler()
-        self.protocol = MrpProtocol(loop, self.connection, self.srp, self.service)
+        self.protocol = MrpProtocol(self.connection, self.srp, self.service)
         self.pairing_procedure = MrpPairingProcedure(self.protocol, self.srp)
         self.pin_code = None
         self._has_paired = False

--- a/pyatv/mrp/protocol.py
+++ b/pyatv/mrp/protocol.py
@@ -29,9 +29,8 @@ class MrpProtocol:
     It provides an API for sending and receiving messages.
     """
 
-    def __init__(self, loop, connection, srp, service):
+    def __init__(self, connection, srp, service):
         """Initialize a new MrpProtocol."""
-        self.loop = loop
         self.connection = connection
         self.connection.listener = self
         self.srp = srp
@@ -139,12 +138,12 @@ class MrpProtocol:
         return await self._receive(identifier, timeout)
 
     async def _receive(self, identifier, timeout):
-        semaphore = asyncio.Semaphore(value=0, loop=self.loop)
+        semaphore = asyncio.Semaphore(value=0)
         self._outstanding[identifier] = OutstandingMessage(semaphore, None)
 
         try:
             # The connection instance will dispatch the message
-            await asyncio.wait_for(semaphore.acquire(), timeout, loop=self.loop)
+            await asyncio.wait_for(semaphore.acquire(), timeout)
 
         except:  # noqa
             del self._outstanding[identifier]
@@ -176,4 +175,4 @@ class MrpProtocol:
                 type(message.inner()).__name__,
                 listener,
             )
-            asyncio.ensure_future(listener.func(message, listener.data), loop=self.loop)
+            asyncio.ensure_future(listener.func(message, listener.data))

--- a/pyatv/scripts/atvproxy.py
+++ b/pyatv/scripts/atvproxy.py
@@ -78,7 +78,6 @@ class MrpAppleTVProxy(MrpServerAuth, asyncio.Protocol):
         """Start the proxy instance."""
         self.connection = MrpConnection(address, port, self.loop)
         protocol = MrpProtocol(
-            self.loop,
             self.connection,
             SRPAuthHandler(),
             MrpService(None, port, credentials=credentials),

--- a/pyatv/support/udns.py
+++ b/pyatv/support/udns.py
@@ -203,21 +203,20 @@ class DnsMessage:
 class UnicastDnsSdClientProtocol(asyncio.Protocol):
     """Protocol to make unicast MDNS requests."""
 
-    def __init__(self, loop, services, host, timeout):
+    def __init__(self, services, host, timeout):
         """Initialize a new UnicastDnsSdClientProtocol."""
         self.message = create_request(services)
         self.host = host
         self.timeout = timeout
-        self.loop = loop
         self.transport = None
-        self.semaphore = asyncio.Semaphore(value=0, loop=loop)
+        self.semaphore = asyncio.Semaphore(value=0)
         self.result = None
         self._task = None
 
     async def get_response(self):
         """Get respoonse with a maximum timeout."""
         await asyncio.wait_for(
-            self.semaphore.acquire(), timeout=self.timeout, loop=self.loop
+            self.semaphore.acquire(), timeout=self.timeout,
         )
         return self.result
 
@@ -273,7 +272,7 @@ async def request(
         )
 
     transport, protocol = await loop.create_datagram_endpoint(
-        lambda: UnicastDnsSdClientProtocol(loop, services, address, timeout),
+        lambda: UnicastDnsSdClientProtocol(services, address, timeout),
         remote_addr=(address, port),
     )
 

--- a/tests/mrp/test_mrp_auth.py
+++ b/tests/mrp/test_mrp_auth.py
@@ -23,7 +23,7 @@ class MrpAuthFunctionalTest(AioHTTPTestCase):
         self.conf.add_service(self.service)
 
     async def tearDownAsync(self):
-        if inspect.iscoroutinefunction(self.handle):
+        if inspect.iscoroutinefunction(self.handle.close):
             await self.handle.close()
         else:
             self.handle.close()

--- a/tests/support/test_support.py
+++ b/tests/support/test_support.py
@@ -12,7 +12,7 @@ from pyatv.support import error_handler, log_binary, log_protobuf
 from pyatv.mrp.protobuf import ProtocolMessage
 
 
-class TestException(Exception):
+class DummyException(Exception):
     pass
 
 
@@ -46,32 +46,32 @@ async def test_error_handler_return_value():
     async def _returns():
         return 123
 
-    assert await error_handler(_returns, TestException) == 123
+    assert await error_handler(_returns, DummyException) == 123
 
 
 async def test_error_handleroserror():
     with pytest.raises(exceptions.ConnectionFailedError):
-        await error_handler(doraise, TestException, OSError)
+        await error_handler(doraise, DummyException, OSError)
 
 
 async def test_error_handler_timeout():
     with pytest.raises(exceptions.ConnectionFailedError):
-        await error_handler(doraise, TestException, asyncio.TimeoutError)
+        await error_handler(doraise, DummyException, asyncio.TimeoutError)
 
 
 async def test_error_handler_backoff():
     with pytest.raises(exceptions.BackOffError):
-        await error_handler(doraise, TestException, exceptions.BackOffError)
+        await error_handler(doraise, DummyException, exceptions.BackOffError)
 
 
 async def test_error_handler_no_credentials():
     with pytest.raises(exceptions.NoCredentialsError):
-        await error_handler(doraise, TestException, exceptions.NoCredentialsError)
+        await error_handler(doraise, DummyException, exceptions.NoCredentialsError)
 
 
 async def test_error_handler_other_exception():
-    with pytest.raises(TestException):
-        await error_handler(doraise, TestException, Exception)
+    with pytest.raises(DummyException):
+        await error_handler(doraise, DummyException, Exception)
 
 
 def test_log_binary_no_log_if_not_debug(logger):


### PR DESCRIPTION
This fixes all warnings provided by pytest that is within pyatv.
Remaining warnings come from dependencies.