### PR TITLE
Support sleep proxies with new scanning

### DIFF
--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -30,12 +30,6 @@ link_group: api
 <li><h3><a href="#header-classes">Classes</a></h3>
 <ul>
 <li>
-<h4><code><a title="pyatv.BaseMdnsScanner" href="#pyatv.BaseMdnsScanner">BaseMdnsScanner</a></code></h4>
-<ul class="">
-<li><code><a title="pyatv.BaseMdnsScanner.handle_response" href="#pyatv.BaseMdnsScanner.handle_response">handle_response</a></code></li>
-</ul>
-</li>
-<li>
 <h4><code><a title="pyatv.MulticastMdnsScanner" href="#pyatv.MulticastMdnsScanner">MulticastMdnsScanner</a></code></h4>
 <ul class="">
 <li><code><a title="pyatv.MulticastMdnsScanner.discover" href="#pyatv.MulticastMdnsScanner.discover">discover</a></code></li>
@@ -80,12 +74,12 @@ from pyatv.support import net, knock, udns
 
 _LOGGER = logging.getLogger(__name__)
 
-HOMESHARING_SERVICE = &#34;_appletv-v2._tcp.local.&#34;
-DEVICE_SERVICE = &#34;_touch-able._tcp.local.&#34;
-MEDIAREMOTE_SERVICE = &#34;_mediaremotetv._tcp.local.&#34;
-AIRPLAY_SERVICE = &#34;_airplay._tcp.local.&#34;
+HOMESHARING_SERVICE: str = &#34;_appletv-v2._tcp.local&#34;
+DEVICE_SERVICE: str = &#34;_touch-able._tcp.local&#34;
+MEDIAREMOTE_SERVICE: str = &#34;_mediaremotetv._tcp.local&#34;
+AIRPLAY_SERVICE: str = &#34;_airplay._tcp.local&#34;
 
