### PR TITLE
gha: Save log for log2html using pygithub

### DIFF
--- a/.github/workflows/log.yaml
+++ b/.github/workflows/log.yaml
@@ -17,24 +17,40 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+    - name: Install pygithub
+      run: |
+        pip install pygithub
+    - uses: jannekem/run-python-script-action@v1
+      with:
+        fail-on-error: false
+        script: |
+          from github import Github
+          g = Github("${{ secrets.GITHUB_TOKEN }}")
+          repo = g.get_repo("${{ github.repository }}")
+          issue = repo.get_issue(${{ github.event.issue.number }})
+
+          if "${{ github.event_name }}" == "issues":
+              body = issue.body
+          else:
+              body = issue.get_comment(${{ github.event.comment.id }}).body
+
+          with open("body", "w") as fh:
+              fh.write(body)
     - name: Generate HTML output
       id: genout
-      env:
-        COMMENT_NUMBER: ${{ github.event.comment.id }}
       run: |
-        if [ "$GITHUB_EVENT_NAME" = "issue_comment" ]; then
-            echo '${{ toJson(github.event.comment.body) }}' > raw
-            source="comment #${COMMENT_NUMBER}"
+        base_name=$(uuidgen)
+        echo "logfile=${base_name}.html" >> $GITHUB_ENV
+
+        if [ "${{ github.event_name }}" = "issues" ]; then
+            echo "source=issue description" >> $GITHUB_ENV
         else
-            echo '${{ toJson(github.event.issue.body) }}' > raw
-            source="issue description"
+            echo "source=for comment #${{ github.event.comment.id }}" >> $GITHUB_ENV
         fi
 
-        python -c 'import json; print(json.load(open("raw")))' > body
-        base_name=$(uuidgen)
-        python scripts/log2html.py --output ${base_name}.html --format markdown body
-        echo "logfile=${base_name}.html" >> $GITHUB_ENV
-        echo "source=${source}" >> $GITHUB_ENV
+        if [ -e "body" ]; then
+            python scripts/log2html.py --output ${base_name}.html --format markdown body
+        fi
     - name: Check if log exists
       id: check_files
       uses: andstor/file-existence-action@v1


### PR DESCRIPTION
To circumvent a lot of problems getting the issue/ comment body used
for log extraction, use the API (via pygithub) to save the body instead.
That takes care of all potential problems with sizes and unescaped characters.