### PR TITLE
Update setup.py, extend exclude mask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     description="Library for controlling an Apple TV",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    packages=find_packages(exclude=["tests", "tests.*"]),
+    packages=find_packages(exclude=["tests", "tests.*", "examples"]),
     include_package_data=True,
     zip_safe=False,
     platforms="any",


### PR DESCRIPTION
otherwise it tries to install a package called `examples` at top level, which is forbidden:

```
...
no previously-included directories found matching 'docs/_site'
no previously-included directories found matching 'docs/.sass-cache'
writing manifest file 'pyatv.egg-info/SOURCES.txt'
Copying pyatv.egg-info to /var/tmp/portage/dev-python/pyatv-0.7.4/image/_python3.8/usr/lib/python3.8/site-packages/pyatv-0.7.4-py3.8.egg-info
running install_scripts
Installing atvproxy script to /var/tmp/portage/dev-python/pyatv-0.7.4/image/_python3.8/usr/lib/python-exec/python3.8
Installing atvremote script to /var/tmp/portage/dev-python/pyatv-0.7.4/image/_python3.8/usr/lib/python-exec/python3.8
Installing atvscript script to /var/tmp/portage/dev-python/pyatv-0.7.4/image/_python3.8/usr/lib/python-exec/python3.8
 * ERROR: dev-python/pyatv-0.7.4::HomeAssistantRepository failed (install phase):
 *   Package installs 'examples' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  125:  Called src_install
 *   environment, line 2971:  Called distutils-r1_src_install
 *   environment, line 1198:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  445:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2587:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2069:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2067:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  802:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1166:  Called distutils-r1_python_install
 *   environment, line 1085:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
```