-ALL_SERVICES = [
+ALL_SERVICES: List[str] = [
     HOMESHARING_SERVICE,
     DEVICE_SERVICE,
     MEDIAREMOTE_SERVICE,
@@ -95,22 +89,7 @@ ALL_SERVICES = [
 # These ports have been &#34;arbitrarily&#34; chosen (see issue #580) because a device normally
 # listen on them (more or less). They are used as best-effort when for unicast scanning
 # to try to wake up a device. Both issue #580 and #595 are good references to read.
-KNOCK_PORTS = [3689, 7000, 49152, 32498]
-
-
-def _decode_properties(properties) -&gt; Dict[str, str]:
-    def _decode(value: bytes):
-        try:
-            # Remove non-breaking-spaces (0xA2A0, 0x00A0) before decoding
-            return (
-                value.replace(b&#34;\xC2\xA0&#34;, b&#34; &#34;)
-                .replace(b&#34;\x00\xA0&#34;, b&#34; &#34;)
-                .decode(&#34;utf-8&#34;)
-            )
-        except Exception:  # pylint: disable=broad-except
-            return str(value)
-
-    return {k.decode(&#34;utf-8&#34;): _decode(v) for k, v in properties.items()}
+KNOCK_PORTS: List[int] = [3689, 7000, 49152, 32498]
 
 
 class BaseScanner(ABC):  # pylint: disable=too-few-public-methods
@@ -118,62 +97,69 @@ class BaseScanner(ABC):  # pylint: disable=too-few-public-methods
 
     def __init__(self) -&gt; None:
         &#34;&#34;&#34;Initialize a new BaseScanner.&#34;&#34;&#34;
-        self._found_devices = {}  # type: Dict[IPv4Address, conf.BaseService]
+        self._found_devices: Dict[IPv4Address, conf.AppleTV] = {}
 
     @abstractmethod
     async def discover(self, timeout: int):
         &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
 
-    def service_discovered(  # pylint: disable=too-many-arguments
-        self, service_type, service_name, address, port, properties
-    ):
+    def service_discovered(self, service: udns.Service) -&gt; None:
         &#34;&#34;&#34;Call when a service was discovered.&#34;&#34;&#34;
-        supported_types = {
+        {
             HOMESHARING_SERVICE: self._hs_service,
             DEVICE_SERVICE: self._non_hs_service,
             MEDIAREMOTE_SERVICE: self._mrp_service,
             AIRPLAY_SERVICE: self._airplay_service,
-        }
+        }.get(service.type, self._unsupported_service)(service)
 
-        handler = supported_types.get(service_type)
-        if handler:
-            handler(service_name, address, port, properties)
-        else:
-            _LOGGER.warning(&#34;Discovered unknown device: %s&#34;, service_type)
-
-    def _hs_service(self, service_name, address, port, properties):
+    def _hs_service(self, mdns_service: udns.Service) -&gt; None:
         &#34;&#34;&#34;Add a new device to discovered list.&#34;&#34;&#34;
-        identifier = service_name.split(&#34;.&#34;)[0]
-        name = properties.get(&#34;Name&#34;)
-        hsgid = properties.get(&#34;hG&#34;)
-        service = conf.DmapService(identifier, hsgid, port=port, properties=properties)
-        self._handle_service(address, name, service)
+        name = mdns_service.properties.get(&#34;Name&#34;)
+        service = conf.DmapService(
+            mdns_service.name,
+            mdns_service.properties.get(&#34;hG&#34;),
+            port=mdns_service.port,
+            properties=mdns_service.properties,
+        )
+        self._handle_service(mdns_service.address, name, service)
 
-    def _non_hs_service(self, service_name, address, port, properties):
+    def _non_hs_service(self, mdns_service: udns.Service) -&gt; None:
         &#34;&#34;&#34;Add a new device without Home Sharing to discovered list.&#34;&#34;&#34;
-        identifier = service_name.split(&#34;.&#34;)[0]
-        name = properties.get(&#34;CtlN&#34;)
-        service = conf.DmapService(identifier, None, port=port, properties=properties)
-        self._handle_service(address, name, service)
+        name = mdns_service.properties.get(&#34;CtlN&#34;)
+        service = conf.DmapService(
+            mdns_service.name,
+            None,
+            port=mdns_service.port,
+            properties=mdns_service.properties,
+        )
+        self._handle_service(mdns_service.address, name, service)
 
-    def _mrp_service(self, _, address, port, properties):
+    def _mrp_service(self, mdns_service: udns.Service) -&gt; None:
         &#34;&#34;&#34;Add a new MediaRemoteProtocol device to discovered list.&#34;&#34;&#34;
-        identifier = properties.get(&#34;UniqueIdentifier&#34;)
-        name = properties.get(&#34;Name&#34;)
-        service = conf.MrpService(identifier, port, properties=properties)
-        self._handle_service(address, name, service)
+        name = mdns_service.properties.get(&#34;Name&#34;)
+        service = conf.MrpService(
+            mdns_service.properties.get(&#34;UniqueIdentifier&#34;),
+            mdns_service.port,
+            properties=mdns_service.properties,
+        )
+        self._handle_service(mdns_service.address, name, service)
 
-    def _airplay_service(self, service_name, address, port, properties):
+    def _airplay_service(self, mdns_service: udns.Service) -&gt; None:
         &#34;&#34;&#34;Add a new AirPlay device to discovered list.&#34;&#34;&#34;
-        identifier = properties.get(&#34;deviceid&#34;)
-        name = service_name.replace(&#34;.&#34; + AIRPLAY_SERVICE, &#34;&#34;)
-        service = conf.AirPlayService(identifier, port, properties=properties)
-        self._handle_service(address, name, service)
+        service = conf.AirPlayService(
+            mdns_service.properties.get(&#34;deviceid&#34;),
+            mdns_service.port,
+            properties=mdns_service.properties,
+        )
+        self._handle_service(mdns_service.address, mdns_service.name, service)
 
-    def _handle_service(self, address, name, service):
-        if address not in self._found_devices:
-            self._found_devices[address] = conf.AppleTV(address, name)
+    def _unsupported_service(self, mdns_service: udns.Service) -&gt; None:
+        &#34;&#34;&#34;Handle unsupported service.&#34;&#34;&#34;
+        _LOGGER.warning(
+            &#34;Discovered unknown device %s (%s)&#34;, mdns_service.name, mdns_service.type
+        )
 
+    def _handle_service(self, address, name, service) -&gt; None:
         _LOGGER.debug(
             &#34;Auto-discovered %s at %s:%d (%s)&#34;,
             name,
@@ -182,52 +168,16 @@ class BaseScanner(ABC):  # pylint: disable=too-few-public-methods
             service.protocol,
         )
 
-        atv = self._found_devices[address]
+        atv = self._found_devices.setdefault(address, conf.AppleTV(address, name))
         atv.add_service(service)
 
 
-class BaseMdnsScanner(BaseScanner):
-    &#34;&#34;&#34;Base scanner for MDNS service discovery.&#34;&#34;&#34;
-
-    def handle_response(self, host: IPv4Address, response: udns.DnsMessage):
-        &#34;&#34;&#34;Handle received DNS message.&#34;&#34;&#34;
-        for resource in response.answers + response.resources:
-            if resource.qtype != udns.QTYPE_TXT:
-                continue
-
-            service_name = &#34;.&#34;.join(resource.qname.split(&#34;.&#34;)[1:]) + &#34;.&#34;
-            if service_name not in ALL_SERVICES:
-                continue
-
-            port = BaseMdnsScanner._get_port(response, resource.qname)
-            if not port:
-                _LOGGER.warning(&#34;Missing port for %s&#34;, resource.qname)
-                continue
-
-            self.service_discovered(
-                service_name,
-                resource.qname + &#34;.&#34;,
-                host,
-                port,
-                _decode_properties(resource.rd),
-            )
-
-    @staticmethod
-    def _get_port(response, qname):
-        for resource in response.answers + response.resources:
-            if resource.qtype != udns.QTYPE_SRV:
-                continue
-
-            if resource.qname == qname:
-                return resource.rd.get(&#34;port&#34;)
-
-        return None
-
-
-class UnicastMdnsScanner(BaseMdnsScanner):
+class UnicastMdnsScanner(BaseScanner):
     &#34;&#34;&#34;Service discovery based on unicast MDNS.&#34;&#34;&#34;
 
-    def __init__(self, hosts: List[IPv4Address], loop: asyncio.AbstractEventLoop):
+    def __init__(
+        self, hosts: List[IPv4Address], loop: asyncio.AbstractEventLoop
+    ) -&gt; None:
         &#34;&#34;&#34;Initialize a new UnicastMdnsScanner.&#34;&#34;&#34;
         super().__init__()
         self.hosts = hosts
@@ -238,19 +188,24 @@ class UnicastMdnsScanner(BaseMdnsScanner):
         results = await asyncio.gather(
             *[self._get_services(host, timeout) for host in self.hosts]
         )
+
         for host, response in results:
-            if response is not None:
-                self.handle_response(host, response)
+            if response is None:
+                continue
+
+            for service in udns.parse_services(response):
+                if service.address and service.port != 0:
+                    self.service_discovered(service)
+
         return self._found_devices
 
     async def _get_services(self, host: IPv4Address, timeout: int):
         port = int(os.environ.get(&#34;PYATV_UDNS_PORT&#34;, 5353))  # For testing purposes
-        services = [s[0:-1] for s in ALL_SERVICES]
         knocker = None
         try:
             knocker = await knock.knocker(host, KNOCK_PORTS, self.loop, timeout=timeout)
             response = await udns.unicast(
-                self.loop, str(host), services, port=port, timeout=timeout
+                self.loop, str(host), ALL_SERVICES, port=port, timeout=timeout
             )
         except asyncio.TimeoutError:
             return host, None
@@ -260,7 +215,7 @@ class UnicastMdnsScanner(BaseMdnsScanner):
         return host, response
 
 
-class MulticastMdnsScanner(BaseMdnsScanner):
+class MulticastMdnsScanner(BaseScanner):
     &#34;&#34;&#34;Service discovery based on multicast MDNS.&#34;&#34;&#34;
 
     def __init__(self, loop: asyncio.AbstractEventLoop):
@@ -270,12 +225,12 @@ class MulticastMdnsScanner(BaseMdnsScanner):
 
     async def discover(self, timeout: int):
         &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
-        services = [s[0:-1] for s in ALL_SERVICES]
-        results = await udns.multicast(self.loop, services)
+        results = await udns.multicast(self.loop, ALL_SERVICES)
 
-        for host, response in results.items():
-            if response is not None:
-                self.handle_response(host, response)
+        for response in results.values():
+            for service in udns.parse_services(response):
+                if service.address and service.port != 0:
+                    self.service_discovered(service)
         return self._found_devices
 
 
@@ -513,100 +468,6 @@ async def pair(
 <section>
 <h2 class="section-title" id="header-classes">Classes</h2>
 <dl>
-<dt id="pyatv.BaseMdnsScanner"><code class="flex name class">
-<span>class <span class="ident">BaseMdnsScanner</span></span>
-</code></dt>
-<dd>
-<section class="desc"><p>Base scanner for MDNS service discovery.</p>
-<p>Initialize a new BaseScanner.</p></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">class BaseMdnsScanner(BaseScanner):
-    &#34;&#34;&#34;Base scanner for MDNS service discovery.&#34;&#34;&#34;
-
-    def handle_response(self, host: IPv4Address, response: udns.DnsMessage):
-        &#34;&#34;&#34;Handle received DNS message.&#34;&#34;&#34;
-        for resource in response.answers + response.resources:
-            if resource.qtype != udns.QTYPE_TXT:
-                continue
-
-            service_name = &#34;.&#34;.join(resource.qname.split(&#34;.&#34;)[1:]) + &#34;.&#34;
-            if service_name not in ALL_SERVICES:
-                continue
-
-            port = BaseMdnsScanner._get_port(response, resource.qname)
-            if not port:
-                _LOGGER.warning(&#34;Missing port for %s&#34;, resource.qname)
-                continue
-
-            self.service_discovered(
-                service_name,
-                resource.qname + &#34;.&#34;,
-                host,
-                port,
-                _decode_properties(resource.rd),
-            )
-
-    @staticmethod
-    def _get_port(response, qname):
-        for resource in response.answers + response.resources:
-            if resource.qtype != udns.QTYPE_SRV:
-                continue
-
-            if resource.qname == qname:
-                return resource.rd.get(&#34;port&#34;)
-
-        return None</code></pre>
-</details>
-<h3>Ancestors</h3>
-<ul class="hlist">
-<li>pyatv.BaseScanner</li>
-<li>abc.ABC</li>
-</ul>
-<h3>Subclasses</h3>
-<ul class="hlist">
-<li><a title="pyatv.MulticastMdnsScanner" href="#pyatv.MulticastMdnsScanner">MulticastMdnsScanner</a></li>
-<li>pyatv.UnicastMdnsScanner</li>
-</ul>
-<h3>Methods</h3>
-<dl>
-<dt id="pyatv.BaseMdnsScanner.handle_response"><code class="name flex">
-<span>def <span class="ident">handle_response</span></span>(<span>self, host: ipaddress.IPv4Address, response: pyatv.support.udns.DnsMessage)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Handle received DNS message.</p></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def handle_response(self, host: IPv4Address, response: udns.DnsMessage):
-    &#34;&#34;&#34;Handle received DNS message.&#34;&#34;&#34;
-    for resource in response.answers + response.resources:
-        if resource.qtype != udns.QTYPE_TXT:
-            continue
-
-        service_name = &#34;.&#34;.join(resource.qname.split(&#34;.&#34;)[1:]) + &#34;.&#34;
-        if service_name not in ALL_SERVICES:
-            continue
-
-        port = BaseMdnsScanner._get_port(response, resource.qname)
-        if not port:
-            _LOGGER.warning(&#34;Missing port for %s&#34;, resource.qname)
-            continue
-
-        self.service_discovered(
-            service_name,
-            resource.qname + &#34;.&#34;,
-            host,
-            port,
-            _decode_properties(resource.rd),
-        )</code></pre>
-</details>
-</dd>
-</dl>
-</dd>
 <dt id="pyatv.MulticastMdnsScanner"><code class="flex name class">
 <span>class <span class="ident">MulticastMdnsScanner</span></span>
 <span>(</span><span>loop: asyncio.events.AbstractEventLoop)</span>
@@ -618,7 +479,7 @@ async def pair(
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">class MulticastMdnsScanner(BaseMdnsScanner):
+<pre><code class="python">class MulticastMdnsScanner(BaseScanner):
     &#34;&#34;&#34;Service discovery based on multicast MDNS.&#34;&#34;&#34;
 
     def __init__(self, loop: asyncio.AbstractEventLoop):
@@ -628,17 +489,16 @@ async def pair(
 
     async def discover(self, timeout: int):
         &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
-        services = [s[0:-1] for s in ALL_SERVICES]
-        results = await udns.multicast(self.loop, services)
+        results = await udns.multicast(self.loop, ALL_SERVICES)
 
-        for host, response in results.items():
-            if response is not None:
-                self.handle_response(host, response)
+        for response in results.values():
+            for service in udns.parse_services(response):
+                if service.address and service.port != 0:
+                    self.service_discovered(service)
         return self._found_devices</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
-<li><a title="pyatv.BaseMdnsScanner" href="#pyatv.BaseMdnsScanner">BaseMdnsScanner</a></li>
 <li>pyatv.BaseScanner</li>
 <li>abc.ABC</li>
 </ul>
@@ -655,24 +515,16 @@ async def pair(
 </summary>
 <pre><code class="python">async def discover(self, timeout: int):
     &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
-    services = [s[0:-1] for s in ALL_SERVICES]
-    results = await udns.multicast(self.loop, services)
+    results = await udns.multicast(self.loop, ALL_SERVICES)
 
-    for host, response in results.items():
-        if response is not None:
-            self.handle_response(host, response)
+    for response in results.values():
+        for service in udns.parse_services(response):
+            if service.address and service.port != 0:
+                self.service_discovered(service)
     return self._found_devices</code></pre>
 </details>
 </dd>
 </dl>
-<h3>Inherited members</h3>
-<ul class="hlist">
-<li><code><b><a title="pyatv.BaseMdnsScanner" href="#pyatv.BaseMdnsScanner">BaseMdnsScanner</a></b></code>:
-<ul class="hlist">
-<li><code><a title="pyatv.BaseMdnsScanner.handle_response" href="#pyatv.BaseMdnsScanner.handle_response">handle_response</a></code></li>
-</ul>
-</li>
-</ul>
 </dd>
 </dl>
 </section>

--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -57,7 +57,7 @@ import logging
 import datetime  # noqa
 from abc import ABC, abstractmethod
 from ipaddress import IPv4Address
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 import aiohttp
 
@@ -189,17 +189,16 @@ class UnicastMdnsScanner(BaseScanner):
             *[self._get_services(host, timeout) for host in self.hosts]
         )
 
-        for host, response in results:
-            if response is None:
-                continue
-
-            for service in udns.parse_services(response):
+        for host, services in results:
+            for service in services:
                 if service.address and service.port != 0:
                     self.service_discovered(service)
 
         return self._found_devices
 
-    async def _get_services(self, host: IPv4Address, timeout: int):
+    async def _get_services(
+        self, host: IPv4Address, timeout: int
+    ) -&gt; Tuple[IPv4Address, List[udns.Service]]:
         port = int(os.environ.get(&#34;PYATV_UDNS_PORT&#34;, 5353))  # For testing purposes
         knocker = None
         try:
@@ -208,7 +207,7 @@ class UnicastMdnsScanner(BaseScanner):
                 self.loop, str(host), ALL_SERVICES, port=port, timeout=timeout
             )
         except asyncio.TimeoutError:
-            return host, None
+            return host, []
         finally:
             if knocker:
                 knocker.cancel()
@@ -227,8 +226,8 @@ class MulticastMdnsScanner(BaseScanner):
         &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
         results = await udns.multicast(self.loop, ALL_SERVICES)
 
-        for response in results.values():
-            for service in udns.parse_services(response):
+        for services in results.values():
+            for service in services:
                 if service.address and service.port != 0:
                     self.service_discovered(service)
         return self._found_devices
@@ -491,8 +490,8 @@ async def pair(
         &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
         results = await udns.multicast(self.loop, ALL_SERVICES)
 
-        for response in results.values():
-            for service in udns.parse_services(response):
+        for services in results.values():
+            for service in services:
                 if service.address and service.port != 0:
                     self.service_discovered(service)
         return self._found_devices</code></pre>
@@ -517,8 +516,8 @@ async def pair(
     &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
     results = await udns.multicast(self.loop, ALL_SERVICES)
 
-    for response in results.values():
-        for service in udns.parse_services(response):
+    for services in results.values():
+        for service in services:
             if service.address and service.port != 0:
                 self.service_discovered(service)
     return self._found_devices</code></pre>

--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -193,7 +193,6 @@ class UnicastMdnsScanner(BaseScanner):
             for service in services:
                 if service.address and service.port != 0:
                     self.service_discovered(service)
-
         return self._found_devices
 
     async def _get_services(
@@ -224,7 +223,7 @@ class MulticastMdnsScanner(BaseScanner):
 
     async def discover(self, timeout: int):
         &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
-        results = await udns.multicast(self.loop, ALL_SERVICES)
+        results = await udns.multicast(self.loop, ALL_SERVICES, timeout=timeout)
 
         for services in results.values():
             for service in services:
@@ -488,7 +487,7 @@ async def pair(
 
     async def discover(self, timeout: int):
         &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
-        results = await udns.multicast(self.loop, ALL_SERVICES)
+        results = await udns.multicast(self.loop, ALL_SERVICES, timeout=timeout)
 
         for services in results.values():
             for service in services:
@@ -514,7 +513,7 @@ async def pair(
 </summary>
 <pre><code class="python">async def discover(self, timeout: int):
     &#34;&#34;&#34;Start discovery of devices and services.&#34;&#34;&#34;
-    results = await udns.multicast(self.loop, ALL_SERVICES)
+    results = await udns.multicast(self.loop, ALL_SERVICES, timeout=timeout)
 
     for services in results.values():
         for service in services:

--- a/docs/api/pyatv/conf.html
+++ b/docs/api/pyatv/conf.html
@@ -221,13 +221,13 @@ class DmapService(BaseService):
 
     def __init__(
         self,
-        identifier: str,
-        credentials: str,
-        port: int = None,
+        identifier: Optional[str],
+        credentials: Optional[str],
+        port: int = 3689,
         properties: Optional[Dict[str, str]] = None,
     ) -&gt; None:
         &#34;&#34;&#34;Initialize a new DmapService.&#34;&#34;&#34;
-        super().__init__(identifier, Protocol.DMAP, port or 3689, properties)
+        super().__init__(identifier, Protocol.DMAP, port, properties)
         self.credentials = credentials
 
 
@@ -237,9 +237,9 @@ class MrpService(BaseService):
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         port: int,
-        credentials: str = None,
+        credentials: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -&gt; None:
         &#34;&#34;&#34;Initialize a new MrpService.&#34;&#34;&#34;
@@ -253,9 +253,9 @@ class AirPlayService(BaseService):
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         port: int = 7000,
-        credentials: str = None,
+        credentials: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -&gt; None:
         &#34;&#34;&#34;Initialize a new AirPlayService.&#34;&#34;&#34;
@@ -274,7 +274,7 @@ class AirPlayService(BaseService):
 <dl>
 <dt id="pyatv.conf.AirPlayService"><code class="flex name class">
 <span>class <span class="ident">AirPlayService</span></span>
-<span>(</span><span>identifier: str, port: int = 7000, credentials: str = None, properties: Union[Dict[str, str], NoneType] = None)</span>
+<span>(</span><span>identifier: Union[str, NoneType], port: int = 7000, credentials: Union[str, NoneType] = None, properties: Union[Dict[str, str], NoneType] = None)</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Representation of an AirPlay service.</p>
@@ -288,9 +288,9 @@ class AirPlayService(BaseService):
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         port: int = 7000,
-        credentials: str = None,
+        credentials: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -&gt; None:
         &#34;&#34;&#34;Initialize a new AirPlayService.&#34;&#34;&#34;
@@ -642,7 +642,7 @@ returned.</p></section>
 </dd>
 <dt id="pyatv.conf.DmapService"><code class="flex name class">
 <span>class <span class="ident">DmapService</span></span>
-<span>(</span><span>identifier: str, credentials: str, port: int = None, properties: Union[Dict[str, str], NoneType] = None)</span>
+<span>(</span><span>identifier: Union[str, NoneType], credentials: Union[str, NoneType], port: int = 3689, properties: Union[Dict[str, str], NoneType] = None)</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Representation of a DMAP service.</p>
@@ -656,13 +656,13 @@ returned.</p></section>
 
     def __init__(
         self,
-        identifier: str,
-        credentials: str,
-        port: int = None,
+        identifier: Optional[str],
+        credentials: Optional[str],
+        port: int = 3689,
         properties: Optional[Dict[str, str]] = None,
     ) -&gt; None:
         &#34;&#34;&#34;Initialize a new DmapService.&#34;&#34;&#34;
-        super().__init__(identifier, Protocol.DMAP, port or 3689, properties)
+        super().__init__(identifier, Protocol.DMAP, port, properties)
         self.credentials = credentials</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -681,7 +681,7 @@ returned.</p></section>
 </dd>
 <dt id="pyatv.conf.MrpService"><code class="flex name class">
 <span>class <span class="ident">MrpService</span></span>
-<span>(</span><span>identifier: str, port: int, credentials: str = None, properties: Union[Dict[str, str], NoneType] = None)</span>
+<span>(</span><span>identifier: Union[str, NoneType], port: int, credentials: Union[str, NoneType] = None, properties: Union[Dict[str, str], NoneType] = None)</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Representation of a MediaRemote Protocol (MRP) service.</p>
@@ -695,9 +695,9 @@ returned.</p></section>
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         port: int,
-        credentials: str = None,
+        credentials: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -&gt; None:
         &#34;&#34;&#34;Initialize a new MrpService.&#34;&#34;&#34;

--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -375,7 +375,7 @@ class BaseService:
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         protocol: Protocol,
         port: int,
         properties: Optional[Dict[str, str]],
@@ -384,11 +384,11 @@ class BaseService:
         self.__identifier = identifier
         self.protocol = protocol
         self.port = port
-        self.credentials = None  # type: Optional[str]
+        self.credentials: Optional[str] = None
         self.properties = properties or {}
 
     @property
-    def identifier(self) -&gt; str:
+    def identifier(self) -&gt; Optional[str]:
         &#34;&#34;&#34;Return unique identifier associated with this service.&#34;&#34;&#34;
         return self.__identifier
 
@@ -1473,7 +1473,7 @@ async def connect(self) -&gt; None:
 </dd>
 <dt id="pyatv.interface.BaseService"><code class="flex name class">
 <span>class <span class="ident">BaseService</span></span>
-<span>(</span><span>identifier: str, protocol: <a title="pyatv.const.Protocol" href="const#pyatv.const.Protocol">Protocol</a>, port: int, properties: Union[Dict[str, str], NoneType])</span>
+<span>(</span><span>identifier: Union[str, NoneType], protocol: <a title="pyatv.const.Protocol" href="const#pyatv.const.Protocol">Protocol</a>, port: int, properties: Union[Dict[str, str], NoneType])</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Base class for protocol services.</p>
@@ -1487,7 +1487,7 @@ async def connect(self) -&gt; None:
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         protocol: Protocol,
         port: int,
         properties: Optional[Dict[str, str]],
@@ -1496,11 +1496,11 @@ async def connect(self) -&gt; None:
         self.__identifier = identifier
         self.protocol = protocol
         self.port = port
-        self.credentials = None  # type: Optional[str]
+        self.credentials: Optional[str] = None
         self.properties = properties or {}
 
     @property
-    def identifier(self) -&gt; str:
+    def identifier(self) -&gt; Optional[str]:
         &#34;&#34;&#34;Return unique identifier associated with this service.&#34;&#34;&#34;
         return self.__identifier
 
@@ -1523,7 +1523,7 @@ async def connect(self) -&gt; None:
 </ul>
 <h3>Instance variables</h3>
 <dl>
-<dt id="pyatv.interface.BaseService.identifier"><code class="name">var <span class="ident">identifier</span> -> str</code></dt>
+<dt id="pyatv.interface.BaseService.identifier"><code class="name">var <span class="ident">identifier</span> -> Union[str, NoneType]</code></dt>
 <dd>
 <section class="desc"><p>Return unique identifier associated with this service.</p></section>
 <details class="source">
@@ -1531,7 +1531,7 @@ async def connect(self) -&gt; None:
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">@property
-def identifier(self) -&gt; str:
+def identifier(self) -&gt; Optional[str]:
     &#34;&#34;&#34;Return unique identifier associated with this service.&#34;&#34;&#34;
     return self.__identifier</code></pre>
 </details>

--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -23,12 +23,12 @@ from pyatv.support import net, knock, udns
 
 _LOGGER = logging.getLogger(__name__)
 
-HOMESHARING_SERVICE = "_appletv-v2._tcp.local."
-DEVICE_SERVICE = "_touch-able._tcp.local."
-MEDIAREMOTE_SERVICE = "_mediaremotetv._tcp.local."
-AIRPLAY_SERVICE = "_airplay._tcp.local."
+HOMESHARING_SERVICE: str = "_appletv-v2._tcp.local"
+DEVICE_SERVICE: str = "_touch-able._tcp.local"
+MEDIAREMOTE_SERVICE: str = "_mediaremotetv._tcp.local"
+AIRPLAY_SERVICE: str = "_airplay._tcp.local"
 
-ALL_SERVICES = [
+ALL_SERVICES: List[str] = [
     HOMESHARING_SERVICE,
     DEVICE_SERVICE,
     MEDIAREMOTE_SERVICE,
@@ -38,22 +38,7 @@ ALL_SERVICES = [
 # These ports have been "arbitrarily" chosen (see issue #580) because a device normally
 # listen on them (more or less). They are used as best-effort when for unicast scanning
 # to try to wake up a device. Both issue #580 and #595 are good references to read.
-KNOCK_PORTS = [3689, 7000, 49152, 32498]
-
-
-def _decode_properties(properties) -> Dict[str, str]:
-    def _decode(value: bytes):
-        try:
-            # Remove non-breaking-spaces (0xA2A0, 0x00A0) before decoding
-            return (
-                value.replace(b"\xC2\xA0", b" ")
-                .replace(b"\x00\xA0", b" ")
-                .decode("utf-8")
-            )
-        except Exception:  # pylint: disable=broad-except
-            return str(value)
-
-    return {k.decode("utf-8"): _decode(v) for k, v in properties.items()}
+KNOCK_PORTS: List[int] = [3689, 7000, 49152, 32498]
 
 
 class BaseScanner(ABC):  # pylint: disable=too-few-public-methods
@@ -61,62 +46,69 @@ class BaseScanner(ABC):  # pylint: disable=too-few-public-methods
 
     def __init__(self) -> None:
         """Initialize a new BaseScanner."""
-        self._found_devices = {}  # type: Dict[IPv4Address, conf.BaseService]
+        self._found_devices: Dict[IPv4Address, conf.AppleTV] = {}
 
     @abstractmethod
     async def discover(self, timeout: int):
         """Start discovery of devices and services."""
 
-    def service_discovered(  # pylint: disable=too-many-arguments
-        self, service_type, service_name, address, port, properties
-    ):
+    def service_discovered(self, service: udns.Service) -> None:
         """Call when a service was discovered."""
-        supported_types = {
+        {
             HOMESHARING_SERVICE: self._hs_service,
             DEVICE_SERVICE: self._non_hs_service,
             MEDIAREMOTE_SERVICE: self._mrp_service,
             AIRPLAY_SERVICE: self._airplay_service,
-        }
+        }.get(service.type, self._unsupported_service)(service)
 
-        handler = supported_types.get(service_type)
-        if handler:
-            handler(service_name, address, port, properties)
-        else:
-            _LOGGER.warning("Discovered unknown device: %s", service_type)
-
-    def _hs_service(self, service_name, address, port, properties):
+    def _hs_service(self, mdns_service: udns.Service) -> None:
         """Add a new device to discovered list."""
-        identifier = service_name.split(".")[0]
-        name = properties.get("Name")
-        hsgid = properties.get("hG")
-        service = conf.DmapService(identifier, hsgid, port=port, properties=properties)
-        self._handle_service(address, name, service)
+        name = mdns_service.properties.get("Name")
+        service = conf.DmapService(
+            mdns_service.name,
+            mdns_service.properties.get("hG"),
+            port=mdns_service.port,
+            properties=mdns_service.properties,
+        )
+        self._handle_service(mdns_service.address, name, service)
 
-    def _non_hs_service(self, service_name, address, port, properties):
+    def _non_hs_service(self, mdns_service: udns.Service) -> None:
         """Add a new device without Home Sharing to discovered list."""
-        identifier = service_name.split(".")[0]
-        name = properties.get("CtlN")
-        service = conf.DmapService(identifier, None, port=port, properties=properties)
-        self._handle_service(address, name, service)
+        name = mdns_service.properties.get("CtlN")
+        service = conf.DmapService(
+            mdns_service.name,
+            None,
+            port=mdns_service.port,
+            properties=mdns_service.properties,
+        )
+        self._handle_service(mdns_service.address, name, service)
 
-    def _mrp_service(self, _, address, port, properties):
+    def _mrp_service(self, mdns_service: udns.Service) -> None:
         """Add a new MediaRemoteProtocol device to discovered list."""
-        identifier = properties.get("UniqueIdentifier")
-        name = properties.get("Name")
-        service = conf.MrpService(identifier, port, properties=properties)
-        self._handle_service(address, name, service)
+        name = mdns_service.properties.get("Name")
+        service = conf.MrpService(
+            mdns_service.properties.get("UniqueIdentifier"),
+            mdns_service.port,
+            properties=mdns_service.properties,
+        )
+        self._handle_service(mdns_service.address, name, service)
 
-    def _airplay_service(self, service_name, address, port, properties):
+    def _airplay_service(self, mdns_service: udns.Service) -> None:
         """Add a new AirPlay device to discovered list."""
-        identifier = properties.get("deviceid")
-        name = service_name.replace("." + AIRPLAY_SERVICE, "")
-        service = conf.AirPlayService(identifier, port, properties=properties)
-        self._handle_service(address, name, service)
+        service = conf.AirPlayService(
+            mdns_service.properties.get("deviceid"),
+            mdns_service.port,
+            properties=mdns_service.properties,
+        )
+        self._handle_service(mdns_service.address, mdns_service.name, service)
 
-    def _handle_service(self, address, name, service):
-        if address not in self._found_devices:
-            self._found_devices[address] = conf.AppleTV(address, name)
+    def _unsupported_service(self, mdns_service: udns.Service) -> None:
+        """Handle unsupported service."""
+        _LOGGER.warning(
+            "Discovered unknown device %s (%s)", mdns_service.name, mdns_service.type
+        )
 
+    def _handle_service(self, address, name, service) -> None:
         _LOGGER.debug(
             "Auto-discovered %s at %s:%d (%s)",
             name,
@@ -125,52 +117,16 @@ class BaseScanner(ABC):  # pylint: disable=too-few-public-methods
             service.protocol,
         )
 
-        atv = self._found_devices[address]
+        atv = self._found_devices.setdefault(address, conf.AppleTV(address, name))
         atv.add_service(service)
 
 
-class BaseMdnsScanner(BaseScanner):
-    """Base scanner for MDNS service discovery."""
-
-    def handle_response(self, host: IPv4Address, response: udns.DnsMessage):
-        """Handle received DNS message."""
-        for resource in response.answers + response.resources:
-            if resource.qtype != udns.QTYPE_TXT:
-                continue
-
-            service_name = ".".join(resource.qname.split(".")[1:]) + "."
-            if service_name not in ALL_SERVICES:
-                continue
-
-            port = BaseMdnsScanner._get_port(response, resource.qname)
-            if not port:
-                _LOGGER.warning("Missing port for %s", resource.qname)
-                continue
-
-            self.service_discovered(
-                service_name,
-                resource.qname + ".",
-                host,
-                port,
-                _decode_properties(resource.rd),
-            )
-
-    @staticmethod
-    def _get_port(response, qname):
-        for resource in response.answers + response.resources:
-            if resource.qtype != udns.QTYPE_SRV:
-                continue
-
-            if resource.qname == qname:
-                return resource.rd.get("port")
-
-        return None
-
-
-class UnicastMdnsScanner(BaseMdnsScanner):
+class UnicastMdnsScanner(BaseScanner):
     """Service discovery based on unicast MDNS."""
 
-    def __init__(self, hosts: List[IPv4Address], loop: asyncio.AbstractEventLoop):
+    def __init__(
+        self, hosts: List[IPv4Address], loop: asyncio.AbstractEventLoop
+    ) -> None:
         """Initialize a new UnicastMdnsScanner."""
         super().__init__()
         self.hosts = hosts
@@ -181,19 +137,24 @@ class UnicastMdnsScanner(BaseMdnsScanner):
         results = await asyncio.gather(
             *[self._get_services(host, timeout) for host in self.hosts]
         )
+
         for host, response in results:
-            if response is not None:
-                self.handle_response(host, response)
+            if response is None:
+                continue
+
+            for service in udns.parse_services(response):
+                if service.address and service.port != 0:
+                    self.service_discovered(service)
+
         return self._found_devices
 
     async def _get_services(self, host: IPv4Address, timeout: int):
         port = int(os.environ.get("PYATV_UDNS_PORT", 5353))  # For testing purposes
-        services = [s[0:-1] for s in ALL_SERVICES]
         knocker = None
         try:
             knocker = await knock.knocker(host, KNOCK_PORTS, self.loop, timeout=timeout)
             response = await udns.unicast(
-                self.loop, str(host), services, port=port, timeout=timeout
+                self.loop, str(host), ALL_SERVICES, port=port, timeout=timeout
             )
         except asyncio.TimeoutError:
             return host, None
@@ -203,7 +164,7 @@ class UnicastMdnsScanner(BaseMdnsScanner):
         return host, response
 
 
-class MulticastMdnsScanner(BaseMdnsScanner):
+class MulticastMdnsScanner(BaseScanner):
     """Service discovery based on multicast MDNS."""
 
     def __init__(self, loop: asyncio.AbstractEventLoop):
@@ -213,12 +174,12 @@ class MulticastMdnsScanner(BaseMdnsScanner):
 
     async def discover(self, timeout: int):
         """Start discovery of devices and services."""
-        services = [s[0:-1] for s in ALL_SERVICES]
-        results = await udns.multicast(self.loop, services)
+        results = await udns.multicast(self.loop, ALL_SERVICES)
 
-        for host, response in results.items():
-            if response is not None:
-                self.handle_response(host, response)
+        for response in results.values():
+            for service in udns.parse_services(response):
+                if service.address and service.port != 0:
+                    self.service_discovered(service)
         return self._found_devices
 
 

--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -6,7 +6,7 @@ import logging
 import datetime  # noqa
 from abc import ABC, abstractmethod
 from ipaddress import IPv4Address
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 import aiohttp
 
@@ -138,17 +138,15 @@ class UnicastMdnsScanner(BaseScanner):
             *[self._get_services(host, timeout) for host in self.hosts]
         )
 
-        for host, response in results:
-            if response is None:
-                continue
-
-            for service in udns.parse_services(response):
+        for host, services in results:
+            for service in services:
                 if service.address and service.port != 0:
                     self.service_discovered(service)
-
         return self._found_devices
 
-    async def _get_services(self, host: IPv4Address, timeout: int):
+    async def _get_services(
+        self, host: IPv4Address, timeout: int
+    ) -> Tuple[IPv4Address, List[udns.Service]]:
         port = int(os.environ.get("PYATV_UDNS_PORT", 5353))  # For testing purposes
         knocker = None
         try:
@@ -157,7 +155,7 @@ class UnicastMdnsScanner(BaseScanner):
                 self.loop, str(host), ALL_SERVICES, port=port, timeout=timeout
             )
         except asyncio.TimeoutError:
-            return host, None
+            return host, []
         finally:
             if knocker:
                 knocker.cancel()
@@ -174,10 +172,10 @@ class MulticastMdnsScanner(BaseScanner):
 
     async def discover(self, timeout: int):
         """Start discovery of devices and services."""
-        results = await udns.multicast(self.loop, ALL_SERVICES)
+        results = await udns.multicast(self.loop, ALL_SERVICES, timeout=timeout)
 
-        for response in results.values():
-            for service in udns.parse_services(response):
+        for services in results.values():
+            for service in services:
                 if service.address and service.port != 0:
                     self.service_discovered(service)
         return self._found_devices

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -160,13 +160,13 @@ class DmapService(BaseService):
 
     def __init__(
         self,
-        identifier: str,
-        credentials: str,
-        port: int = None,
+        identifier: Optional[str],
+        credentials: Optional[str],
+        port: int = 3689,
         properties: Optional[Dict[str, str]] = None,
     ) -> None:
         """Initialize a new DmapService."""
-        super().__init__(identifier, Protocol.DMAP, port or 3689, properties)
+        super().__init__(identifier, Protocol.DMAP, port, properties)
         self.credentials = credentials
 
 
@@ -176,9 +176,9 @@ class MrpService(BaseService):
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         port: int,
-        credentials: str = None,
+        credentials: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -> None:
         """Initialize a new MrpService."""
@@ -192,9 +192,9 @@ class AirPlayService(BaseService):
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         port: int = 7000,
-        credentials: str = None,
+        credentials: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ) -> None:
         """Initialize a new AirPlayService."""

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -156,7 +156,7 @@ class BaseService:
 
     def __init__(
         self,
-        identifier: str,
+        identifier: Optional[str],
         protocol: Protocol,
         port: int,
         properties: Optional[Dict[str, str]],
@@ -165,11 +165,11 @@ class BaseService:
         self.__identifier = identifier
         self.protocol = protocol
         self.port = port
-        self.credentials = None  # type: Optional[str]
+        self.credentials: Optional[str] = None
         self.properties = properties or {}
 
     @property
-    def identifier(self) -> str:
+    def identifier(self) -> Optional[str]:
         """Return unique identifier associated with this service."""
         return self.__identifier
 

--- a/pyatv/support/udns.py
+++ b/pyatv/support/udns.py
@@ -54,7 +54,8 @@ def qname_encode(name):
     """Encode QNAME without using labels."""
 
     def _enc_word(word):
-        return bytes([len(word) & 0xFF]) + word.encode("ascii")
+        encoded = word.encode("utf-8")
+        return bytes([len(encoded) & 0xFF]) + encoded
 
     return b"".join([_enc_word(x) for x in name.split(".")]) + b"\x00"
 
@@ -81,7 +82,7 @@ def qname_decode(ptr, message, raw=False):
     name_components, rest = _rec(ptr)
     if raw:
         return name_components, rest[1:]
-    return ".".join([x.decode() for x in name_components]), rest[1:]
+    return ".".join([x.decode("utf-8") for x in name_components]), rest[1:]
 
 
 def parse_txt_dict(data, msg):

--- a/pyatv/support/udns.py
+++ b/pyatv/support/udns.py
@@ -17,6 +17,7 @@ DnsQuestion = namedtuple("DnsQuestion", "qname qtype qclass")
 DnsAnswer = namedtuple("DnsAnswer", "qname qtype qclass ttl rd_length rd")
 DnsResource = namedtuple("DnsResource", "qname qtype qclass ttl rd_length rd")
 
+QTYPE_A = 0x0001
 QTYPE_PTR = 0x000C
 QTYPE_TXT = 0x0010
 QTYPE_SRV = 0x0021
@@ -105,6 +106,8 @@ def unpack_rr(ptr, msg):
         rd_data = parse_txt_dict(rd_data, msg)
     elif qtype == QTYPE_SRV:
         rd_data = parse_srv_dict(rd_data, msg)
+    elif qtype == QTYPE_A:
+        rd_data = str(IPv4Address(rd_data))
 
     return ptr, data + (rd_data,)
 

--- a/tests/fake_udns.py
+++ b/tests/fake_udns.py
@@ -21,14 +21,20 @@ def mrp_service(service_name, atv_name, identifier, address="127.0.0.1", port=49
         name=service_name,
         address=address,
         port=port,
-        properties={"Name": atv_name, "UniqueIdentifier": identifier},
+        properties={
+            b"Name": atv_name.encode("utf-8"),
+            b"UniqueIdentifier": identifier.encode("utf-8"),
+        },
     )
     return ("_mediaremotetv._tcp.local", service)
 
 
 def airplay_service(atv_name, deviceid, address="127.0.0.1", port=7000):
     service = FakeDnsService(
-        name=atv_name, address=address, port=port, properties={"deviceid": deviceid}
+        name=atv_name,
+        address=address,
+        port=port,
+        properties={b"deviceid": deviceid.encode("utf-8")},
     )
     return ("_airplay._tcp.local", service)
 
@@ -38,14 +44,17 @@ def homesharing_service(service_name, atv_name, hsgid, address="127.0.0.1"):
         name=service_name,
         address=address,
         port=3689,
-        properties={"hG": hsgid, "Name": atv_name},
+        properties={b"hG": hsgid.encode("utf-8"), b"Name": atv_name.encode("utf-8")},
     )
     return ("_appletv-v2._tcp.local", service)
 
 
 def device_service(service_name, atv_name, address="127.0.0.1"):
     service = FakeDnsService(
-        name=service_name, address=address, port=3689, properties={"CtlN": atv_name}
+        name=service_name,
+        address=address,
+        port=3689,
+        properties={b"CtlN": atv_name.encode("utf-8")},
     )
     return ("_touch-able._tcp.local", service)
 

--- a/tests/fake_udns.py
+++ b/tests/fake_udns.py
@@ -111,6 +111,13 @@ class FakeUdns(asyncio.Protocol):
                 rd = struct.pack(">3H", 0, 0, service.port) + local_name
                 resp.resources.append(dns_utils.resource(full_name, udns.QTYPE_SRV, rd))
 
+            # Add IP address
+            if service.address:
+                ipaddr = IPv4Address(service.address).packed
+                resp.resources.append(
+                    dns_utils.resource(service.name + ".local", udns.QTYPE_A, ipaddr)
+                )
+
             # Add properties
             if service.properties:
                 rd = dns_utils.properties(service.properties)

--- a/tests/support/dns_utils.py
+++ b/tests/support/dns_utils.py
@@ -27,6 +27,13 @@ def properties(properties: Dict[bytes, bytes]) -> bytes:
     return rd
 
 
+def get_qtype(messages: udns.DnsMessage, qtype: int) -> Optional[udns.DnsResource]:
+    for message in messages:
+        if message.qtype == qtype:
+            return message
+    return None
+
+
 def add_service(
     message: udns.DnsMessage,
     service_type: Optional[str],

--- a/tests/support/dns_utils.py
+++ b/tests/support/dns_utils.py
@@ -1,25 +1,89 @@
 """Helper methods for DNS messages."""
 
 import struct
+from ipaddress import IPv4Address
+from typing import Optional, Dict
 from pyatv.support import udns
 
 DEFAULT_QCLASS = 1
 DEFAULT_TTL = 10
 
 
-def answer(qname, full_name):
+def answer(qname: str, full_name: str) -> udns.DnsAnswer:
     return udns.DnsAnswer(
         qname, udns.QTYPE_PTR, DEFAULT_QCLASS, DEFAULT_TTL, 0, full_name
     )
 
 
-def resource(qname, qtype, rd):
+def resource(qname: str, qtype: int, rd) -> udns.DnsResource:
     return udns.DnsResource(qname, qtype, DEFAULT_QCLASS, DEFAULT_TTL, len(rd), rd)
 
 
-def properties(properties):
+def properties(properties: Dict[bytes, bytes]) -> bytes:
     rd = b""
     for k, v in properties.items():
         encoded = k + b"=" + v
         rd += bytes([len(encoded)]) + encoded
     return rd
+
+
+def add_service(
+    message: udns.DnsMessage,
+    service_type: Optional[str],
+    service_name: Optional[str],
+    address: Optional[str],
+    port: int,
+    properties: dict,
+) -> None:
+    if service_name is None:
+        return message
+
+    if address:
+        message.resources.append(
+            resource(service_name + ".local", udns.QTYPE_A, address)
+        )
+
+    # Remaining depends on service type
+    if service_type is None:
+        return message
+
+    message.answers.append(answer(service_type, service_name + "." + service_type))
+
+    message.resources.append(
+        resource(
+            service_name + "." + service_type,
+            udns.QTYPE_SRV,
+            {
+                "priority": 0,
+                "weight": 0,
+                "port": port,
+                "target": service_name + ".local",
+            },
+        )
+    )
+
+    if properties:
+        message.resources.append(
+            resource(
+                service_name + "." + service_type,
+                udns.QTYPE_TXT,
+                {k.encode("utf-8"): v.encode("utf-8") for k, v in properties.items()},
+            )
+        )
+
+    return message
+
+
+def assert_service(
+    messages: udns.DnsMessage,
+    service_type: str,
+    service_name: str,
+    address: str,
+    port: int,
+    properties: dict,
+) -> None:
+    assert messages.type == service_type
+    assert messages.name == service_name
+    assert messages.address == (IPv4Address(address) if address else None)
+    assert messages.port == port
+    assert messages.properties == properties

--- a/tests/support/dns_utils.py
+++ b/tests/support/dns_utils.py
@@ -20,6 +20,6 @@ def resource(qname, qtype, rd):
 def properties(properties):
     rd = b""
     for k, v in properties.items():
-        encoded = (k + "=" + v).encode("ascii")
+        encoded = k + b"=" + v
         rd += bytes([len(encoded)]) + encoded
     return rd

--- a/tests/support/dns_utils.py
+++ b/tests/support/dns_utils.py
@@ -1,0 +1,25 @@
+"""Helper methods for DNS messages."""
+
+import struct
+from pyatv.support import udns
+
+DEFAULT_QCLASS = 1
+DEFAULT_TTL = 10
+
+
+def answer(qname, full_name):
+    return udns.DnsAnswer(
+        qname, udns.QTYPE_PTR, DEFAULT_QCLASS, DEFAULT_TTL, 0, full_name
+    )
+
+
+def resource(qname, qtype, rd):
+    return udns.DnsResource(qname, qtype, DEFAULT_QCLASS, DEFAULT_TTL, len(rd), rd)
+
+
+def properties(properties):
+    rd = b""
+    for k, v in properties.items():
+        encoded = (k + "=" + v).encode("ascii")
+        rd += bytes([len(encoded)]) + encoded
+    return rd

--- a/tests/support/test_udns.py
+++ b/tests/support/test_udns.py
@@ -14,14 +14,15 @@ from tests import fake_udns
 from tests.support import dns_utils
 
 
+SERVICE_NAME = "Kitchen"
 MEDIAREMOTE_SERVICE = "_mediaremotetv._tcp.local"
 
 TEST_SERVICES = {
     MEDIAREMOTE_SERVICE: fake_udns.FakeDnsService(
-        name="Kitchen",
+        name=SERVICE_NAME,
         address="127.0.0.1",
         port=1234,
-        properties={b"Name": b"Kitchen", b"foo": b"=bar"},
+        properties={b"Name": SERVICE_NAME.encode("utf-8"), b"foo": b"=bar"},
     ),
 }
 
@@ -42,15 +43,24 @@ async def udns_server(event_loop):
 
 
 # This is a very complex fixture that will hook into the receiver of multicast
-# responses and abort the "waiting" period whenever all responses have been received.
-# Mainly this is for not slowing down tests.
+# responses and abort the "waiting" period whenever all responses or a certain amount
+# of requests have been received. Mainly this is for not slowing down tests.
 @pytest.fixture
-async def multicast_fastexit(event_loop, monkeypatch):
+async def multicast_fastexit(event_loop, monkeypatch, udns_server):
     # Interface used to set number of expected responses (1 by default)
-    expected_responses = [1]
+    expected_responses: List[int] = [1, 0]
 
-    def _set_expected_responses(responses):
-        expected_responses[0] = responses
+    def _set_expected_responses(response_count: int, request_count: int):
+        expected_responses[0] = response_count
+        expected_responses[1] = request_count
+
+    # Checks if either response or request count has been fulfilled
+    def _check_cond(protocol: udns.MulticastDnsSdClientProtocol) -> bool:
+        if len(protocol.responses) == expected_responses[0]:
+            return False
+        if expected_responses[1] == 0:
+            return True
+        return udns_server.request_count < expected_responses[1]
 
     # Replace create_datagram_endpoint with a method that captures the created
     # endpoints and use a simple poller to detect if all responses have been received
@@ -60,7 +70,7 @@ async def multicast_fastexit(event_loop, monkeypatch):
         transport, protocol = await create_endpoint(factory, **kwargs)
 
         async def _poll_responses():
-            while len(protocol.responses) != expected_responses[0]:
+            while _check_cond(protocol):
                 await asyncio.sleep(0.1)
             protocol.semaphore.release()
 
@@ -94,13 +104,6 @@ def get_response_for_service(
     req = udns.create_request([service])
     resp = fake_udns.create_response(req, TEST_SERVICES)
     return udns.DnsMessage().unpack(resp.pack()), TEST_SERVICES.get(service)
-
-
-def get_qtype(messages, qtype):
-    for message in messages:
-        if message.qtype == qtype:
-            return message
-    return None
 
 
 def test_qname_with_label():
@@ -159,7 +162,7 @@ async def test_service_has_valid_answer():
 async def test_service_has_valid_srv_resource():
     resp, data = get_response_for_service(MEDIAREMOTE_SERVICE)
 
-    srv = get_qtype(resp.resources, udns.QTYPE_SRV)
+    srv = dns_utils.get_qtype(resp.resources, udns.QTYPE_SRV)
     assert srv.qname == data.name + "." + MEDIAREMOTE_SERVICE
     assert srv.qtype == udns.QTYPE_SRV
     assert srv.qclass == dns_utils.DEFAULT_QCLASS
@@ -176,7 +179,7 @@ async def test_service_has_valid_srv_resource():
 async def test_service_has_valid_txt_resource():
     resp, data = get_response_for_service(MEDIAREMOTE_SERVICE)
 
-    srv = get_qtype(resp.resources, udns.QTYPE_TXT)
+    srv = dns_utils.get_qtype(resp.resources, udns.QTYPE_TXT)
     assert srv.qname == data.name + "." + MEDIAREMOTE_SERVICE
     assert srv.qtype == udns.QTYPE_TXT
     assert srv.qclass == dns_utils.DEFAULT_QCLASS
@@ -192,7 +195,7 @@ async def test_service_has_valid_txt_resource():
 async def test_service_has_valid_a_resource():
     resp, data = get_response_for_service(MEDIAREMOTE_SERVICE)
 
-    srv = get_qtype(resp.resources, udns.QTYPE_A)
+    srv = dns_utils.get_qtype(resp.resources, udns.QTYPE_A)
     assert srv.qname == data.name + ".local"
     assert srv.qtype == udns.QTYPE_A
     assert srv.qclass == dns_utils.DEFAULT_QCLASS
@@ -200,18 +203,10 @@ async def test_service_has_valid_a_resource():
     assert srv.rd == "127.0.0.1"
 
 
-# @pytest.mark.asyncio
-# async def test_resend_if_no_response(event_loop, udns_server):
-#     udns_server.skip_count = 2
-#     resp, _ = await unicast(event_loop, udns_server, MEDIAREMOTE_SERVICE, 3)
-#     assert len(resp.questions) == 1
-#     assert len(resp.answers) == 1
-#     assert len(resp.resources) == 3
-
-
 @pytest.mark.asyncio
 async def test_multicast_no_response(event_loop, udns_server, multicast_fastexit):
-    multicast_fastexit(0)
+    multicast_fastexit(0, 0)
+
     await udns.multicast(event_loop, [], "127.0.0.1", udns_server.port)
 
 
@@ -235,8 +230,21 @@ async def test_unicast_resend_if_no_response(event_loop, udns_server):
 
 
 @pytest.mark.asyncio
+async def test_unicast_specific_service(event_loop, udns_server):
+    resp, _ = await unicast(
+        event_loop, udns_server, SERVICE_NAME + "." + MEDIAREMOTE_SERVICE
+    )
+    assert len(resp) == 1
+
+    service = TEST_SERVICES.get(MEDIAREMOTE_SERVICE)
+    assert resp[0].type == MEDIAREMOTE_SERVICE
+    assert resp[0].name == service.name
+    assert resp[0].port == service.port
+
+
+@pytest.mark.asyncio
 async def test_multicast_has_valid_service(event_loop, udns_server, multicast_fastexit):
-    multicast_fastexit(1)
+    multicast_fastexit(1, 0)
 
     resp = await udns.multicast(
         event_loop, [MEDIAREMOTE_SERVICE], "127.0.0.1", udns_server.port
@@ -245,8 +253,33 @@ async def test_multicast_has_valid_service(event_loop, udns_server, multicast_fa
 
     first = resp[IPv4Address("127.0.0.1")][0]
     assert first.type == MEDIAREMOTE_SERVICE
-    assert first.name == "Kitchen"
+    assert first.name == SERVICE_NAME
     assert first.port == 1234
+
+
+@pytest.mark.asyncio
+async def test_multicast_sleeping_device(event_loop, udns_server, multicast_fastexit):
+    multicast_fastexit(0, 3)
+    udns_server.sleep_proxy = True
+
+    udns_server.services = {
+        MEDIAREMOTE_SERVICE: fake_udns.FakeDnsService(
+            name=SERVICE_NAME, address=None, port=0, properties={},
+        ),
+    }
+
+    resp = await udns.multicast(
+        event_loop, [MEDIAREMOTE_SERVICE], "127.0.0.1", udns_server.port
+    )
+    assert len(resp) == 0
+
+    multicast_fastexit(1, 0)
+    udns_server.services = TEST_SERVICES
+
+    resp = await udns.multicast(
+        event_loop, [MEDIAREMOTE_SERVICE], "127.0.0.1", udns_server.port
+    )
+    assert len(resp) == 1
 
 
 def test_parse_empty_service():
@@ -309,6 +342,7 @@ def test_parse_double_service():
     message = dns_utils.add_service(message, *service2_params)
 
     parsed = udns.parse_services(message)
+    print(parsed)
     assert len(parsed) == 2
     dns_utils.assert_service(parsed[0], *service1_params)
     dns_utils.assert_service(parsed[1], *service2_params)

--- a/tests/support/test_udns.py
+++ b/tests/support/test_udns.py
@@ -123,7 +123,7 @@ async def test_service_has_expected_responses(event_loop, udns_server):
     resp, _ = await unicast(event_loop, udns_server, MEDIAREMOTE_SERVICE)
     assert len(resp.questions) == 1
     assert len(resp.answers) == 1
-    assert len(resp.resources) == 2
+    assert len(resp.resources) == 3
 
 
 @pytest.mark.asyncio
@@ -182,12 +182,24 @@ async def test_service_has_valid_txt_resource(event_loop, udns_server):
 
 
 @pytest.mark.asyncio
+async def test_service_has_valid_a_resource(event_loop, udns_server):
+    resp, data = await unicast(event_loop, udns_server, MEDIAREMOTE_SERVICE)
+
+    srv = get_qtype(resp.resources, udns.QTYPE_A)
+    assert srv.qname == data.name + ".local"
+    assert srv.qtype == udns.QTYPE_A
+    assert srv.qclass == dns_utils.DEFAULT_QCLASS
+    assert srv.ttl == dns_utils.DEFAULT_TTL
+    assert srv.rd == "127.0.0.1"
+
+
+@pytest.mark.asyncio
 async def test_resend_if_no_response(event_loop, udns_server):
     udns_server.skip_count = 2
     resp, _ = await unicast(event_loop, udns_server, MEDIAREMOTE_SERVICE, 3)
     assert len(resp.questions) == 1
     assert len(resp.answers) == 1
-    assert len(resp.resources) == 2
+    assert len(resp.resources) == 3
 
 
 @pytest.mark.asyncio
@@ -210,4 +222,4 @@ async def test_multicast_has_valid_response(
     first = resp[IPv4Address("127.0.0.1")]
     assert len(first.questions) == 1
     assert len(first.answers) == 1
-    assert len(first.resources) == 2
+    assert len(first.resources) == 3

--- a/tests/support/test_udns.py
+++ b/tests/support/test_udns.py
@@ -10,6 +10,7 @@ import pytest
 from pyatv import exceptions
 from pyatv.support import udns
 from tests import fake_udns
+from tests.support import dns_utils
 
 
 MEDIAREMOTE_SERVICE = "_mediaremotetv._tcp.local"
@@ -142,8 +143,8 @@ async def test_service_has_valid_answer(event_loop, udns_server):
     answer = resp.answers[0]
     assert answer.qname == MEDIAREMOTE_SERVICE
     assert answer.qtype == udns.QTYPE_PTR
-    assert answer.qclass == fake_udns.DEFAULT_QCLASS
-    assert answer.ttl == fake_udns.DEFAULT_TTL
+    assert answer.qclass == dns_utils.DEFAULT_QCLASS
+    assert answer.ttl == dns_utils.DEFAULT_TTL
     assert answer.rd == data.name + "." + MEDIAREMOTE_SERVICE
 
 
@@ -154,8 +155,8 @@ async def test_service_has_valid_srv_resource(event_loop, udns_server):
     srv = get_qtype(resp.resources, udns.QTYPE_SRV)
     assert srv.qname == data.name + "." + MEDIAREMOTE_SERVICE
     assert srv.qtype == udns.QTYPE_SRV
-    assert srv.qclass == fake_udns.DEFAULT_QCLASS
-    assert srv.ttl == fake_udns.DEFAULT_TTL
+    assert srv.qclass == dns_utils.DEFAULT_QCLASS
+    assert srv.ttl == dns_utils.DEFAULT_TTL
 
     rd = srv.rd
     assert rd["priority"] == 0
@@ -171,8 +172,8 @@ async def test_service_has_valid_txt_resource(event_loop, udns_server):
     srv = get_qtype(resp.resources, udns.QTYPE_TXT)
     assert srv.qname == data.name + "." + MEDIAREMOTE_SERVICE
     assert srv.qtype == udns.QTYPE_TXT
-    assert srv.qclass == fake_udns.DEFAULT_QCLASS
-    assert srv.ttl == fake_udns.DEFAULT_TTL
+    assert srv.qclass == dns_utils.DEFAULT_QCLASS
+    assert srv.ttl == dns_utils.DEFAULT_TTL
 
     rd = srv.rd
     assert len(rd) == len(data.properties)

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -253,13 +253,7 @@ async def test_unicast_scan_homesharing(udns_server, unicast_scan):
     assert len(atvs) == 1
 
     assert_device(
-        atvs[0],
-        "Apple TV HS",
-        ip_address(IP_LOCALHOST),
-        "abcd",
-        Protocol.DMAP,
-        3689,
-        HSGID,
+        atvs[0], "Apple TV HS", ip_address(IP_3), "abcd", Protocol.DMAP, 3689, HSGID,
     )
 
 
@@ -273,12 +267,7 @@ async def test_unicast_scan_no_homesharing(udns_server, unicast_scan):
     assert len(atvs) == 1
 
     assert_device(
-        atvs[0],
-        "Apple TV Device",
-        ip_address(IP_LOCALHOST),
-        "Apple TV",
-        Protocol.DMAP,
-        3689,
+        atvs[0], "Apple TV Device", ip_address(IP_2), "Apple TV", Protocol.DMAP, 3689,
     )
 
 


### PR DESCRIPTION
Add better service parsing to mdns implantation and perform unicast scanning if result is sent from a sleep proxy.