### PR TITLE
Fix invalid DMAP identifier when name collision exists on the network

### DIFF
--- a/docs/api/pyatv/conf.html
+++ b/docs/api/pyatv/conf.html
@@ -252,7 +252,12 @@ class DmapService(BaseService):
         properties: Optional[Dict[str, str]] = None,
     ) -&gt; None:
         &#34;&#34;&#34;Initialize a new DmapService.&#34;&#34;&#34;
-        super().__init__(identifier, Protocol.DMAP, port, properties)
+        super().__init__(
+            identifier.split(&#34;_&#34;)[0] if identifier else None,
+            Protocol.DMAP,
+            port,
+            properties,
+        )
         self.credentials = credentials
 
 
@@ -753,7 +758,12 @@ returned.</p></section>
         properties: Optional[Dict[str, str]] = None,
     ) -&gt; None:
         &#34;&#34;&#34;Initialize a new DmapService.&#34;&#34;&#34;
-        super().__init__(identifier, Protocol.DMAP, port, properties)
+        super().__init__(
+            identifier.split(&#34;_&#34;)[0] if identifier else None,
+            Protocol.DMAP,
+            port,
+            properties,
+        )
         self.credentials = credentials</code></pre>
 </details>
 <h3>Ancestors</h3>

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -188,7 +188,12 @@ class DmapService(BaseService):
         properties: Optional[Dict[str, str]] = None,
     ) -> None:
         """Initialize a new DmapService."""
-        super().__init__(identifier, Protocol.DMAP, port, properties)
+        super().__init__(
+            identifier.split("_")[0] if identifier else None,
+            Protocol.DMAP,
+            port,
+            properties,
+        )
         self.credentials = credentials
 
 

--- a/tests/dmap/test_dmap_functional.py
+++ b/tests/dmap/test_dmap_functional.py
@@ -71,7 +71,7 @@ class DMAPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         return self.fake_atv.app
 
     async def get_connected_device(self, hsgid):
-        self.dmap_service = DmapService("dmap_id", hsgid, port=self.server.port)
+        self.dmap_service = DmapService("dmapid", hsgid, port=self.server.port)
         self.airplay_service = AirPlayService(
             "airplay_id", self.server.port, DEVICE_CREDENTIALS
         )

--- a/tests/scripts/script_env.py
+++ b/tests/scripts/script_env.py
@@ -19,7 +19,7 @@ from tests.fake_device import FakeAppleTV
 
 IP_1 = "10.0.0.1"
 IP_2 = "127.0.0.1"
-DMAP_ID = "dmap_id"
+DMAP_ID = "dmapid"
 MRP_ID = "mrp_id"
 AIRPLAY_ID = "AA:BB:CC:DD:EE:FF"
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,6 +1,6 @@
 """Unit tests for pyatv.conf."""
 
-import unittest
+import pytest
 
 from pyatv import conf, exceptions
 from pyatv.const import Protocol, OperatingSystem, DeviceModel
@@ -26,173 +26,183 @@ AIRPLAY_PROPERTIES = {
     "osvers": "8.0.0",
 }
 
+DMAP_SERVICE = conf.DmapService(IDENTIFIER_1, None, port=PORT_1)
+MRP_SERVICE = conf.MrpService(IDENTIFIER_2, PORT_2, properties=MRP_PROPERTIES)
+AIRPLAY_SERVICE = conf.AirPlayService(
+    IDENTIFIER_3, PORT_1, properties=AIRPLAY_PROPERTIES
+)
 
-class ConfTest(unittest.TestCase):
-    def setUp(self):
-        self.config = conf.AppleTV(
-            ADDRESS_1, NAME, deep_sleep=True, model=DeviceModel.Gen2
-        )
-        self.dmap_service = conf.DmapService(IDENTIFIER_1, None, port=PORT_1)
-        self.mrp_service = conf.MrpService(
-            IDENTIFIER_2, PORT_2, properties=MRP_PROPERTIES
-        )
-        self.airplay_service = conf.AirPlayService(
-            IDENTIFIER_3, PORT_1, properties=AIRPLAY_PROPERTIES
-        )
 
-    def test_address_and_name(self):
-        self.assertEqual(self.config.address, ADDRESS_1)
-        self.assertEqual(self.config.name, NAME)
+@pytest.fixture
+def config():
+    yield conf.AppleTV(ADDRESS_1, NAME, deep_sleep=True, model=DeviceModel.Gen2)
 
