### PR TITLE
raop: Respect receiver audio properties

### DIFF
--- a/pyatv/raop/__init__.py
+++ b/pyatv/raop/__init__.py
@@ -47,8 +47,6 @@ class RaopStream(Stream):
 
         INCUBATING METHOD - MIGHT CHANGE IN THE FUTURE!
         """
-        audio_file = MiniaudioWrapper(filename)
-
         context = RtspContext()
         _, session = await self.loop.create_connection(
             lambda: RtspSession(context), self.address, self.service.port
@@ -56,7 +54,17 @@ class RaopStream(Stream):
 
         client = RaopClient(cast(RtspSession, session), context)
         try:
-            await client.initialize()
+            await client.initialize(self.service.properties)
+
+            # After initialize has been called, all the audio properties will be
+            # initialized and can be used in the miniaudio wrapper
+            audio_file = MiniaudioWrapper(
+                filename,
+                context.sample_rate,
+                context.channels,
+                context.bytes_per_channel,
+            )
+
             await client.send_audio(audio_file)
         finally:
             client.close()

--- a/pyatv/raop/miniaudio.py
+++ b/pyatv/raop/miniaudio.py
@@ -6,6 +6,21 @@ wrapper, any file type supported by miniaudio can be played by the RAOP
 implementation in pyatv.
 """
 import miniaudio
+from miniaudio import SampleFormat
+
+from pyatv.exceptions import NotSupportedError
+
+
+def _int2sf(sample_size: int) -> SampleFormat:
+    if sample_size == 1:
+        return SampleFormat.UNSIGNED8
+    if sample_size == 2:
+        return SampleFormat.SIGNED16
+    if sample_size == 3:
+        return SampleFormat.SIGNED24
+    if sample_size == 4:
+        return SampleFormat.SIGNED32
+    raise NotSupportedError(f"unsupported sample size: {sample_size}")
 
 
 class MiniaudioWrapper:
@@ -14,9 +29,16 @@ class MiniaudioWrapper:
     Only the parts needed by pyatv (in Wave_read) are implemented!
     """
 
-    def __init__(self, filename) -> None:
+    def __init__(
+        self, filename: str, sample_rate: int, channels: int, sample_size: int
+    ) -> None:
         """Initialize a new MiniaudioWrapper instance."""
-        self.src = miniaudio.decode_file(filename)
+        self.src = miniaudio.decode_file(
+            filename,
+            output_format=_int2sf(sample_size),
+            nchannels=channels,
+            sample_rate=sample_rate,
+        )
         self.samples = self.src.samples.tobytes()
         self.pos = 0
 

--- a/pyatv/raop/parsers.py
+++ b/pyatv/raop/parsers.py
@@ -1,0 +1,65 @@
+"""Utility methods for parsing various kinds of data."""
+
+from enum import IntFlag
+from typing import Mapping, Tuple
+
+from pyatv import exceptions
+
+DEFAULT_SAMPLE_RATE = 44100
+DEFAULT_SAMPLE_SIZE = 16  # bits
+DEAFULT_CHANNELS = 2
+
+# pylint: disable=invalid-name
+
+
+class EncryptionType(IntFlag):
+    """Encryptions supported by receiver."""
+
+    Unknown = 0
+    Unencrypted = 1
+    RSA = 2
+    FairPlay = 4
+    MFiSAP = 8
+    FairPlaySAPv25 = 16
+
+
+# pylint: enable=invalid-name
+
+
+def get_audio_properties(properties: Mapping[str, str]) -> Tuple[int, int, int]:
+    """Parse Zeroconf properties and return sample rate, channels and sample size."""
+    try:
+        sample_rate = int(properties.get("sr", DEFAULT_SAMPLE_RATE))
+        channels = int(properties.get("ch", DEAFULT_CHANNELS))
+        sample_size = int(int(properties.get("ss", DEFAULT_SAMPLE_SIZE)) / 8)
+    except Exception as ex:
+        raise exceptions.ProtocolError("invalid audio property") from ex
+    else:
+        return sample_rate, channels, sample_size
+
+
+def get_encryption_types(properties: Mapping[str, str]) -> EncryptionType:
+    """Return encryption types supported by receiver.
+
+    Input format from zeroconf is a comma separated list:
+
+        0,1,3
+
+    Each number represents one encryption type.
+    """
+    output = EncryptionType.Unknown
+    try:
+        enc_types = [int(x) for x in properties["et"].split(",")]
+    except (KeyError, ValueError):
+        return output
+
+    else:
+        for enc_type in enc_types:
+            output |= {
+                0: EncryptionType.Unencrypted,
+                1: EncryptionType.RSA,
+                3: EncryptionType.FairPlay,
+                4: EncryptionType.MFiSAP,
+                5: EncryptionType.FairPlaySAPv25,
+            }.get(enc_type, EncryptionType.Unknown)
+    return output

--- a/tests/raop/test_parsers.py
+++ b/tests/raop/test_parsers.py
@@ -1,0 +1,66 @@
+"""Unit tests for pyatv.raop.raop."""
+
+import pytest
+
+from pyatv.exceptions import ProtocolError
+from pyatv.raop.parsers import (
+    EncryptionType,
+    get_audio_properties,
+    get_encryption_types,
+)
+
+
+@pytest.mark.parametrize(
+    "properties,expected_sr,expected_ch,expected_ss",
+    [
+        ({}, 44100, 2, 2),
+        ({"sr": "22050"}, 22050, 2, 2),
+        ({"ch": "4"}, 44100, 4, 2),
+        ({"ss": "32"}, 44100, 2, 4),
+    ],
+)
+def test_parse_properties(properties, expected_sr, expected_ch, expected_ss):
+    sample_rate, channels, sample_size = get_audio_properties(properties)
+    assert sample_rate == expected_sr
+    assert channels == expected_ch
+    assert sample_size == expected_ss
+
+
+@pytest.mark.parametrize("properties", [{"sr": "abc"}, {"ch": "cde"}, {"ss": "fgh"}])
+def test_parse_invalid_property_raises(properties):
+    with pytest.raises(ProtocolError):
+        get_audio_properties(properties)
+
+
+@pytest.mark.parametrize(
+    "properties,expected",
+    [
+        ({"et": "0"}, EncryptionType.Unencrypted),
+        ({"et": "1"}, EncryptionType.RSA),
+        ({"et": "3"}, EncryptionType.FairPlay),
+        ({"et": "4"}, EncryptionType.MFiSAP),
+        ({"et": "5"}, EncryptionType.FairPlaySAPv25),
+        ({"et": "0,1"}, EncryptionType.Unencrypted | EncryptionType.RSA),
+    ],
+)
+def test_parse_encryption_type(properties, expected):
+    assert get_encryption_types(properties) == expected
+
+
+@pytest.mark.parametrize(
+    "properties",
+    [
+        ({}),
+        ({"et": ""}),
+        ({"et": "foobar"}),
+    ],
+)
+def test_parse_encryption_bad_types(properties):
+    assert get_encryption_types(properties) == EncryptionType.Unknown
+
+
+def test_parse_encryption_include_unknown_type():
+    assert (
+        get_encryption_types({"et": "0,1000"})
+        == EncryptionType.Unknown | EncryptionType.Unencrypted
+    )


### PR DESCRIPTION
This makes sure that we re-encode and output audio in a format that the
receiver expects. Default parameters 44100/2/16bit is used when
properties are not present in Zeroconf.

A check has also been added that verifies that unencrypted audio is
supported by the receiver. Raises an exception otherwise.

Fixes #1067