### PR TITLE
scan: Migrate back to zeroconf from aiozeroconf

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,6 +1,6 @@
 aiohttp==3.1.0,<5
-aiozeroconf==0.1.8
 cryptography==2.6
 netifaces==0.10.0
 protobuf==3.6.0
 srptools===0.2.0
+zeroconf==0.28.0

--- a/docs/development/scan_pair_and_connect.md
+++ b/docs/development/scan_pair_and_connect.md
@@ -185,7 +185,7 @@ The following extra settings are supported by `DMAP`:
 | ------- | ----- |
 | name | Name of the device that is exposed on the network (what you see on your Apple TV). |
 | pairing_guid | Custom value for `pairing_guid` (credentials) with format `0xXXXXXXXXXXXXXXXX`. |
-| zeroconf | If you want to use a custom `aiozeroconf.Zeroconf` instance, you can pass it here. |
+| zeroconf | If you want to use a custom `zeroconf.Zeroconf` instance, you can pass it here. |
 
 You pass these via `kwargs` to {% include api i="pyatv.pair" %}:
 

--- a/docs/documentation/documentation.md
+++ b/docs/documentation/documentation.md
@@ -63,11 +63,11 @@ To get the work done, `pyatv` requires some other pieces of software, more speci
 
 - python >= 3.6.0
 - aiohttp >= 3.1.0, <5
-- aiozeroconf >= 0.1.8
 - cryptography >= 2.6
 - netifaces >= 0.10.0
 - protobuf >= 3.6.0
 - srptools >= 0.2.0
+- zeroconf==0.28.0
 
 You also need to have OpenSSL compiled with support for ed25519 in order
 to connect to MRP devices.

--- a/docs/support/scanning_issues.md
+++ b/docs/support/scanning_issues.md
@@ -40,7 +40,7 @@ scanning, that one or more service is missing. This is the reason why that happe
 ## Response filtering
 
 A behavior that has been observed is that the response is indeed received by the host
-(as seen with Wireshark), but it is never forwarded to the python process so `aiozeroconf`
+(as seen with Wireshark), but it is never forwarded to the python process so `zeroconf`
 never receives it. Some filtering happens at some point for some reason. It is still
 unclear if this is a bug in python or not and should be investigated further.
 

--- a/pyatv/scripts/__init__.py
+++ b/pyatv/scripts/__init__.py
@@ -1,12 +1,9 @@
 """Scripts bundled with pyatv."""
 
 import json
-import socket
 import logging
 import argparse
 from ipaddress import ip_address
-
-from aiozeroconf import ServiceInfo
 
 from pyatv import const
 
@@ -50,21 +47,3 @@ class TransformOutput(argparse.Action):
             setattr(namespace, self.dest, json.dumps)
         else:
             raise argparse.ArgumentTypeError("Valid formats are: json")
-
-
-async def publish_service(zconf, service, name, address, port, props):
-    """Publish a custom zeroconf service."""
-    service = ServiceInfo(
-        service,
-        name + "." + service,
-        address=socket.inet_aton(address),
-        port=port,
-        weight=0,
-        priority=0,
-        properties=props,
-    )
-
-    await zconf.register_service(service)
-    _LOGGER.debug("Published zeroconf service: %s", service)
-
-    return service

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -38,13 +38,6 @@ AIRPLAY_STREAM = "http://stream"
 # (extracted form a real device)
 PAIRINGCODE = "690E6FF61E0D7C747654A42AED17047D"
 
-HOMESHARING_SERVICE_1 = zeroconf_stub.homesharing_service(
-    "AAAA", b"Apple TV 1", "10.0.0.1", b"aaaa"
-)
-HOMESHARING_SERVICE_2 = zeroconf_stub.homesharing_service(
-    "BBBB", b"Apple TV 2", "10.0.0.2", b"bbbb"
-)
-
 SKIP_TIME = 10
 
 

--- a/tests/dmap/test_pairing.py
+++ b/tests/dmap/test_pairing.py
@@ -82,7 +82,7 @@ async def test_zeroconf_service_published(mock_pairing):
     assert len(zeroconf.registered_services) == 1, "no zeroconf service registered"
 
     service = zeroconf.registered_services[0]
-    assert service.properties[b"DvNm"] == REMOTE_NAME, "remote name does not match"
+    assert service.properties["DvNm"] == REMOTE_NAME, "remote name does not match"
 
 
 @pytest.mark.asyncio

--- a/tests/fake_device/dmap.py
+++ b/tests/fake_device/dmap.py
@@ -82,7 +82,7 @@ class FakeDmapState:
                 continue
 
             # Look for the response matching this remote
