### PR TITLE
Add support for button actions

### DIFF
--- a/docs/api/pyatv/const.html
+++ b/docs/api/pyatv/const.html
@@ -91,6 +91,14 @@ link_group: api
 </ul>
 </li>
 <li>
+<h4><code><a title="pyatv.const.InputAction" href="#pyatv.const.InputAction">InputAction</a></code></h4>
+<ul class="">
+<li><code><a title="pyatv.const.InputAction.DoubleTap" href="#pyatv.const.InputAction.DoubleTap">DoubleTap</a></code></li>
+<li><code><a title="pyatv.const.InputAction.Hold" href="#pyatv.const.InputAction.Hold">Hold</a></code></li>
+<li><code><a title="pyatv.const.InputAction.SingleTap" href="#pyatv.const.InputAction.SingleTap">SingleTap</a></code></li>
+</ul>
+</li>
+<li>
 <h4><code><a title="pyatv.const.MediaType" href="#pyatv.const.MediaType">MediaType</a></code></h4>
 <ul class="">
 <li><code><a title="pyatv.const.MediaType.Music" href="#pyatv.const.MediaType.Music">Music</a></code></li>
@@ -289,6 +297,19 @@ class DeviceModel(Enum):
 
     Gen4K = 4
     &#34;&#34;&#34;Device model is Apple TV 4K.&#34;&#34;&#34;
+
+
+class InputAction(Enum):
+    &#34;&#34;&#34;Type of input when pressing a button.&#34;&#34;&#34;
+
+    SingleTap = 0
+    &#34;&#34;&#34;Press and release quickly.&#34;&#34;&#34;
+
+    DoubleTap = 1
+    &#34;&#34;&#34;Press and release twice quickly.&#34;&#34;&#34;
+
+    Hold = 2
+    &#34;&#34;&#34;Press and hold for one second before releasing.&#34;&#34;&#34;
 
 
 class FeatureState(Enum):
@@ -894,6 +915,48 @@ class FeatureName(Enum):
 <dt id="pyatv.const.FeatureState.Unsupported"><code class="name">var <span class="ident">Unsupported</span></code></dt>
 <dd>
 <section class="desc"><p>Device does not support this feature.</p></section>
+</dd>
+</dl>
+</dd>
+<dt id="pyatv.const.InputAction"><code class="flex name class">
+<span>class <span class="ident">InputAction</span></span>
+<span>(</span><span>value, names=None, *, module=None, qualname=None, type=None, start=1)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Type of input when pressing a button.</p></section>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class InputAction(Enum):
+    &#34;&#34;&#34;Type of input when pressing a button.&#34;&#34;&#34;
+
+    SingleTap = 0
+    &#34;&#34;&#34;Press and release quickly.&#34;&#34;&#34;
+
+    DoubleTap = 1
+    &#34;&#34;&#34;Press and release twice quickly.&#34;&#34;&#34;
+
+    Hold = 2
+    &#34;&#34;&#34;Press and hold for one second before releasing.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>enum.Enum</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="pyatv.const.InputAction.DoubleTap"><code class="name">var <span class="ident">DoubleTap</span></code></dt>
+<dd>
+<section class="desc"><p>Press and release twice quickly.</p></section>
+</dd>
+<dt id="pyatv.const.InputAction.Hold"><code class="name">var <span class="ident">Hold</span></code></dt>
+<dd>
+<section class="desc"><p>Press and hold for one second before releasing.</p></section>
+</dd>
+<dt id="pyatv.const.InputAction.SingleTap"><code class="name">var <span class="ident">SingleTap</span></code></dt>
+<dd>
+<section class="desc"><p>Press and release quickly.</p></section>
 </dd>
 </dl>
 </dd>

--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -248,6 +248,7 @@ from pyatv.const import (
     DeviceModel,
     FeatureState,
     FeatureName,
+    InputAction,
 )
 from pyatv.support import net
 
