### PR TITLE
mrp: Potential fix for protocol hangs

### DIFF
--- a/pyatv/mrp/messages.py
+++ b/pyatv/mrp/messages.py
@@ -94,6 +94,7 @@ def playback_queue_request(location, width=-1, height=400):
     request.length = 1
     request.artworkWidth = width
     request.artworkHeight = height
+    request.returnContentItemAssetsInUserCompletion = True
     return message
 
 


### PR DESCRIPTION
The connection sometimes seems to hang after artwork has been received.
Reason is still unknown, but this change seems to make it work better.
It comes with the price that if artwork is large (file size), the
artwork might only be delivered as a transaction. Since transactions are
not implemented yet, artwork will fail in these cases.

Relates to #609.