### PR TITLE
cq: Run tests with base versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.platform }}
     strategy:
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         # https://help.github.com/articles/virtual-environments-for-github-actions
         platform:
@@ -41,7 +41,10 @@ jobs:
         python -m pip install --upgrade setuptools pip wheel
         python -m pip install tox-gh-actions
     - name: Test with tox
-      run: tox
+      run: tox -q -p auto
+    - name: Regression
+      run: tox -q -p auto -e regression
+      if: matrix.python-version == '3.8' && runner.os == 'Linux'
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,0 +1,6 @@
+aiohttp==3.1.0,<4
+aiozeroconf==0.1.8
+cryptography==2.6
+netifaces==0.10.0
+protobuf==3.6.0
+srptools===0.2.0

--- a/docs/documentation/documentation.md
+++ b/docs/documentation/documentation.md
@@ -33,12 +33,12 @@ To try out the latest development version (a.k.a. `master` on GitHub), you can i
 
 To get the work done, `pyatv` requires some other pieces of software, more specifically:
 
-- python >= 3.5.3
-- aiohttp >= 3.0.1, <4
+- python >= 3.6.0
+- aiohttp >= 3.1.0, <4
 - aiozeroconf >= 0.1.8
-- cryptography >= 1.8.1
+- cryptography >= 2.6
 - netifaces >= 0.10.0
-- protobuf >= 3.4.0
+- protobuf >= 3.6.0
 - srptools >= 0.2.0
 
 ### Milestones

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
-import os
+from pathlib import Path
+from os.path import join, dirname
 from setuptools import setup, find_packages
 
 # Read in version without importing pyatv
@@ -9,9 +10,14 @@ from setuptools import setup, find_packages
 exec(compile(open('pyatv/const.py', "rb").read(), 'pyatv/const.py', 'exec'))
 
 
-# Read content of a file and return as a string
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    """Read content of a file and return as a string."""
+    return Path(join(dirname(__file__), fname)).read_text()
+
+
+def get_requirements():
+    """Retuen requirements with loose version restrictions."""
+    return read("base_versions.txt").replace("==", ">=").split("\n")
 
 
 setup(
@@ -28,18 +34,11 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=[
-        'aiohttp>=3.0.1, <4',
-        'aiozeroconf>=0.1.8',
-        'cryptography>=1.8.1',
-        'netifaces>=0.10.0',
-        'protobuf>=3.6.0',
-        'srptools>=0.2.0',
-    ],
+    install_requires=get_requirements(),
     test_suite='tests',
     keywords=['apple', 'tv'],
     setup_requires=['pytest-runner'],
-    tests_require=['tox', 'pytest==5.4.1', 'pytest-xdist==1.31.0'],
+    tests_require=['tox==3.14.6', 'pytest==5.4.1', 'pytest-xdist==1.31.0'],
     entry_points={
         'console_scripts': [
             'atvremote = pyatv.scripts.atvremote:main',

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,11 @@ cs_exclude_words = cann,cant
 python =
   3.6: clean, py36, docs, generated, lint, typing, report
   3.7: clean, py37, docs, generated, lint, typing, report
-  3.8: clean, py38, docs, generated, lint, typing, report
+  3.8: clean, py38, docs, generated, lint, typing, report, regression
 
 [testenv]
 usedevelop = True
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv = TOXENV CI CODECOV_*
 setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}/pyatv
@@ -20,9 +20,16 @@ depends =
     py{36,37,38}: clean generated
     report: py{36,37,38}
 deps =
-     -r{toxinidir}/requirements_test.txt
+    -r{toxinidir}/requirements_test.txt
 commands =
-     pytest -n auto --log-level=debug -v --timeout=30 --durations=10 --cov --cov-append --cov-report=term-missing --cov-report=xml {posargs}
+    pytest -n auto --log-level=debug -v --timeout=30 --durations=10 --cov --cov-append --cov-report=term-missing --cov-report=xml {posargs}
+
+[testenv:regression]
+deps =
+    {[testenv]deps}
+    -c base_versions.txt
+commands =
+    pytest -n auto --log-level=debug -v --timeout=30 --durations=10 {posargs}
 
 [testenv:clean]
 deps = coverage
@@ -31,12 +38,12 @@ commands = coverage erase
 
 [testenv:docs]
 deps =
-     {[testenv]deps}
-     -r{toxinidir}/requirements_docs.txt
+    {[testenv]deps}
+    -r{toxinidir}/requirements_docs.txt
 commands =
     python scripts/api.py verify
-     codespell -q 4 -L {[tox]cs_exclude_words} --skip="*.pyc,*.pyi,*~" {[tox]pysources} tests
-     codespell -q 6 -L cann,cant -S "lib,vendor,_site,api,assets,*~,.sass-cache,*.lock" docs
+    codespell -q 4 -L {[tox]cs_exclude_words} --skip="*.pyc,*.pyi,*~" {[tox]pysources} tests
+    codespell -q 6 -L cann,cant -S "lib,vendor,_site,api,assets,*~,.sass-cache,*.lock" docs
 
 [testenv:generated]
 commands =
@@ -45,13 +52,13 @@ commands =
 [testenv:lint]
 ignore_errors = True
 commands =
-     flake8 --exclude=pyatv/mrp/protobuf {[tox]pysources}
-     black --fast --check .
-     pydocstyle -v --match='(?!test_).*[^pb2]\.py' {[tox]pysources}
+    flake8 --exclude=pyatv/mrp/protobuf {[tox]pysources}
+    black --fast --check .
+    pydocstyle -v --match='(?!test_).*[^pb2]\.py' {[tox]pysources}
 
 [testenv:typing]
 commands =
-     mypy --ignore-missing-imports --follow-imports=skip pyatv
+    mypy --ignore-missing-imports --follow-imports=skip pyatv
 
 [testenv:report]
 deps = coverage


### PR DESCRIPTION
This will run all tests on python 3.8 (with Github Actions) with the
lowest supported version of all depdendencies. I have bumped a few
versions so that it actually works...

Fixes #627.