-    def test_equality(self):
-        self.assertEqual(self.config, self.config)
 
-        atv2 = conf.AppleTV(ADDRESS_1, NAME)
-        atv2.add_service(conf.AirPlayService(IDENTIFIER_1, PORT_1))
-        self.assertNotEqual(self.config, atv2)
+def test_address_and_name(config):
+    assert config.address == ADDRESS_1
+    assert config.name == NAME
 
-    def test_add_services_and_get(self):
-        self.config.add_service(self.dmap_service)
-        self.config.add_service(self.mrp_service)
-        self.config.add_service(self.airplay_service)
 
-        services = self.config.services
-        self.assertEqual(len(services), 3)
+def test_equality(config):
+    assert config == config
 
-        self.assertIn(self.dmap_service, services)
-        self.assertIn(self.mrp_service, services)
-        self.assertIn(self.airplay_service, services)
+    atv2 = conf.AppleTV(ADDRESS_1, NAME)
+    atv2.add_service(conf.AirPlayService(IDENTIFIER_1, PORT_1))
+    assert config != atv2
 
-        self.assertEqual(self.config.get_service(Protocol.DMAP), self.dmap_service)
-        self.assertEqual(self.config.get_service(Protocol.MRP), self.mrp_service)
-        self.assertEqual(
-            self.config.get_service(Protocol.AirPlay), self.airplay_service
-        )
 
-    def test_identifier_order(self):
-        self.assertIsNone(self.config.identifier)
+def test_add_services_and_get(config):
+    config.add_service(DMAP_SERVICE)
+    config.add_service(MRP_SERVICE)
+    config.add_service(AIRPLAY_SERVICE)
 
-        self.config.add_service(self.dmap_service)
-        self.assertEqual(self.config.identifier, IDENTIFIER_1)
+    services = config.services
+    assert len(services), 3
 
-        self.config.add_service(self.mrp_service)
-        self.assertEqual(self.config.identifier, IDENTIFIER_2)
+    assert DMAP_SERVICE in services
+    assert MRP_SERVICE in services
+    assert AIRPLAY_SERVICE in services
 
-        self.config.add_service(self.airplay_service)
-        self.assertEqual(self.config.identifier, IDENTIFIER_2)
+    assert config.get_service(Protocol.DMAP) == DMAP_SERVICE
+    assert config.get_service(Protocol.MRP) == MRP_SERVICE
+    assert config.get_service(Protocol.AirPlay) == AIRPLAY_SERVICE
 
-    def test_add_airplay_service(self):
-        self.config.add_service(self.airplay_service)
 
-        airplay = self.config.get_service(Protocol.AirPlay)
-        self.assertEqual(airplay.protocol, Protocol.AirPlay)
-        self.assertEqual(airplay.port, PORT_1)
+def test_identifier_order(config):
+    assert config.identifier is None
 
-    def test_main_service_no_service(self):
-        with self.assertRaises(exceptions.NoServiceError):
-            self.config.main_service()
+    config.add_service(DMAP_SERVICE)
+    assert config.identifier == IDENTIFIER_1
 
-    def test_main_service_airplay_no_service(self):
-        self.config.add_service(self.airplay_service)
-        with self.assertRaises(exceptions.NoServiceError):
-            self.config.main_service()
+    config.add_service(MRP_SERVICE)
+    assert config.identifier == IDENTIFIER_2
 
-    def test_main_service_get_service(self):
-        self.config.add_service(self.dmap_service)
-        self.assertEqual(self.config.main_service(), self.dmap_service)
+    config.add_service(AIRPLAY_SERVICE)
+    assert config.identifier == IDENTIFIER_2
 
-        self.config.add_service(self.mrp_service)
-        self.assertEqual(self.config.main_service(), self.mrp_service)
 
-    def test_main_service_override_protocol(self):
-        self.config.add_service(self.dmap_service)
-        self.config.add_service(self.mrp_service)
-        self.assertEqual(
-            self.config.main_service(protocol=self.dmap_service.protocol),
-            self.dmap_service,
-        )
+def test_add_airplay_service(config):
+    config.add_service(AIRPLAY_SERVICE)
 
