### PR TITLE
Support for retrieving artwork of arbitrary size

### DIFF
--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -48,7 +48,9 @@ link_group: api
 <h4><code><a title="pyatv.interface.ArtworkInfo" href="#pyatv.interface.ArtworkInfo">ArtworkInfo</a></code></h4>
 <ul class="">
 <li><code><a title="pyatv.interface.ArtworkInfo.bytes" href="#pyatv.interface.ArtworkInfo.bytes">bytes</a></code></li>
+<li><code><a title="pyatv.interface.ArtworkInfo.height" href="#pyatv.interface.ArtworkInfo.height">height</a></code></li>
 <li><code><a title="pyatv.interface.ArtworkInfo.mimetype" href="#pyatv.interface.ArtworkInfo.mimetype">mimetype</a></code></li>
+<li><code><a title="pyatv.interface.ArtworkInfo.width" href="#pyatv.interface.ArtworkInfo.width">width</a></code></li>
 </ul>
 </li>
 <li>
@@ -264,6 +266,8 @@ class ArtworkInfo(NamedTuple):
 
     bytes: bytes
     mimetype: str
+    width: int
+    height: int
 
 
 class FeatureInfo(NamedTuple):
@@ -772,8 +776,15 @@ class Metadata(ABC):
 
     @abstractmethod
     @feature(30, &#34;Artwork&#34;, &#34;Playing media artwork.&#34;)
-    async def artwork(self) -&gt; Optional[ArtworkInfo]:
-        &#34;&#34;&#34;Return artwork for what is currently playing (or None).&#34;&#34;&#34;
+    async def artwork(self, width=512, height=None) -&gt; Optional[ArtworkInfo]:
+        &#34;&#34;&#34;Return artwork for what is currently playing (or None).
+
+        The parameters &#34;width&#34; and &#34;height&#34; makes it possible to request artwork of a
+        specific size. This is just a request, the device might impose restrictions and
+        return artwork of a different size. Set both parameters to None to request
+        default size. Set one of them and let the other one be None to keep original
+        aspect ratio.
+        &#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @property
@@ -1421,7 +1432,7 @@ async def connect(self) -&gt; None:
 </dd>
 <dt id="pyatv.interface.ArtworkInfo"><code class="flex name class">
 <span>class <span class="ident">ArtworkInfo</span></span>
-<span>(</span><span>bytes: bytes, mimetype: str)</span>
+<span>(</span><span>bytes: bytes, mimetype: str, width: int, height: int)</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Artwork information.</p></section>
@@ -1433,7 +1444,9 @@ async def connect(self) -&gt; None:
     &#34;&#34;&#34;Artwork information.&#34;&#34;&#34;
 
     bytes: bytes
-    mimetype: str</code></pre>
+    mimetype: str
+    width: int
+    height: int</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -1445,9 +1458,17 @@ async def connect(self) -&gt; None:
 <dd>
 <section class="desc"><p>Alias for field number 0</p></section>
 </dd>
+<dt id="pyatv.interface.ArtworkInfo.height"><code class="name">var <span class="ident">height</span> -> int</code></dt>
+<dd>
+<section class="desc"><p>Alias for field number 3</p></section>
+</dd>
 <dt id="pyatv.interface.ArtworkInfo.mimetype"><code class="name">var <span class="ident">mimetype</span> -> str</code></dt>
 <dd>
 <section class="desc"><p>Alias for field number 1</p></section>
+</dd>
+<dt id="pyatv.interface.ArtworkInfo.width"><code class="name">var <span class="ident">width</span> -> int</code></dt>
+<dd>
+<section class="desc"><p>Alias for field number 2</p></section>
 </dd>
 </dl>
 </dd>
@@ -1923,8 +1944,15 @@ in one of the listed states.</p></section>
 
     @abstractmethod
     @feature(30, &#34;Artwork&#34;, &#34;Playing media artwork.&#34;)
-    async def artwork(self) -&gt; Optional[ArtworkInfo]:
-        &#34;&#34;&#34;Return artwork for what is currently playing (or None).&#34;&#34;&#34;
+    async def artwork(self, width=512, height=None) -&gt; Optional[ArtworkInfo]:
+        &#34;&#34;&#34;Return artwork for what is currently playing (or None).
+
+        The parameters &#34;width&#34; and &#34;height&#34; makes it possible to request artwork of a
+        specific size. This is just a request, the device might impose restrictions and
+        return artwork of a different size. Set both parameters to None to request
+        default size. Set one of them and let the other one be None to keep original
+        aspect ratio.
+        &#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @property
@@ -2015,18 +2043,30 @@ def device_id(self) -&gt; Optional[str]:
 <h3>Methods</h3>
 <dl>
 <dt id="pyatv.interface.Metadata.artwork"><code class="name flex">
-<span>async def <span class="ident">artwork</span></span>(<span>self) -> Union[<a title="pyatv.interface.ArtworkInfo" href="#pyatv.interface.ArtworkInfo">ArtworkInfo</a>, NoneType]</span>
+<span>async def <span class="ident">artwork</span></span>(<span>self, width=512, height=None) -> Union[<a title="pyatv.interface.ArtworkInfo" href="#pyatv.interface.ArtworkInfo">ArtworkInfo</a>, NoneType]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Return artwork for what is currently playing (or None).</p></section>
+<section class="desc"><p>Return artwork for what is currently playing (or None).</p>
+<p>The parameters "width" and "height" makes it possible to request artwork of a
+specific size. This is just a request, the device might impose restrictions and
+return artwork of a different size. Set both parameters to None to request
+default size. Set one of them and let the other one be None to keep original
+aspect ratio.</p></section>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">@abstractmethod
 @feature(30, &#34;Artwork&#34;, &#34;Playing media artwork.&#34;)
-async def artwork(self) -&gt; Optional[ArtworkInfo]:
-    &#34;&#34;&#34;Return artwork for what is currently playing (or None).&#34;&#34;&#34;
+async def artwork(self, width=512, height=None) -&gt; Optional[ArtworkInfo]:
+    &#34;&#34;&#34;Return artwork for what is currently playing (or None).
+
+    The parameters &#34;width&#34; and &#34;height&#34; makes it possible to request artwork of a
+    specific size. This is just a request, the device might impose restrictions and
+    return artwork of a different size. Set both parameters to None to request
+    default size. Set one of them and let the other one be None to keep original
+    aspect ratio.
+    &#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
 </dd>

--- a/docs/development/metadata.md
+++ b/docs/development/metadata.md
@@ -42,11 +42,24 @@ To retrieve the artwork, use the asynchronous artwork method:
 artwork = await atv.metadata.artwork()
 ```
 
-This will return an {% include api i="interface.ArtworkInfo" %}, containing the image bytes and mimetype. If no artwork is available,
-`None` is returned instead.
+This will return an {% include api i="interface.ArtworkInfo" %}, containing the image bytes,
+mimetype and dimensions. If no artwork is available, `None` is returned instead. If dimensions
+could not be determined by the device, `width` and `height` will be set to -1.
+
+It is also possible to request artwork with a particular size by passing `width` and `height`:
+
+```python
+artwork = await atv.metadata.artwork(width=300, height=200)
+```
+
+Do note that this is the desired size and the device might return artwork with another size,
+e.g. to keep aspect ratio or if specified size it not available. You can pass `None` as one
+of the arguments to let the device maintain aspect ratio of the image.
 
 Remember that the artwork is relatively large, so you should try to minimize
 this call. More information is available at  {% include api i="interface.Metadata.artwork" %}.
+Internally, a small cache is used for the last few requested artworks. The size of this cache
+is not yet configurable and you should write a feature request if you need to change it.
 
 ## Device identifier
 

--- a/docs/documentation/atvremote.md
+++ b/docs/documentation/atvremote.md
@@ -329,6 +329,12 @@ Play a video via AirPlay:
 
     $ atvremote --id 00:11:22:33:44:54 play_url=http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
 
+Artwork with a specific size (width,height):
+
+    $ atvremote --id 00:11:22:33:44:54 artwork_save=300,-1
+
+Using -1 will let the device decide that parameter in order to keep aspect ratio.
+
 If you want additional help for a specific command, use help:
 
     $ atvremote help pair

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -114,10 +114,14 @@ class BaseDmapAppleTV:
         self.latest_hash = self.latest_playing.hash
         return self.latest_playing
 
-    async def artwork(self):
-        """Return an image file (png) for what is currently playing.
+    async def artwork(self, width=None, height=None) -> Optional[ArtworkInfo]:
+        """Return artwork for what is currently playing (or None).
 
-        None is returned if no artwork is available. Must be logged in.
+        The parameters "width" and "height" makes it possible to request artwork of a
+        specific size. This is just a request, the device might impose restrictions and
+        return artwork of a different size. Set both parameters to None to request
+        default size. Set one of them and let the other one be None to keep original
+        aspect ratio.
         """
         art = await self.daap.get(_ARTWORK_CMD, daap_data=False)
         return art if art != b"" else None

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -47,6 +47,8 @@ class ArtworkInfo(NamedTuple):
 
     bytes: bytes
     mimetype: str
+    width: int
+    height: int
 
 
 class FeatureInfo(NamedTuple):
@@ -555,8 +557,15 @@ class Metadata(ABC):
 
     @abstractmethod
     @feature(30, "Artwork", "Playing media artwork.")
-    async def artwork(self) -> Optional[ArtworkInfo]:
-        """Return artwork for what is currently playing (or None)."""
+    async def artwork(self, width=512, height=None) -> Optional[ArtworkInfo]:
+        """Return artwork for what is currently playing (or None).
+
+        The parameters "width" and "height" makes it possible to request artwork of a
+        specific size. This is just a request, the device might impose restrictions and
+        return artwork of a different size. Set both parameters to None to request
+        default size. Set one of them and let the other one be None to keep original
+        aspect ratio.
+        """
         raise exceptions.NotSupportedError()
 
     @property

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -407,8 +407,15 @@ class MrpMetadata(Metadata):
         self.psm = psm
         self.artwork_cache = Cache(limit=4)
 
-    async def artwork(self):
-        """Return artwork for what is currently playing (or None)."""
+    async def artwork(self, width=None, height=None) -> Optional[ArtworkInfo]:
+        """Return artwork for what is currently playing (or None).
+
+        The parameters "width" and "height" makes it possible to request artwork of a
+        specific size. This is just a request, the device might impose restrictions and
+        return artwork of a different size. Set both parameters to None to request
+        default size. Set one of them and let the other one be None to keep original
+        aspect ratio.
+        """
         identifier = self.artwork_id
         if not identifier:
             _LOGGER.debug("No artwork available")
@@ -434,7 +441,12 @@ class MrpMetadata(Metadata):
             return None
 
         item = resp.inner().playbackQueue.contentItems[playing.location]
-        return ArtworkInfo(item.artworkData, playing.metadata.artworkMIMEType)
+        return ArtworkInfo(
+            bytes=item.artworkData,
+            mimetype=playing.metadata.artworkMIMEType,
+            width=-1,
+            height=-1,
+        )
 
     @property
     def artwork_id(self):

--- a/pyatv/scripts/atvremote.py
+++ b/pyatv/scripts/atvremote.py
@@ -227,9 +227,9 @@ class DeviceCommands:
 
             await _handle_device_command(self.args, command, self.atv, self.loop)
 
-    async def artwork_save(self):
+    async def artwork_save(self, width=None, height=None):
         """Download artwork and save it to artwork.png."""
-        artwork = await self.atv.metadata.artwork()
+        artwork = await self.atv.metadata.artwork(width=width, height=height)
         if artwork is not None:
             with open("artwork.png", "wb") as file:
                 file.write(artwork.bytes)

--- a/tests/common_functional_tests.py
+++ b/tests/common_functional_tests.py
@@ -26,6 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 ARTWORK_BYTES = b"1234"
 ARTWORK_BYTES2 = b"4321"
 ARTWORK_MIMETYPE = "image/png"
+ARTWORK_WIDTH = 512
+ARTWORK_HEIGHT = 512
 ARTWORK_ID = "artwork_id1"
 EXAMPLE_STREAM = "http://stream"
 

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -122,6 +122,23 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         self.assertEqual(artwork.bytes, ARTWORK_BYTES)
 
     @unittest_run_loop
+    async def test_metadata_artwork_size(self):
+        self.usecase.example_video()
+        self.usecase.change_artwork(ARTWORK_BYTES, ARTWORK_MIMETYPE)
+        await self.playing(title="dummy")
+
+        # DMAP does not indicate dimensions of artwork, so -1 is returned here. In the
+        # future, extracting dimensions from PNG header should be feasible.
+        artwork = await self.atv.metadata.artwork(width=123, height=456)
+        self.assertIsNotNone(artwork)
+        self.assertEqual(artwork.width, -1)
+        self.assertEqual(artwork.height, -1)
+
+        # Verify that the specified width and height was requested
+        self.assertEqual(self.state.last_artwork_width, 123)
+        self.assertEqual(self.state.last_artwork_height, 456)
+
+    @unittest_run_loop
     async def test_login_with_pairing_guid_succeed(self):
         self.atv.close()
         self.atv = await self.get_connected_device(PAIRING_GUID)

--- a/tests/fake_device/dmap.py
+++ b/tests/fake_device/dmap.py
@@ -348,7 +348,9 @@ class FakeDmapUseCases:
         """Call this method to make login fail with response 503."""
         self.state.login_response = LoginResponse(0, 503)
 
-    def change_artwork(self, artwork, mimetype, identifier=None):
+    def change_artwork(
+        self, artwork, mimetype, identifier=None, width=None, height=None
+    ):
         """Call this method to change artwork response."""
         self.state.playing.artwork = artwork
         self.state.playing.artwork_status = 200

--- a/tests/fake_device/dmap.py
+++ b/tests/fake_device/dmap.py
@@ -70,6 +70,8 @@ class FakeDmapState:
         self.volume_controls = False
         self.last_button_pressed = None
         self.buttons_press_count = 0
+        self.last_artwork_width = None
+        self.last_artwork_height = None
 
     async def trigger_bonjour(self, stubbed_zeroconf):
         """Act upon available Bonjour services."""
@@ -192,8 +194,16 @@ class FakeDmapService:
     async def handle_artwork(self, request):
         """Handle artwork requests."""
         self._verify_auth_parameters(request)
-        playing = self.state.playing
-        return web.Response(body=playing.artwork, status=playing.artwork_status)
+
+        if "mh" in request.query:
+            self.state.last_artwork_height = int(request.query.get("mh"))
+
+        if "mw" in request.query:
+            self.state.last_artwork_width = int(request.query.get("mw"))
+
+        return web.Response(
+            body=self.state.playing.artwork, status=self.state.playing.artwork_status
+        )
 
     async def handle_playstatus(self, request):
         """Handle  playstatus (currently playing) requests."""

--- a/tests/mrp/test_mrp_functional.py
+++ b/tests/mrp/test_mrp_functional.py
@@ -105,6 +105,20 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         self.assertEqual(self.atv.metadata.artwork_id, "some_id")
 
     @unittest_run_loop
+    async def test_metadata_artwork_width_and_height(self):
+        self.usecase.example_video()
+        self.usecase.change_artwork(
+            ARTWORK_BYTES, ARTWORK_MIMETYPE, width=111, height=222
+        )
+
+        await self.playing(title="dummy")
+
+        # Request one size but simulate that a smaller artwork was returned
+        artwork = await self.atv.metadata.artwork(width=123, height=456)
+        self.assertEqual(artwork.width, 111)
+        self.assertEqual(artwork.height, 222)
+
+    @unittest_run_loop
     async def test_item_updates(self):
         self.usecase.video_playing(
             False, "dummy", 100, 1, identifier="id", artist="some artist"


### PR DESCRIPTION
This adds `width` and `height` to the `artwork` method so that artwork of arbitrary sizes can be requested. In the end, this is just a request and the device can return artwork with any size. For MRP the correct size is returned. DMAP does not support this yet.