### PR TITLE
update MANIFEST.in, add missing file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include CHANGES.md
 include README.md
 include LICENSE.md
 include CONTRIBUTORS.md
+include base_versions.txt
 graft pyatv
 graft tests
 graft docs


### PR DESCRIPTION
otherwise the SDIST from Pypi is not compilable, because base_versions.txt (which is read by setup.py) would be missing.