-    def test_set_credentials_for_missing_service(self):
-        self.assertFalse(self.config.set_credentials(Protocol.DMAP, "dummy"))
+    airplay = config.get_service(Protocol.AirPlay)
+    assert airplay.protocol == Protocol.AirPlay
+    assert airplay.port == PORT_1
 
-    def test_set_credentials(self):
-        self.config.add_service(self.dmap_service)
-        self.assertIsNone(self.config.get_service(Protocol.DMAP).credentials)
 
-        self.config.set_credentials(Protocol.DMAP, "dummy")
-        self.assertEqual(self.config.get_service(Protocol.DMAP).credentials, "dummy")
+def test_main_service_no_service(config):
+    with pytest.raises(exceptions.NoServiceError):
+        config.main_service()
 
-    def test_empty_device_info(self):
-        config = conf.AppleTV(ADDRESS_1, NAME)
-        device_info = config.device_info
-        self.assertEqual(device_info.operating_system, OperatingSystem.Unknown)
-        self.assertIsNone(device_info.version)
-        self.assertIsNone(device_info.build_number)
-        self.assertEqual(device_info.model, DeviceModel.Unknown)
-        self.assertIsNone(device_info.mac)
 
-    def test_tvos_device_info(self):
-        self.config.add_service(self.mrp_service)
-        self.config.add_service(self.airplay_service)
+def test_main_service_airplay_no_service(config):
+    config.add_service(AIRPLAY_SERVICE)
+    with pytest.raises(exceptions.NoServiceError):
+        config.main_service()
 
-        device_info = self.config.device_info
-        self.assertEqual(device_info.operating_system, OperatingSystem.TvOS)
-        self.assertEqual(device_info.version, "8.0.0")
-        self.assertEqual(device_info.build_number, "17K795")
-        self.assertEqual(device_info.model, DeviceModel.Gen4K)
-        self.assertEqual(device_info.mac, "FF:EE:DD:CC:BB:AA")
 
-    def test_tvos_device_info_no_airplay(self):
-        self.config.add_service(self.mrp_service)
+def test_main_service_get_service(config):
+    config.add_service(DMAP_SERVICE)
+    assert config.main_service() == DMAP_SERVICE
 
-        device_info = self.config.device_info
-        self.assertEqual(device_info.operating_system, OperatingSystem.TvOS)
-        self.assertEqual(device_info.version, "13.3.1")
-        self.assertEqual(device_info.build_number, "17K795")
-        self.assertEqual(device_info.model, DeviceModel.Gen2)
-        self.assertEqual(device_info.mac, "FF:EE:DD:CC:BB:AA")
+    config.add_service(MRP_SERVICE)
+    assert config.main_service() == MRP_SERVICE
 
-    def test_legacy_device_info(self):
-        self.config.add_service(self.dmap_service)
-        self.config.add_service(self.airplay_service)
 
-        device_info = self.config.device_info
-        self.assertEqual(device_info.operating_system, OperatingSystem.Legacy)
-        self.assertEqual(device_info.version, "8.0.0")
-        self.assertIsNone(device_info.build_number)
-        self.assertEqual(device_info.model, DeviceModel.Gen4K)
-        self.assertEqual(device_info.mac, "AA:BB:CC:DD:EE:FF")
+def test_main_service_override_protocol(config):
+    config.add_service(DMAP_SERVICE)
+    config.add_service(MRP_SERVICE)
+    assert config.main_service(protocol=DMAP_SERVICE.protocol) == DMAP_SERVICE
 
-    def test_ready_dmap(self):
-        self.assertFalse(self.config.ready)
 
-        self.config.add_service(self.airplay_service)
-        self.assertFalse(self.config.ready)
+def test_set_credentials_for_missing_service(config):
+    assert not config.set_credentials(Protocol.DMAP, "dummy")
 
-        self.config.add_service(self.dmap_service)
-        self.assertTrue(self.config.ready)
 
-    def test_ready_mrp(self):
-        self.assertFalse(self.config.ready)
+def test_set_credentials(config):
+    config.add_service(DMAP_SERVICE)
+    assert config.get_service(Protocol.DMAP).credentials is None
 
-        self.config.add_service(self.airplay_service)
-        self.assertFalse(self.config.ready)
+    config.set_credentials(Protocol.DMAP, "dummy")
+    assert config.get_service(Protocol.DMAP).credentials == "dummy"
 
