### PR TITLE
Use TCP keepalive on more platforms

### DIFF
--- a/pyatv/support/net.py
+++ b/pyatv/support/net.py
@@ -123,7 +123,7 @@ def tcp_keepalive(sock) -> None:
         try:
             option = getattr(socket, option_name)
         except AttributeError:
-            if current_platform == "Darwin":
+            if current_platform == "Darwin" and option_name == "TCP_KEEPIDLE":
                 # TCP_KEEPALIVE will hopefully be available at some point,
                 # (https://bugs.python.org/issue34932) but until then the value is
                 # hardcoded.

--- a/pyatv/support/net.py
+++ b/pyatv/support/net.py
@@ -105,23 +105,6 @@ def get_private_addresses() -> List[IPv4Address]:
 # Reference: https://stackoverflow.com/a/14855726
 def tcp_keepalive(sock) -> None:
     """Configure keep-alive on a socket."""
-
-    def _setopt(option, value):
-        try:
-            if isinstance(option, str):
-                if hasattr(socket, option):
-                    option = getattr(socket, option)
-                else:
-                    raise exceptions.NotSupportedError(
-                        f"Option {option} is not supported"
-                    )
-
-            sock.setsockopt(socket.IPPROTO_TCP, option, value)
-        except OSError as ex:
-            raise exceptions.NotSupportedError(
-                f"Unable to set {option} on {sock}: {ex}"
-            )
-
     current_platform = platform.system()
 
     if not hasattr(socket, "SO_KEEPALIVE"):
@@ -129,24 +112,33 @@ def tcp_keepalive(sock) -> None:
 
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 
-    # Look up options depending on operating system
-    optnames = {
-        # https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/netinet/tcp.h#L206  # noqa
-        "Darwin": (0x10, 0x101, 0x102),
-        "Linux": ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT"),
-        "Windows": ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT"),
-    }.get(current_platform, None)
-
-    if optnames is None:
-        raise exceptions.NotSupportedError(
-            f"{current_platform} does not support keep-alive"
-        )
-
     # Default values are 1s idle time, 5s interval and 4 fails
-    idle, intvl, cnt = optnames
-    _setopt(idle, 1)
-    _setopt(intvl, 5)
-    _setopt(cnt, 4)
+    keepalive_options = {
+        "TCP_KEEPIDLE": 1,
+        "TCP_KEEPINTVL": 5,
+        "TCP_KEEPCNT": 4,
+    }
+
+    for option_name, value in keepalive_options.items():
+        try:
+            option = getattr(socket, option_name)
+        except AttributeError:
+            if current_platform == "Darwin":
+                # TCP_KEEPALIVE will hopefully be available at some point,
+                # (https://bugs.python.org/issue34932) but until then the value is
+                # hardcoded.
+                # https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/netinet/tcp.h#L206  # noqa
+                option = 0x10
+            else:
+                raise exceptions.NotSupportedError(
+                    f"Option {option_name} is not supported"
+                )
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, option, value)
+        except OSError as ex:
+            raise exceptions.NotSupportedError(
+                f"Unable to set {option_name} ({option:#x}) on {sock}: {ex}"
+            )
 
     _LOGGER.debug("Configured keep-alive on %s (%s)", sock, current_platform)
 

--- a/tests/support/test_net.py
+++ b/tests/support/test_net.py
@@ -2,12 +2,14 @@
 
 from typing import Dict, List
 from ipaddress import IPv4Address, ip_address
+import socket
 from unittest.mock import patch
 
 import pytest
 import netifaces
 
-from pyatv.support.net import get_private_addresses
+from pyatv.support.net import get_private_addresses, tcp_keepalive
+from pyatv.exceptions import NotSupportedError
 
 
 @pytest.fixture(autouse=True)
@@ -32,6 +34,25 @@ def mock_address():
             mock_interfaces.side_effect = lambda: list(addresses.keys())
             mock_ifaddr.side_effect = _ifaddresses
             yield _add
+
+
+@pytest.fixture
+def mock_server():
+    sock = socket.socket()
+    sock.bind(("127.0.0.127", 0))
+    sock.listen(1)
+    yield sock
+    sock.shutdown(socket.SHUT_RDWR)
+    sock.close()
+
+
+@pytest.fixture
+def mock_client(mock_server):
+    sock = socket.socket()
+    sock.connect(mock_server.getsockname())
+    yield sock
+    sock.shutdown(socket.SHUT_RDWR)
+    sock.close()
 
 
 def test_no_address():
@@ -59,3 +80,36 @@ def test_public_addresses(mock_address):
 def test_localhost(mock_address):
     mock_address("eth0", "127.0.0.1")
     assert get_private_addresses() == [IPv4Address("127.0.0.1")]
