### PR TITLE
env: Remove documentation tab from GitPod for now

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,8 @@
 image: gitpod/workspace-full
 tasks:
-  - init: ./scripts/setup_dev_env.sh
+  - name: Development
+    init: ./scripts/setup_dev_env.sh
     command: source bin/activate
-    prebuild: tox -p auto
-  - command: ./scripts/build_docs.sh serve
 
 ports:
   - port: 4000 # Used for documentation

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A python client library for the Apple TV
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![PyPi Package](https://badge.fury.io/py/pyatv.svg)](https://badge.fury.io/py/pyatv)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/postlund/pyatv.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/postlund/pyatv/context:python)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/postlund/pyatv)
 [![Downloads](https://pepy.tech/badge/pyatv)](https://pepy.tech/project/pyatv)
 [![PyPI pyversions](https://img.shields.io/pypi/pyversions/pyatv.svg)](https://pypi.python.org/pypi/pyatv/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
It's not possible to use DockerInDocker, so the build_docs.sh script
won't work. I need to create my own Dockerfile with Jekyll in it and
run without Docker.

Add a GitPod badge to README as well.