-            remote_name = service.properties[b"DvNm"]
+            remote_name = service.properties["DvNm"]
             for remote_name, expected_code in self.pairing_responses.items():
                 if remote_name == remote_name:
                     return await self.perform_pairing(

--- a/tests/zeroconf_stub.py
+++ b/tests/zeroconf_stub.py
@@ -3,96 +3,7 @@
 As zeroconf does not provide a stub or mock, this implementation will serve as
 stub here. It can fake immediate answers for any service.
 """
-from aiozeroconf import ServiceInfo
-
-
-def homesharing_service(service_name, atv_name, address, hsgid):
-    """Create a new home sharing service simulating an Apple TV."""
-    # Mostly default values here for now
-    props = {
-        b"DFID": b"2",
-        b"PrVs": b"65538",
-        b"hG": hsgid,
-        b"Name": atv_name,
-        b"txtvers": b"1",
-        b"atSV": b"65541",
-        b"MiTPV": b"196611",
-        b"EiTS": b"1",
-        b"fs": b"2",
-        b"MniT": b"167845888",
-    }
-
-    return ServiceInfo(
-        "_appletv-v2._tcp.local.",
-        service_name + "._appletv-v2._tcp.local.",
-        address=address,
-        port=3689,
-        properties=props,
-    )
-
-
-def mrp_service(service_name, atv_name, address, identifier, port=49152):
-    """Create a MediaRemote service simulating an Apple TV."""
-    props = {
-        b"ModelName": b"Mac",
-        b"SystemBuildVersion": b"16G29",
-        b"Name": atv_name,
-        b"AllowPairing": b"YES",
-        b"UniqueIdentifier": identifier.encode("utf-8"),
-    }
-
-    return ServiceInfo(
-        "_mediaremotetv._tcp.local.",
-        service_name + "._mediaremotetv._tcp.local.",
-        address=address,
-        port=port,
-        properties=props,
-    )
-
-
-def airplay_service(atv_name, address, deviceid, port=7000):
-    """Create a MediaRemote service simulating an Apple TV."""
-    props = {
-        b"deviceid": deviceid.encode("utf-8"),
-        b"model": b"AppleTV3,1",
-        b"pi": b"4EE5AF58-7E5D-465A-935E-82E4DB74385D",
-        b"flags": b"0x44",
-        b"vv": b"2",
-        b"features": b"0x5A7FFFF7,0xE",
-        b"pk": b"3853c0e2ce3844727ca0cb1b86a3e3875e66924d2648d8f8caf71f8118793d98",  # noqa
-        b"srcvers": b"220.68",
-    }
-
-    return ServiceInfo(
-        "_airplay._tcp.local.",
-        atv_name + "._airplay._tcp.local.",
-        address=address,
-        port=port,
-        properties=props,
-    )
-
-
-def device_service(service_name, atv_name, address):
-    """Create a service representing an Apple TV with no home-sharing."""
-    props = {
-        b"DvTy": b"AppleTV",
-        b"Ver": b"131077",
-        b"DvSv": b"1792",
-        b"atCV": b"65539",
-        b"atSV": b"65541",
-        b"txtvers": b"1",
-        b"DbId": b"AAAAAAAAAAAAAAAA",
-        b"CtlN": atv_name,
-    }
-
-    return ServiceInfo(
-        "_touch-able._tcp.local.",
-        service_name + "._touch-able._tcp.local.",
-        address=address,
-        port=3689,
-        server="AppleTV-2.local.",
-        properties=props,
-    )
+from zeroconf import ServiceInfo
 
 
 class ServiceBrowserStub:
@@ -100,15 +11,9 @@ class ServiceBrowserStub:
 
     def __init__(self, zeroconf, service_type, listener):
         """Create a new instance of ServiceBrowser."""
-        zeroconf.browsers.append(self)
-        self.service_type = service_type
-        self.is_running = True
         for service in zeroconf.services:
             if service.type == service_type:
                 listener.add_service(zeroconf, service_type, service.name)
-
-    def cancel(self):
-        self.is_running = False
 
 
 class ZeroconfStub:
@@ -116,33 +21,31 @@ class ZeroconfStub:
 
     def __init__(self, services):
         """Create a new instance of Zeroconf."""
-        self.browsers = []
         self.services = services
         self.registered_services = []
 
-    async def get_service_info(self, service_type, service_name, timeout=2000):
+    def get_service_info(self, service_type, service_name):
         """Look up service information."""
         for service in self.services:
             if service.name == service_name:
                 return service
 
-    async def register_service(self, service):
+    def register_service(self, service):
         """Save services registered services."""
         self.registered_services.append(service)
 
-    async def unregister_service(self, service):
+    def unregister_service(self, service):
         """Stub for unregistering services (does nothing)."""
         pass
 
-    async def close(self):
+    def close(self):
         """Stub for closing zeroconf (does nothing)."""
-        for browser in self.browsers:
-            assert not browser.is_running, f"{browser.service_type} was not cancelled"
+        pass
 
 
 def stub(module, *services):
     """Stub a module using zeroconf."""
     instance = ZeroconfStub(list(services))
-    module.Zeroconf = lambda loop, address_family=None: instance
+    module.Zeroconf = lambda: instance
     module.ServiceBrowser = ServiceBrowserStub
     return instance


### PR DESCRIPTION
As aiozeroconf causes problems (due to bugs) and is not maintained
anymore, it's better to move back to zeroconf again. Since service
discovery is already done by pyatv, only service publishing is really
used.

Relates to #750.