@@ -460,25 +461,25 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
     # pylint: disable=invalid-name
     @abstractmethod
     @feature(0, &#34;Up&#34;, &#34;Up button on remote.&#34;)
-    async def up(self) -&gt; None:
+    async def up(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key up.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(1, &#34;Down&#34;, &#34;Down button on remote.&#34;)
-    async def down(self) -&gt; None:
+    async def down(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key down.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(2, &#34;Left&#34;, &#34;Left button on remote.&#34;)
-    async def left(self) -&gt; None:
+    async def left(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key left.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(3, &#34;Right&#34;, &#34;Right button on remote.&#34;)
-    async def right(self) -&gt; None:
+    async def right(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key right.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
@@ -520,13 +521,13 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
 
     @abstractmethod
     @feature(10, &#34;Select&#34;, &#34;Select current option.&#34;)
-    async def select(self) -&gt; None:
+    async def select(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key select.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(11, &#34;Menu&#34;, &#34;Go back to previous menu.&#34;)
-    async def menu(self) -&gt; None:
+    async def menu(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key menu.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
@@ -544,12 +545,14 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
 
     @abstractmethod
     @feature(14, &#34;Home&#34;, &#34;Home/TV button.&#34;)
-    async def home(self) -&gt; None:
+    async def home(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key home.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
-    @feature(15, &#34;HomeHold&#34;, &#34;Long-press home button.&#34;)
+    @feature(
+        15, &#34;HomeHold&#34;, &#34;Long-press home button (deprecated: use RemoteControl.home).&#34;
+    )
     async def home_hold(self) -&gt; None:
         &#34;&#34;&#34;Hold key home.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
@@ -2926,25 +2929,25 @@ def stop(self) -&gt; None:
     # pylint: disable=invalid-name
     @abstractmethod
     @feature(0, &#34;Up&#34;, &#34;Up button on remote.&#34;)
-    async def up(self) -&gt; None:
+    async def up(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key up.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(1, &#34;Down&#34;, &#34;Down button on remote.&#34;)
-    async def down(self) -&gt; None:
+    async def down(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key down.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(2, &#34;Left&#34;, &#34;Left button on remote.&#34;)
-    async def left(self) -&gt; None:
+    async def left(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key left.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(3, &#34;Right&#34;, &#34;Right button on remote.&#34;)
-    async def right(self) -&gt; None:
+    async def right(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key right.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
@@ -2986,13 +2989,13 @@ def stop(self) -&gt; None:
 
     @abstractmethod
     @feature(10, &#34;Select&#34;, &#34;Select current option.&#34;)
-    async def select(self) -&gt; None:
+    async def select(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key select.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(11, &#34;Menu&#34;, &#34;Go back to previous menu.&#34;)
-    async def menu(self) -&gt; None:
+    async def menu(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key menu.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
@@ -3010,12 +3013,14 @@ def stop(self) -&gt; None:
 
     @abstractmethod
     @feature(14, &#34;Home&#34;, &#34;Home/TV button.&#34;)
-    async def home(self) -&gt; None:
+    async def home(self, action: InputAction = InputAction.SingleTap) -&gt; None:
         &#34;&#34;&#34;Press key home.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
 
     @abstractmethod
-    @feature(15, &#34;HomeHold&#34;, &#34;Long-press home button.&#34;)
+    @feature(
+        15, &#34;HomeHold&#34;, &#34;Long-press home button (deprecated: use RemoteControl.home).&#34;
+    )
     async def home_hold(self) -&gt; None:
         &#34;&#34;&#34;Hold key home.&#34;&#34;&#34;
         raise exceptions.NotSupportedError()
@@ -3088,7 +3093,7 @@ def stop(self) -&gt; None:
 <h3>Methods</h3>
 <dl>
 <dt id="pyatv.interface.RemoteControl.down"><code class="name flex">
-<span>async def <span class="ident">down</span></span>(<span>self) -> NoneType</span>
+<span>async def <span class="ident">down</span></span>(<span>self, action: <a title="pyatv.const.InputAction" href="const#pyatv.const.InputAction">InputAction</a> = InputAction.SingleTap) -> NoneType</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Press key down.</p></section>
@@ -3098,13 +3103,13 @@ def stop(self) -&gt; None:
 </summary>
 <pre><code class="python">@abstractmethod
 @feature(1, &#34;Down&#34;, &#34;Down button on remote.&#34;)
-async def down(self) -&gt; None:
+async def down(self, action: InputAction = InputAction.SingleTap) -&gt; None:
     &#34;&#34;&#34;Press key down.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
 </dd>
 <dt id="pyatv.interface.RemoteControl.home"><code class="name flex">
-<span>async def <span class="ident">home</span></span>(<span>self) -> NoneType</span>
+<span>async def <span class="ident">home</span></span>(<span>self, action: <a title="pyatv.const.InputAction" href="const#pyatv.const.InputAction">InputAction</a> = InputAction.SingleTap) -> NoneType</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Press key home.</p></section>
@@ -3114,7 +3119,7 @@ async def down(self) -&gt; None:
 </summary>
 <pre><code class="python">@abstractmethod
 @feature(14, &#34;Home&#34;, &#34;Home/TV button.&#34;)
-async def home(self) -&gt; None:
+async def home(self, action: InputAction = InputAction.SingleTap) -&gt; None:
     &#34;&#34;&#34;Press key home.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
@@ -3129,14 +3134,16 @@ async def home(self) -&gt; None:
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">@abstractmethod
-@feature(15, &#34;HomeHold&#34;, &#34;Long-press home button.&#34;)
+@feature(
+    15, &#34;HomeHold&#34;, &#34;Long-press home button (deprecated: use RemoteControl.home).&#34;
+)
 async def home_hold(self) -&gt; None:
     &#34;&#34;&#34;Hold key home.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
 </dd>
 <dt id="pyatv.interface.RemoteControl.left"><code class="name flex">
-<span>async def <span class="ident">left</span></span>(<span>self) -> NoneType</span>
+<span>async def <span class="ident">left</span></span>(<span>self, action: <a title="pyatv.const.InputAction" href="const#pyatv.const.InputAction">InputAction</a> = InputAction.SingleTap) -> NoneType</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Press key left.</p></section>
@@ -3146,13 +3153,13 @@ async def home_hold(self) -&gt; None:
 </summary>
 <pre><code class="python">@abstractmethod
 @feature(2, &#34;Left&#34;, &#34;Left button on remote.&#34;)
-async def left(self) -&gt; None:
+async def left(self, action: InputAction = InputAction.SingleTap) -&gt; None:
     &#34;&#34;&#34;Press key left.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
 </dd>
 <dt id="pyatv.interface.RemoteControl.menu"><code class="name flex">
-<span>async def <span class="ident">menu</span></span>(<span>self) -> NoneType</span>
+<span>async def <span class="ident">menu</span></span>(<span>self, action: <a title="pyatv.const.InputAction" href="const#pyatv.const.InputAction">InputAction</a> = InputAction.SingleTap) -> NoneType</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Press key menu.</p></section>
@@ -3162,7 +3169,7 @@ async def left(self) -&gt; None:
 </summary>
 <pre><code class="python">@abstractmethod
 @feature(11, &#34;Menu&#34;, &#34;Go back to previous menu.&#34;)
-async def menu(self) -&gt; None:
+async def menu(self, action: InputAction = InputAction.SingleTap) -&gt; None:
     &#34;&#34;&#34;Press key menu.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
@@ -3248,7 +3255,7 @@ async def previous(self) -&gt; None:
 </details>
 </dd>
 <dt id="pyatv.interface.RemoteControl.right"><code class="name flex">
-<span>async def <span class="ident">right</span></span>(<span>self) -> NoneType</span>
+<span>async def <span class="ident">right</span></span>(<span>self, action: <a title="pyatv.const.InputAction" href="const#pyatv.const.InputAction">InputAction</a> = InputAction.SingleTap) -> NoneType</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Press key right.</p></section>
@@ -3258,13 +3265,13 @@ async def previous(self) -&gt; None:
 </summary>
 <pre><code class="python">@abstractmethod
 @feature(3, &#34;Right&#34;, &#34;Right button on remote.&#34;)
-async def right(self) -&gt; None:
+async def right(self, action: InputAction = InputAction.SingleTap) -&gt; None:
     &#34;&#34;&#34;Press key right.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
 </dd>
 <dt id="pyatv.interface.RemoteControl.select"><code class="name flex">
-<span>async def <span class="ident">select</span></span>(<span>self) -> NoneType</span>
+<span>async def <span class="ident">select</span></span>(<span>self, action: <a title="pyatv.const.InputAction" href="const#pyatv.const.InputAction">InputAction</a> = InputAction.SingleTap) -> NoneType</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Press key select.</p></section>
@@ -3274,7 +3281,7 @@ async def right(self) -&gt; None:
 </summary>
 <pre><code class="python">@abstractmethod
 @feature(10, &#34;Select&#34;, &#34;Select current option.&#34;)
-async def select(self) -&gt; None:
+async def select(self, action: InputAction = InputAction.SingleTap) -&gt; None:
     &#34;&#34;&#34;Press key select.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>
@@ -3418,7 +3425,7 @@ async def top_menu(self) -&gt; None:
 </details>
 </dd>
 <dt id="pyatv.interface.RemoteControl.up"><code class="name flex">
-<span>async def <span class="ident">up</span></span>(<span>self) -> NoneType</span>
+<span>async def <span class="ident">up</span></span>(<span>self, action: <a title="pyatv.const.InputAction" href="const#pyatv.const.InputAction">InputAction</a> = InputAction.SingleTap) -> NoneType</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Press key up.</p></section>
@@ -3428,7 +3435,7 @@ async def top_menu(self) -&gt; None:
 </summary>
 <pre><code class="python">@abstractmethod
 @feature(0, &#34;Up&#34;, &#34;Up button on remote.&#34;)
-async def up(self) -&gt; None:
+async def up(self, action: InputAction = InputAction.SingleTap) -&gt; None:
     &#34;&#34;&#34;Press key up.&#34;&#34;&#34;
     raise exceptions.NotSupportedError()</code></pre>
 </details>

--- a/docs/development/control.md
+++ b/docs/development/control.md
@@ -29,3 +29,28 @@ await rc.set_position(100)
 ```
 
 All available actions can be found in {% include api i="interface.RemoteControl" %}.
+
+## Input Actions
+
+Currently three types of input actions are supported:
+
+* Single tap ("click")
+* Double tap ("double click")
+* Hold
+
+These actions are supported by the following buttons:
+
+* Arrow keys (up, down, left, right)
+* Select
+* Menu
+* Home
+
+By default, {% include api i="const.InputAction.SingleTap" %} are used. Pass another `action`
+to use another input action:
+
+```python
+await rc.menu(action=InputAction.Hold)
+await rc.home(action=InputAction.DoubleTap)
+```
+
+All input actions are specified in {% include api i="const.InputAction" %}.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,8 @@ Here is the feature list by protocol (DMAP = devices not running tvOS, MRP = App
 | --------------------------------------------------------------- | -------- | --------- | --------- |
 | Navigation controls (select, menu, top_menu, arrow keys)        | Yes      | Yes       | [Doc](development/control), {% include api i="interface.RemoteControl" %}
 | --------------------------------------------------------------- |--------- | --------- | --------- |
+| Different input actions (tap, double tap, hold)                 | Yes      | No        | [Doc](development/control), {% include api i="interface.RemoteControl" %}
+| --------------------------------------------------------------- |--------- | --------- | --------- |
 | Fetch artwork                                                   | Yes      | Yes       | [Doc](development/metadata/#artwork), {% include api i="interface.Metadata.artwork" %}
 | --------------------------------------------------------------- | -------- | --------- | --------- |
 | Currently playing (e.g. title, artist, album, total time, etc.) | Yes      | Yes       | [Doc](development/metadata), {% include api i="interface.Metadata" %}

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -136,6 +136,19 @@ class DeviceModel(Enum):
     """Device model is Apple TV 4K."""
 
 
+class InputAction(Enum):
+    """Type of input when pressing a button."""
+
+    SingleTap = 0
+    """Press and release quickly."""
+
+    DoubleTap = 1
+    """Press and release twice quickly."""
+
+    Hold = 2
+    """Press and hold for one second before releasing."""
+
+
 class FeatureState(Enum):
     """State of a particular feature."""
 

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -18,6 +18,7 @@ from pyatv.const import (
     PowerState,
     FeatureState,
     FeatureName,
+    InputAction,
 )
 from pyatv.dmap import daap, parser, tags
 from pyatv.dmap.daap import DaapRequester
@@ -149,7 +150,7 @@ class DmapRemoteControl(RemoteControl):
         super().__init__()
         self.apple_tv = apple_tv
 
-    async def up(self) -> None:
+    async def up(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key up."""
         await self._send_commands(
             self._move("Down", 0, 20, 275),
@@ -161,7 +162,7 @@ class DmapRemoteControl(RemoteControl):
             self._move("Up", 6, 20, 250),
         )
 
-    async def down(self) -> None:
+    async def down(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key down."""
         await self._send_commands(
             self._move("Down", 0, 20, 250),
@@ -173,7 +174,7 @@ class DmapRemoteControl(RemoteControl):
             self._move("Up", 6, 20, 275),
         )
 
-    async def left(self) -> None:
+    async def left(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key left."""
         await self._send_commands(
             self._move("Down", 0, 75, 100),
@@ -185,7 +186,7 @@ class DmapRemoteControl(RemoteControl):
             self._move("Up", 7, 50, 100),
         )
 
-    async def right(self) -> None:
+    async def right(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key right."""
         await self._send_commands(
             self._move("Down", 0, 50, 100),
@@ -230,11 +231,11 @@ class DmapRemoteControl(RemoteControl):
         """Press key previous."""
         await self.apple_tv.ctrl_int_cmd("previtem")
 
-    async def select(self) -> None:
+    async def select(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key select."""
         await self.apple_tv.controlprompt_cmd("select")
 
-    async def menu(self) -> None:
+    async def menu(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key menu."""
         await self.apple_tv.controlprompt_cmd("menu")
 
@@ -250,11 +251,12 @@ class DmapRemoteControl(RemoteControl):
         """Press key volume down."""
         await self.apple_tv.ctrl_int_cmd("volumedown")
 
-    async def home(self) -> None:
+    async def home(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key home."""
         # DMAP support unknown
         raise exceptions.NotSupportedError()
 
+    @deprecated
     async def home_hold(self) -> None:
         """Hold key home."""
         # DMAP support unknown

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -29,6 +29,7 @@ from pyatv.const import (
     DeviceModel,
     FeatureState,
     FeatureName,
+    InputAction,
 )
 from pyatv.support import net
 
@@ -241,25 +242,25 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
     # pylint: disable=invalid-name
     @abstractmethod
     @feature(0, "Up", "Up button on remote.")
-    async def up(self) -> None:
+    async def up(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key up."""
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(1, "Down", "Down button on remote.")
-    async def down(self) -> None:
+    async def down(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key down."""
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(2, "Left", "Left button on remote.")
-    async def left(self) -> None:
+    async def left(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key left."""
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(3, "Right", "Right button on remote.")
-    async def right(self) -> None:
+    async def right(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key right."""
         raise exceptions.NotSupportedError()
 
@@ -301,13 +302,13 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
 
     @abstractmethod
     @feature(10, "Select", "Select current option.")
-    async def select(self) -> None:
+    async def select(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key select."""
         raise exceptions.NotSupportedError()
 
     @abstractmethod
     @feature(11, "Menu", "Go back to previous menu.")
-    async def menu(self) -> None:
+    async def menu(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key menu."""
         raise exceptions.NotSupportedError()
 
@@ -325,12 +326,14 @@ class RemoteControl(ABC):  # pylint: disable=too-many-public-methods
 
     @abstractmethod
     @feature(14, "Home", "Home/TV button.")
-    async def home(self) -> None:
+    async def home(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key home."""
         raise exceptions.NotSupportedError()
 
     @abstractmethod
-    @feature(15, "HomeHold", "Long-press home button.")
+    @feature(
+        15, "HomeHold", "Long-press home button (deprecated: use RemoteControl.home)."
+    )
     async def home_hold(self) -> None:
         """Hold key home."""
         raise exceptions.NotSupportedError()

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -17,6 +17,7 @@ from pyatv.const import (
     PowerState,
     FeatureState,
     FeatureName,
+    InputAction,
 )
 from pyatv.support.cache import Cache
 from pyatv.mrp import messages, protobuf
@@ -160,19 +161,19 @@ class MrpRemoteControl(RemoteControl):
             f"{protobuf.HandlerReturnStatus.Enum.Name(inner.handlerReturnStatus)}"
         )
 
-    async def up(self) -> None:
+    async def up(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key up."""
         await self._press_key("up")
 
-    async def down(self) -> None:
+    async def down(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key down."""
         await self._press_key("down")
 
-    async def left(self) -> None:
+    async def left(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key left."""
         await self._press_key("left")
 
-    async def right(self) -> None:
+    async def right(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key right."""
         await self._press_key("right")
 
@@ -209,11 +210,11 @@ class MrpRemoteControl(RemoteControl):
         """Press key previous."""
         await self._send_command(CommandInfo_pb2.PreviousTrack)
 
-    async def select(self) -> None:
+    async def select(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key select."""
         await self._press_key("select")
 
-    async def menu(self) -> None:
+    async def menu(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key menu."""
         await self._press_key("menu")
 
@@ -225,10 +226,11 @@ class MrpRemoteControl(RemoteControl):
         """Press key volume down."""
         await self._press_key("volume_down")
 
-    async def home(self) -> None:
+    async def home(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key home."""
         await self._press_key("home")
 
+    @deprecated
     async def home_hold(self) -> None:
         """Hold key home."""
         await self._press_key("home", hold=True)

--- a/pyatv/scripts/atvremote.py
+++ b/pyatv/scripts/atvremote.py
@@ -10,7 +10,7 @@ import traceback
 
 from pyatv import const, exceptions, interface, scan, connect, pair
 from pyatv.conf import AppleTV, DmapService, MrpService, AirPlayService
-from pyatv.const import Protocol, ShuffleState, RepeatState
+from pyatv.const import Protocol, ShuffleState, RepeatState, InputAction
 from pyatv.dmap import tag_definitions
 from pyatv.dmap.parser import pprint
 from pyatv.interface import retrieve_commands
@@ -528,6 +528,8 @@ def _extract_command_with_args(cmd):
             return [ShuffleState(args[0])]
         if cmd == "set_repeat":
             return [RepeatState(args[0])]
+        if cmd in ["up", "down", "left", "right", "select", "menu", "home"]:
+            return [InputAction(args[0])]
         return args
 
     equal_sign = cmd.find("=")

--- a/tests/common_functional_tests.py
+++ b/tests/common_functional_tests.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from pathlib import Path
+from typing import Optional
 
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 
@@ -16,6 +17,7 @@ from pyatv.const import (
     ShuffleState,
     FeatureName,
     FeatureState,
+    InputAction,
 )
 from pyatv.conf import AppleTV, AirPlayService
 from tests.utils import stub_sleep, unstub_sleep, until, faketime
@@ -74,6 +76,10 @@ class CommonFunctionalTests(AioHTTPTestCase):
                 state,
                 f"{feature} has wrong state",
             )
+
+    async def waitForButtonPress(self, button: str, action: Optional[InputAction]):
+        await until(lambda: self.state.last_button_pressed == button)
+        await until(lambda: self.state.last_button_action == action)
 
     @unittest_run_loop
     async def test_connect_missing_device_id(self):
@@ -160,57 +166,57 @@ class CommonFunctionalTests(AioHTTPTestCase):
     @unittest_run_loop
     async def test_button_up(self):
         await self.atv.remote_control.up()
-        await until(lambda: self.state.last_button_pressed == "up")
+        await self.waitForButtonPress("up", InputAction.SingleTap)
 
     @unittest_run_loop
     async def test_button_down(self):
         await self.atv.remote_control.down()
-        await until(lambda: self.state.last_button_pressed == "down")
+        await self.waitForButtonPress("down", InputAction.SingleTap)
 
     @unittest_run_loop
     async def test_button_left(self):
         await self.atv.remote_control.left()
-        await until(lambda: self.state.last_button_pressed == "left")
+        await self.waitForButtonPress("left", InputAction.SingleTap)
 
     @unittest_run_loop
     async def test_button_right(self):
         await self.atv.remote_control.right()
-        await until(lambda: self.state.last_button_pressed == "right")
+        await self.waitForButtonPress("right", InputAction.SingleTap)
 
     @unittest_run_loop
     async def test_button_select(self):
         await self.atv.remote_control.select()
-        await until(lambda: self.state.last_button_pressed == "select")
+        await self.waitForButtonPress("select", InputAction.SingleTap)
 
     @unittest_run_loop
     async def test_button_menu(self):
         await self.atv.remote_control.menu()
-        await until(lambda: self.state.last_button_pressed == "menu")
+        await self.waitForButtonPress("menu", InputAction.SingleTap)
 
     @unittest_run_loop
     async def test_button_play(self):
         await self.atv.remote_control.play()
-        await until(lambda: self.state.last_button_pressed == "play")
+        await self.waitForButtonPress("play", None)
 
     @unittest_run_loop
     async def test_button_pause(self):
         await self.atv.remote_control.pause()
-        await until(lambda: self.state.last_button_pressed == "pause")
+        await self.waitForButtonPress("pause", None)
 
     @unittest_run_loop
     async def test_button_stop(self):
         await self.atv.remote_control.stop()
-        await until(lambda: self.state.last_button_pressed == "stop")
+        await self.waitForButtonPress("stop", None)
 
     @unittest_run_loop
     async def test_button_next(self):
         await self.atv.remote_control.next()
-        await until(lambda: self.state.last_button_pressed == "nextitem")
+        await self.waitForButtonPress("nextitem", None)
 
     @unittest_run_loop
     async def test_button_previous(self):
         await self.atv.remote_control.previous()
-        await until(lambda: self.state.last_button_pressed == "previtem")
+        await self.waitForButtonPress("previtem", None)
 
     @unittest_run_loop
     async def test_button_volume_up(self):

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -15,6 +15,7 @@ from pyatv.const import (
     OperatingSystem,
     FeatureState,
     FeatureName,
+    InputAction,
 )
 from pyatv.dmap import pairing
 from tests.fake_device import FakeAppleTV
@@ -164,7 +165,7 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
     @unittest_run_loop
     async def test_button_top_menu(self):
         await self.atv.remote_control.top_menu()
-        await until(lambda: self.state.last_button_pressed == "topmenu")
+        await self.waitForButtonPress("topmenu", InputAction.SingleTap)
 
     @unittest_run_loop
     async def test_button_play_pause(self):

--- a/tests/fake_device/dmap.py
+++ b/tests/fake_device/dmap.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 from aiohttp import web
 
-from pyatv.const import ShuffleState, RepeatState
+from pyatv.const import ShuffleState, RepeatState, InputAction
 from pyatv.dmap import parser, tags, tag_definitions
 from pyatv.support.net import unused_port
 from tests import utils
@@ -69,6 +69,7 @@ class FakeDmapState:
         self.session = None
         self.volume_controls = False
         self.last_button_pressed = None
+        self.last_button_action = None
         self.buttons_press_count = 0
         self.last_artwork_width = None
         self.last_artwork_height = None
@@ -163,6 +164,7 @@ class FakeDmapService:
         """Handle playback buttons."""
         self._verify_auth_parameters(request)
         self.state.last_button_pressed = request.rel_url.path.split("/")[-1]
+        self.state.last_button_action = None
         self.state.buttons_press_count += 1
         return web.Response(status=200)
 
@@ -172,6 +174,7 @@ class FakeDmapService:
         content = await request.content.read()
         parsed = parser.parse(content, tag_definitions.lookup_tag)
         self.state.last_button_pressed = self._convert_button(parsed)
+        self.state.last_button_action = InputAction.SingleTap
         self.state.buttons_press_count += 1
         return web.Response(status=200)
 

--- a/tests/mrp/test_mrp_functional.py
+++ b/tests/mrp/test_mrp_functional.py
@@ -13,6 +13,7 @@ from pyatv.const import (
     OperatingSystem,
     FeatureState,
     FeatureName,
+    InputAction,
 )
 from pyatv.conf import AirPlayService, MrpService, AppleTV
 from pyatv.mrp.protobuf import CommandInfo_pb2
@@ -60,9 +61,68 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         return await pyatv.connect(self.conf, loop=self.loop)
 
     @unittest_run_loop
+    async def test_button_up_actions(self):
+        await self.atv.remote_control.up(action=InputAction.DoubleTap)
+        await self.waitForButtonPress("up", InputAction.DoubleTap)
+
+        await self.atv.remote_control.up(action=InputAction.Hold)
+        await self.waitForButtonPress("up", InputAction.Hold)
+
+    @unittest_run_loop
+    async def test_button_down_actions(self):
+        await self.atv.remote_control.down(action=InputAction.DoubleTap)
+        await self.waitForButtonPress("down", InputAction.DoubleTap)
+
+        await self.atv.remote_control.down(action=InputAction.Hold)
+        await self.waitForButtonPress("down", InputAction.Hold)
+
+    @unittest_run_loop
+    async def test_button_left_actions(self):
+        await self.atv.remote_control.left(action=InputAction.DoubleTap)
+        await self.waitForButtonPress("left", InputAction.DoubleTap)
+
+        await self.atv.remote_control.left(action=InputAction.Hold)
+        await self.waitForButtonPress("left", InputAction.Hold)
+
+    @unittest_run_loop
+    async def test_button_right_actions(self):
+        await self.atv.remote_control.right(action=InputAction.DoubleTap)
+        await self.waitForButtonPress("right", InputAction.DoubleTap)
+
+        await self.atv.remote_control.right(action=InputAction.Hold)
+        await self.waitForButtonPress("right", InputAction.Hold)
+
+    @unittest_run_loop
+    async def test_button_top_menu(self):
+        await self.atv.remote_control.top_menu()
+        await self.waitForButtonPress("top_menu", InputAction.SingleTap)
+
+    @unittest_run_loop
     async def test_button_home(self):
         await self.atv.remote_control.home()
-        await until(lambda: self.state.last_button_pressed == "home")
+        await self.waitForButtonPress("home", InputAction.SingleTap)
+
+        await self.atv.remote_control.home(action=InputAction.DoubleTap)
+        await self.waitForButtonPress("home", InputAction.DoubleTap)
+
+        await self.atv.remote_control.home(action=InputAction.Hold)
+        await self.waitForButtonPress("home", InputAction.Hold)
+
+    @unittest_run_loop
+    async def test_button_select_actions(self):
+        await self.atv.remote_control.select(action=InputAction.DoubleTap)
+        await self.waitForButtonPress("select", InputAction.DoubleTap)
+
+        await self.atv.remote_control.select(action=InputAction.Hold)
+        await self.waitForButtonPress("select", InputAction.Hold)
+
+    @unittest_run_loop
+    async def test_button_menu_actions(self):
+        await self.atv.remote_control.menu(action=InputAction.DoubleTap)
+        await self.waitForButtonPress("menu", InputAction.DoubleTap)
+
+        await self.atv.remote_control.menu(action=InputAction.Hold)
+        await self.waitForButtonPress("menu", InputAction.Hold)
 
     @unittest_run_loop
     async def test_button_suspend(self):


### PR DESCRIPTION
This PR makes it possible to perform different actions for some buttons, e.g. long pressing menu or double tapping home. It also reverts the behavior in #579 for the `topmenu` button to make that more usable.