### PR TITLE
atvscript: Add start log entry

### DIFF
--- a/pyatv/scripts/atvscript.py
+++ b/pyatv/scripts/atvscript.py
@@ -302,6 +302,8 @@ async def appstart(loop):
 
     loop.set_exception_handler(_handle_exception)
 
+    _LOGGER.debug("Started atvscript")
+
     try:
         print(args.output(await _handle_command(args, abort_sem, loop)), flush=True)
     except Exception as ex:


### PR DESCRIPTION
Add a line that is printed when the script is started to make it easier
to separate different runs because of append mode.