### PR TITLE
gha: Generate html logs for logs in issues

### DIFF
--- a/.github/workflows/log.yaml
+++ b/.github/workflows/log.yaml
@@ -1,0 +1,56 @@
+name: Log2HTML
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+
+jobs:
+  generate_html:
+    name: Generate HTML log
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Generate HTML output
+      id: genout
+      env:
+        CONTENT_COMMENT: ${{ github.event.comment.body }}
+        CONTENT_ISSUE: ${{ github.event.issue.body }}
+        COMMENT_NUMBER: ${{ github.event.comment.id }}
+      run: |
+        if [ "$GITHUB_EVENT_NAME" = "issue_comment" ]; then
+            var=CONTENT_COMMENT
+            source="comment #${COMMENT_NUMBER}"
+        else
+            var=CONTENT_ISSUE
+            source="issue description"
+        fi
+
+        base_name=$(uuidgen)
+        python scripts/log2html.py --output ${base_name}.html --format markdown --env $var
+        echo "logfile=${base_name}.html" >> $GITHUB_ENV
+        echo "source=${source}" >> $GITHUB_ENV
+    - name: Check if log exists
+      id: check_files
+      uses: andstor/file-existence-action@v1
+      with:
+        files: ${{ env.logfile }}
+    - uses: EndBug/add-and-commit@v7
+      if: steps.check_files.outputs.files_exists == 'true'
+      with:
+        message: "Add ${{ env.logfile }}"
+        branch: logfiles
+        add: ${{ env.logfile }}
+    - name: Post Status
+      if: steps.check_files.outputs.files_exists == 'true'
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        body: |
+          Generated html log for ${{ env.source }} is <a href="http://htmlpreview.github.io/?${{ github.server_url }}/${{ github.repository }}/blob/logfiles/${{ env.logfile }}">here</a>.


### PR DESCRIPTION
When using the following syntax to add logs in an issue:

~~~
```log
log goes here
 ```
~~~

A workflow will be triggered that generates an html log, commits it to a
branch and posts a new comment in the issue with a link to the file.
It works with new issues, comments and edits to existing comments.