### PR TITLE
cq: Exclude __pycache__ from black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 target-version = ["py35", "py36", "py37", "py38"]
-exclude = 'protobuf/(__init__|.*_pb2).py'
+exclude = '(protobuf/(__init__|.*_pb2).py)|__pycache__'
 include = '(pyatv|tests|examples|scripts).*\.py'


### PR DESCRIPTION
These directories seems to cause a lot of problems when running in
Github Actions. This is an attempt to improve stability.