### PR TITLE
log2html: Fix broken log entry loading

### DIFF
--- a/.github/workflows/log.yaml
+++ b/.github/workflows/log.yaml
@@ -20,15 +20,13 @@ jobs:
     - name: Generate HTML output
       id: genout
       env:
-        ISSUE_BODY: ${{ toJson(github.event.issue.body) }}
         COMMENT_NUMBER: ${{ github.event.comment.id }}
-        COMMENT_BODY: ${{ toJson(github.event.comment.body) }}
       run: |
         if [ "$GITHUB_EVENT_NAME" = "issue_comment" ]; then
-            echo $COMMENT_BODY > raw
+            echo '${{ toJson(github.event.comment.body) }}' > raw
             source="comment #${COMMENT_NUMBER}"
         else
-            echo $ISSUE_BODY > raw
+            echo '${{ toJson(github.event.issue.body) }}' > raw
             source="issue description"
         fi
 

--- a/scripts/log2html.py
+++ b/scripts/log2html.py
@@ -97,7 +97,7 @@ HTML_TEMPLATE = """<head>
       populate();
     }}
 
-    window.onload = function loadData() {{
+    function loadData() {{
       var log_levels = new Set();
 
       for (const entry of content) {{
@@ -131,6 +131,14 @@ HTML_TEMPLATE = """<head>
 
       populate();
     }}
+
+    // onload does not seem to work nicely with htmlpreview, so this is a workaround
+    var checkExist = setInterval(function() {{
+      if (document.getElementById("entries")) {{
+        loadData();
+        clearInterval(checkExist);
+      }}
+    }}, 100);
   </script>
 
 </head>


### PR DESCRIPTION
It seems like onload does not work reliably with htmlpreview, so now a
polling loop looking for the element used for displaying log entries
is used instead. Not so pretty but works for now.

A workaround, storing the issue/comment body in a file instead of
passsing via environment variable has also been introduced. Storing too
large payloads in an environment variable seemed to throw an error.