### PR TITLE
atvproxy: Add tunnel support

### DIFF
--- a/docs/documentation/atvproxy.md
+++ b/docs/documentation/atvproxy.md
@@ -5,6 +5,23 @@ permalink: /documentation/atvproxy/
 link_group: documentation
 ---
 # atvproxy
+
+The `atvproxy` is a helper script used to intercept traffic by doing versions
+of MITM "attacks" (it's not *really* attacks). It can help when reverse engineering
+a new protocol or exploring new features in an already well-known protocol,
+like MRP.
+
+Currently this script support MRP, for which it can fully output decrypted
+messages. It also has a "relay" mode, which just sits between two devices and
+prints the trafffic. The latter is meant for simplifying reverse engineering
+of new protocols.
+
+*Note: This is an incubating script and may change behavior with short notice.
+It also depends on the internal API, meaning you should not use it as a
+reference for your own projects.*
+
+# MRP Proxy
+
 Due to MRP using encryption, it's not possible to capture the traffic using
 for instance Wireshark and analyze it. Since it's very hard to extract the
 used keys, decryption is more or less not possible. To cicrumvent this, you
@@ -17,14 +34,6 @@ the proxy and Apple TV and another set between the proxy and your iOS device.
 A private key is hardcoded into the proxy, so you can re-connect to it again
 multiple times without having to re-pair. Even when restarting the proxy. This
 of course means that **there is no security when using the proxy**.
-
-*Note: This is an incubating script and may change behavior with short notice.
-It also depends on the internal API, meaning you should not use it as a
-reference for your own projects.*
-
-# Using the Proxy
-
-This section describes how to use the proxy.
 
 ## Device Credentials
 
@@ -70,11 +79,58 @@ To run the proxy, run:
 $ atvproxy mrp `cat creds` 10.0.0.2 10.0.0.10 49152
 ```
 
-Please note that the proxy is not distributed with `pyatv`, so you will have
-to clone the repository to use it.
-
 ## Pairing and Looking at Traffic
 
 Open the Remote app and select the device called `Proxy`. Use pin code `1111`
 when pairing. The app should work and behave as expected and all traffic
 should be logged to console.
+
+# Relay Proxy
+
+Sometimes it's convenient to be able to look at network traffic when reverse
+engineering a protocol. Wireshark is really good for that, but requires a tap
+somewhere to see the traffic (not always easy). To simplify this, the relay
+proxy can be used. It sets up arbitrary zeroconf service (e.g. you can
+specify the properties manually) and combines it with a local server that will
+send all traffic to another host and relay data back from the same host.
+Basically man-in-the-middle (MITM). It does nothing with the data other than
+relaying it between the two hosts and printing it to the console. So it is
+merely designed for looking at small data exchanges to discover patterns.
+
+## Running the Relay
+
+You need a couple of things to run the relay proxy:
+
+* IP address and port of the target hosts
+* IP address of a local interface on the same network as the target
+* The name to be used when publishing the service, e.g. *ATV Relay*
+* Zeroconf service, e.g. *_mediaremotetv._tcp.local.*
+* Properties to include with the service (one or more key-value pairs)
+
+It is easiest to run `atvproxy relay --help` to see the order. See examples
+below for some inspiration.
+
+*Note: Only string values are supported for properties at this stage.*
+
+## Examples
+
+Here is an example for MRP:
+
+```shell
+$ atvproxy -p ModelName="Apple TV" \
+AllowPairing=YES \
+BluetoothAddress=00:11:22:33:44:55 \
+macAddress=aa:bb:cc:dd:ee:ff \
+Name=Vardagsrum \
+UniqueIdentifier=46CE1111-3B67-48EF-AAB1-77BCF67C886A \
+SystemBuildVersion=17L256 \
+LocalAirPlayReceiverPairingIdentity=7C7878A9-9AC2-7D93-852F-A91312B98AF9 \
+-- 10.0.10.254 10.0.10.81 49152 TestATV _mediaremotetv._tcp.local.
+```
+
+The local IP (on the computer running `atvproxy` is 10.0.10.254), IP
+address and MRP port is 10.0.10.81 and 49152. When browsing for devices,
+it will be called `TestATV`.
+
+Note that *--* is used to separate properties from other configuration
+values.

--- a/pyatv/scripts/__init__.py
+++ b/pyatv/scripts/__init__.py
@@ -1,10 +1,16 @@
 """Scripts bundled with pyatv."""
 
 import json
+import socket
+import logging
 import argparse
 from ipaddress import ip_address
 
+from aiozeroconf import ServiceInfo
+
 from pyatv import const
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=too-few-public-methods
@@ -44,3 +50,21 @@ class TransformOutput(argparse.Action):
             setattr(namespace, self.dest, json.dumps)
         else:
             raise argparse.ArgumentTypeError("Valid formats are: json")
+
+
+async def publish_service(zconf, service, name, address, port, props):
+    """Publish a custom zeroconf service."""
+    service = ServiceInfo(
+        service,
+        name + "." + service,
+        address=socket.inet_aton(address),
+        port=port,
+        weight=0,
+        priority=0,
+        properties=props,
+    )
+
+    await zconf.register_service(service)
+    _LOGGER.debug("Published zeroconf service: %s", service)
+
+    return service


### PR DESCRIPTION
Tunnel support allows publishing of arbitrary zeroconf service and
relaying of data between hosts for easy interception. A limitation is
currently that atvproxy will have to be restarted between each connect.
This shall be fixed later.