### PR TITLE
Improve handling of unreliable connections

### DIFF
--- a/docs/api/pyatv/exceptions.html
+++ b/docs/api/pyatv/exceptions.html
@@ -39,6 +39,9 @@ link_group: api
 <h4><code><a title="pyatv.exceptions.InvalidDmapDataError" href="#pyatv.exceptions.InvalidDmapDataError">InvalidDmapDataError</a></code></h4>
 </li>
 <li>
+<h4><code><a title="pyatv.exceptions.InvalidStateError" href="#pyatv.exceptions.InvalidStateError">InvalidStateError</a></code></h4>
+</li>
+<li>
 <h4><code><a title="pyatv.exceptions.NoAsyncListenerError" href="#pyatv.exceptions.NoAsyncListenerError">NoAsyncListenerError</a></code></h4>
 </li>
 <li>
@@ -153,7 +156,11 @@ class NonLocalSubnetError(Exception):
     &#34;&#34;&#34;Thrown when address it not in any local subnet.
 
     DEPRECATED: Not used since 0.7.1. Will be removed in 0.9.0!
-    &#34;&#34;&#34;</code></pre>
+    &#34;&#34;&#34;
+
+
+class InvalidStateError(Exception):
+    &#34;&#34;&#34;Thrown when trying to perform an action not possible in the current state.&#34;&#34;&#34;</code></pre>
 </details>
 </section>
 <section>
@@ -291,6 +298,25 @@ class NonLocalSubnetError(Exception):
 </summary>
 <pre><code class="python">class InvalidDmapDataError(Exception):
     &#34;&#34;&#34;Thrown when invalid DMAP data is parsed.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="pyatv.exceptions.InvalidStateError"><code class="flex name class">
+<span>class <span class="ident">InvalidStateError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Thrown when trying to perform an action not possible in the current state.</p></section>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class InvalidStateError(Exception):
+    &#34;&#34;&#34;Thrown when trying to perform an action not possible in the current state.&#34;&#34;&#34;</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">

--- a/pyatv/exceptions.py
+++ b/pyatv/exceptions.py
@@ -70,3 +70,7 @@ class NonLocalSubnetError(Exception):
 
     DEPRECATED: Not used since 0.7.1. Will be removed in 0.9.0!
     """
+
+
+class InvalidStateError(Exception):
+    """Thrown when trying to perform an action not possible in the current state."""


### PR DESCRIPTION
Resolves #1007

- Cleans up old connection by calling ```stop()``` before establishing a new connection
- Prevents unintentionally ```start()```ing a new connection after ```stop()```ing
- Prevents multiple parallel ```connect()``` calls