### PR TITLE
Resolve performance slowdown with copying playing data

### DIFF
--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -4,7 +4,7 @@ import math
 import logging
 import asyncio
 import datetime
-from copy import deepcopy
+from copy import copy
 from typing import Dict, List, Optional, Tuple
 
 from pyatv import conf, exceptions
@@ -475,7 +475,7 @@ class MrpMetadata(Metadata):
 
     async def playing(self):
         """Return what is currently playing."""
-        return MrpPlaying(deepcopy(self.psm.playing))
+        return MrpPlaying(copy(self.psm.playing))
 
     @property
     def app(self) -> Optional[App]:


### PR DESCRIPTION
I'm not sure if this will cause a regression but it solves the performance issue.

Resolves #773 

Before this change the event loop was taking 13% of the recording time.  
https://maui.koston.org:8123/local/ec.svg

After its below the measurable threshold.
https://maui.koston.org:8123/local/ec3.svg