-        self.config.add_service(self.mrp_service)
-        self.assertTrue(self.config.ready)
 
-    # This test is a bit strange and couples to protocol specific services,
-    # but it's mainly to exercise string as that is important. Might refactor
-    # this in the future.
-    def test_to_str(self):
-        self.config.add_service(conf.DmapService(IDENTIFIER_1, "LOGIN_ID"))
-        self.config.add_service(conf.MrpService(IDENTIFIER_2, PORT_2))
+def test_empty_device_info(config):
+    config = conf.AppleTV(ADDRESS_1, NAME)
+    device_info = config.device_info
+    assert device_info.operating_system == OperatingSystem.Unknown
+    assert device_info.version is None
+    assert device_info.build_number is None
+    assert device_info.model == DeviceModel.Unknown
+    assert device_info.mac is None
 
-        # Check for some keywords to not lock up format too much
-        output = str(self.config)
-        self.assertIn(ADDRESS_1, output)
-        self.assertIn(NAME, output)
-        self.assertIn("LOGIN_ID", output)
-        self.assertIn(str(PORT_2), output)
-        self.assertIn("3689", output)
-        self.assertIn("Deep Sleep: True", output)
+
+def test_tvos_device_info(config):
+    config.add_service(MRP_SERVICE)
+    config.add_service(AIRPLAY_SERVICE)
+
+    device_info = config.device_info
+    assert device_info.operating_system == OperatingSystem.TvOS
+    assert device_info.version == "8.0.0"
+    assert device_info.build_number == "17K795"
+    assert device_info.model == DeviceModel.Gen4K
+    assert device_info.mac == "FF:EE:DD:CC:BB:AA"
+
+
+def test_tvos_device_info_no_airplay(config):
+    config.add_service(MRP_SERVICE)
+
+    device_info = config.device_info
+    assert device_info.operating_system == OperatingSystem.TvOS
+    assert device_info.version == "13.3.1"
+    assert device_info.build_number == "17K795"
+    assert device_info.model == DeviceModel.Gen2
+    assert device_info.mac == "FF:EE:DD:CC:BB:AA"
+
+
+def test_legacy_device_info(config):
+    config.add_service(DMAP_SERVICE)
+    config.add_service(AIRPLAY_SERVICE)
+
+    device_info = config.device_info
+    assert device_info.operating_system == OperatingSystem.Legacy
+    assert device_info.version == "8.0.0"
+    assert device_info.build_number is None
+    assert device_info.model == DeviceModel.Gen4K
+    assert device_info.mac == "AA:BB:CC:DD:EE:FF"
+
+
+def test_ready_dmap(config):
+    assert not config.ready
+
+    config.add_service(AIRPLAY_SERVICE)
+    assert not config.ready
+
+    config.add_service(DMAP_SERVICE)
+    assert config.ready
+
+
+def test_ready_mrp(config):
+    assert not config.ready
+
+    config.add_service(AIRPLAY_SERVICE)
+    assert not config.ready
+
+    config.add_service(MRP_SERVICE)
+    assert config.ready
+
+
+# This test is a bit strange and couples to protocol specific services,
+# but it's mainly to exercise string as that is important. Might refactor
+# this in the future.
+def test_to_str(config):
+    config.add_service(conf.DmapService(IDENTIFIER_1, "LOGIN_ID"))
+    config.add_service(conf.MrpService(IDENTIFIER_2, PORT_2))
+
+    # Check for some keywords to not lock up format too much
+    output = str(config)
+    assert ADDRESS_1 in output
+    assert NAME in output
+    assert "LOGIN_ID" in output
+    assert str(PORT_2) in output
+    assert "3689" in output
+    assert "Deep Sleep: True" in output

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -191,6 +191,13 @@ def test_ready_mrp(config):
     assert config.ready
 
 
+# Name collisions on the network results in _X being added to the identifier,
+# which should be stripped
+def test_dmap_identifier_strip():
+    service = conf.DmapService("abcd_2", "dummy")
+    assert service.identifier == "abcd"
+
+
 # This test is a bit strange and couples to protocol specific services,
 # but it's mainly to exercise string as that is important. Might refactor
 # this in the future.


### PR DESCRIPTION
See #780.