### PR TITLE
Slightly refine protobuf and srptools base requirements

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,6 +1,6 @@
 aiohttp==3.1.0,<5
 cryptography==2.6
 netifaces==0.10.0
-protobuf==3.6.0
+protobuf==3.6.0,<4
 srptools===0.2.0
 zeroconf==0.28.0

--- a/base_versions.txt
+++ b/base_versions.txt
@@ -2,5 +2,5 @@ aiohttp==3.1.0,<5
 cryptography==2.6
 netifaces==0.10.0
 protobuf==3.6.0,<4
-srptools===0.2.0
+srptools==0.2.0
 zeroconf==0.28.0


### PR DESCRIPTION
This was triggered by protobuf having release 4.0.0-rc2, and then
abandoning the idea of a 4.0 release. There have been a few releases
since then, and 4.0 is spewing warning messages.