### PR TITLE
Release 0.7.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # CHANGES
 
+## 0.7.4 (2020-10-12)
+
+*Changes:*
+
+* PIN code screen for MRP will now disappear after pairing
+* Less and more compact debug logs in mdns and knock
+
+*All changes:*
+
+```
+9f1d1d0 mrp: Verify credentials after pairing
+1d799f2 cq: Minor clean ups and fixes
+061add1 build(deps): bump codecov from 2.1.9 to 2.1.10
+dc31ac9 build(deps-dev): bump tox from 3.20.0 to 3.20.1
+```
+
 ## 0.7.3 (2020-10-08)
 
 *Changes:*

--- a/docs/api/pyatv/const.html
+++ b/docs/api/pyatv/const.html
@@ -168,7 +168,7 @@ from enum import Enum
 
 MAJOR_VERSION = &#34;0&#34;
 MINOR_VERSION = &#34;7&#34;
-PATCH_VERSION = &#34;3&#34;
+PATCH_VERSION = &#34;4&#34;
 __short_version__ = &#34;{}.{}&#34;.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = &#34;{}.{}&#34;.format(__short_version__, PATCH_VERSION)
 

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 MAJOR_VERSION = "0"
 MINOR_VERSION = "7"
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 


### PR DESCRIPTION
## 0.7.4 (2020-10-12)

*Changes:*

* PIN code screen for MRP will now disappear after pairing
* Less and more compact debug logs in mdns and knock

*All changes:*

```
9f1d1d0 mrp: Verify credentials after pairing
1d799f2 cq: Minor clean ups and fixes
061add1 build(deps): bump codecov from 2.1.9 to 2.1.10
dc31ac9 build(deps-dev): bump tox from 3.20.0 to 3.20.1
```