+
+
+def test_keepalive(mock_server, mock_client):
+    """Test that TCP keepalive can be enabled."""
+    server2client, client_address = mock_server.accept()
+    with server2client:
+        # No assert, as we're just testing that enabling keepalive works
+        tcp_keepalive(mock_client)
+        server2client.shutdown(socket.SHUT_RDWR)
+
+
+# TCP keepalive options to remove one at a time
+TCP_KEEPALIVE_OPTIONS = [
+    "TCP_KEEPIDLE",
+    "TCP_KEEPINTVL",
+    "TCP_KEEPCNT",
+]
+
+
+@pytest.mark.parametrize("missing_option", TCP_KEEPALIVE_OPTIONS)
+def test_keepalive_missing_sockopt(
+    missing_option,
+    mock_server,
+    mock_client,
+    monkeypatch,
+):
+    """Test that missing keepalive options raise `NotSupportedError`."""
+    monkeypatch.delattr(socket, missing_option)
+    server2client, client_address = mock_server.accept()
+    with server2client:
+        with pytest.raises(NotSupportedError):
+            tcp_keepalive(mock_client)
+        server2client.shutdown(socket.SHUT_RDWR)

--- a/tests/support/test_net.py
+++ b/tests/support/test_net.py
@@ -39,7 +39,8 @@ def mock_address():
 @pytest.fixture
 def mock_server():
     sock = socket.socket()
-    sock.bind(("127.0.0.127", 0))
+    # 127.0.0.1 *must* be used when testing on macOS
+    sock.bind(("127.0.0.1", 0))
     sock.listen(1)
     yield sock
     sock.shutdown(socket.SHUT_RDWR)

--- a/tests/support/test_net.py
+++ b/tests/support/test_net.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, List
 from ipaddress import IPv4Address, ip_address
+import platform
 import socket
 from unittest.mock import patch
 
@@ -10,6 +11,12 @@ import netifaces
 
 from pyatv.support.net import get_private_addresses, tcp_keepalive
 from pyatv.exceptions import NotSupportedError
+
+
+skip_darwin = pytest.mark.skipif(
+    platform.system() == "Darwin",
+    reason="not applicable to Darwin",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -91,7 +98,8 @@ def test_keepalive(mock_server, mock_client):
 
 # TCP keepalive options to remove one at a time
 TCP_KEEPALIVE_OPTIONS = [
-    "TCP_KEEPIDLE",
+    # Darwin has a hard-coded value for the equivalent option
+    pytest.param("TCP_KEEPIDLE", marks=skip_darwin),
     "TCP_KEEPINTVL",
     "TCP_KEEPCNT",
 ]

--- a/tests/support/test_net.py
+++ b/tests/support/test_net.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 from ipaddress import IPv4Address, ip_address
 import platform
 import socket
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -104,6 +105,10 @@ def test_localhost(mock_address):
 # Windows 10 1709 (build 16299) is the first version with TCP_KEEPIDLE
 # ref: https://github.com/python/cpython/blob/66d3b589c44fcbcf9afe1e442d9beac3bd8bcd34/Modules/socketmodule.c#L318-L322 # noqa
 @skip_before_win_build(16299)
+# More specifically, TCP_KEEPIDLE and TCP_KEEPINTVL were added in 3.7, while 3.6.5 added
+# TCP_KEEPCNT
+# ref: `socket.SO_*` documentation.
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="keepalive added in 3.7")
 def test_keepalive(mock_server, mock_client):
     """Test that TCP keepalive can be enabled."""
     server2client, client_address = mock_server.accept()

--- a/tests/support/test_net.py
+++ b/tests/support/test_net.py
@@ -43,7 +43,6 @@ def mock_server():
     sock.bind(("127.0.0.1", 0))
     sock.listen(1)
     yield sock
-    sock.shutdown(socket.SHUT_RDWR)
     sock.close()
 
 
@@ -52,7 +51,6 @@ def mock_client(mock_server):
     sock = socket.socket()
     sock.connect(mock_server.getsockname())
     yield sock
-    sock.shutdown(socket.SHUT_RDWR)
     sock.close()
 
 
@@ -89,7 +87,6 @@ def test_keepalive(mock_server, mock_client):
     with server2client:
         # No assert, as we're just testing that enabling keepalive works
         tcp_keepalive(mock_client)
-        server2client.shutdown(socket.SHUT_RDWR)
 
 
 # TCP keepalive options to remove one at a time
@@ -113,4 +110,3 @@ def test_keepalive_missing_sockopt(
     with server2client:
         with pytest.raises(NotSupportedError):
             tcp_keepalive(mock_client)
-        server2client.shutdown(socket.SHUT_RDWR)


### PR DESCRIPTION
This should allow using keepalive on platforms that have the appropriate constants available within Python, as well as Darwin. The main personal driver for this was to silence the warning (and actually implementing keepalive support) on FreeBSD, which should address #836. I also added a couple of tests for the `tcp_keepailve()` function.