### PR TITLE
companion: Add support for turn_on and turn_off

### DIFF
--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -44,6 +44,7 @@ link_group: api
 import asyncio
 import datetime  # noqa
 from ipaddress import IPv4Address
+import logging
 from typing import Dict, List
 
 import aiohttp
@@ -62,6 +63,8 @@ from pyatv.raop import setup as raop_setup
 from pyatv.support import net
 from pyatv.support.facade import FacadeAppleTV, SetupMethod
 from pyatv.support.scan import BaseScanner, MulticastMdnsScanner, UnicastMdnsScanner
+
+_LOGGER = logging.getLogger(__name__)
 
 _PROTOCOL_IMPLEMENTATIONS: Dict[Protocol, SetupMethod] = {
     Protocol.MRP: mrp_setup,
@@ -125,7 +128,9 @@ async def connect(
             raise RuntimeError(&#34;missing implementation for protocol {service.protocol}&#34;)
 
         setup_data = setup_method(loop, config, atv.interfaces, atv, session_manager)
-        atv.add_protocol(service.protocol, setup_data)
+        if setup_data:
+            _LOGGER.debug(&#34;Not adding protocol %s&#34;, service.protocol)
+            atv.add_protocol(service.protocol, setup_data)
 
     try:
         await atv.connect()
@@ -146,9 +151,7 @@ async def pair(
     &#34;&#34;&#34;Pair a protocol for an Apple TV.&#34;&#34;&#34;
     service = config.get_service(protocol)
     if not service:
-        raise exceptions.NoServiceError(
-            &#34;no service available for protocol &#34; + str(protocol)
-        )
+        raise exceptions.NoServiceError(f&#34;no service available for {protocol}&#34;)
 
     handler = {
         Protocol.DMAP: DmapPairingHandler,
@@ -158,7 +161,7 @@ async def pair(
     }.get(protocol)
 
     if handler is None:
-        raise RuntimeError(&#34;missing implementation for {protocol}&#34;)
+        raise RuntimeError(f&#34;missing implementation for {protocol}&#34;)
 
     return handler(config, await net.create_session(session), loop, **kwargs)</code></pre>
 </details>
@@ -228,7 +231,9 @@ async def pair(
             raise RuntimeError(&#34;missing implementation for protocol {service.protocol}&#34;)
 
         setup_data = setup_method(loop, config, atv.interfaces, atv, session_manager)
-        atv.add_protocol(service.protocol, setup_data)
+        if setup_data:
+            _LOGGER.debug(&#34;Not adding protocol %s&#34;, service.protocol)
+            atv.add_protocol(service.protocol, setup_data)
 
     try:
         await atv.connect()
@@ -258,9 +263,7 @@ async def pair(
     &#34;&#34;&#34;Pair a protocol for an Apple TV.&#34;&#34;&#34;
     service = config.get_service(protocol)
     if not service:
-        raise exceptions.NoServiceError(
-            &#34;no service available for protocol &#34; + str(protocol)
-        )
+        raise exceptions.NoServiceError(f&#34;no service available for {protocol}&#34;)
 
     handler = {
         Protocol.DMAP: DmapPairingHandler,
@@ -270,7 +273,7 @@ async def pair(
     }.get(protocol)
 
     if handler is None:
-        raise RuntimeError(&#34;missing implementation for {protocol}&#34;)
+        raise RuntimeError(f&#34;missing implementation for {protocol}&#34;)
 
     return handler(config, await net.create_session(session), loop, **kwargs)</code></pre>
 </details>

--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -2996,6 +2996,7 @@ def total_time(self) -&gt; Optional[int]:
 </ul>
 <h3>Subclasses</h3>
 <ul class="hlist">
+<li>pyatv.companion.CompanionPower</li>
 <li>pyatv.dmap.DmapPower</li>
 <li>pyatv.mrp.MrpPower</li>
 <li>pyatv.support.facade.FacadePower</li>

--- a/pyatv/airplay/__init__.py
+++ b/pyatv/airplay/__init__.py
@@ -5,7 +5,7 @@ import binascii
 import logging
 import os
 import re
-from typing import Any, Awaitable, Callable, Dict, Set, Tuple, cast
+from typing import Any, Awaitable, Callable, Dict, Optional, Set, Tuple, cast
 
 from aiohttp import ClientSession
 
@@ -128,7 +128,9 @@ def setup(
     interfaces: Dict[Any, Relayer],
     device_listener: StateProducer,
     session_manager: ClientSessionManager,
-) -> Tuple[Callable[[], Awaitable[None]], Callable[[], None], Set[FeatureName]]:
+) -> Optional[
+    Tuple[Callable[[], Awaitable[None]], Callable[[], None], Set[FeatureName]]
+]:
     """Set up a new AirPlay service."""
     service = config.get_service(Protocol.AirPlay)
     assert service is not None

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -588,7 +588,9 @@ def setup(
     interfaces: Dict[Any, Relayer],
     device_listener: StateProducer,
     session_manager: ClientSessionManager,
-) -> Tuple[Callable[[], Awaitable[None]], Callable[[], None], Set[FeatureName]]:
+) -> Optional[
+    Tuple[Callable[[], Awaitable[None]], Callable[[], None], Set[FeatureName]]
+]:
     """Set up a new DMAP service."""
     service = config.get_service(Protocol.DMAP)
     assert service is not None

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -688,7 +688,9 @@ def setup(  # pylint: disable=too-many-locals
     interfaces: Dict[Any, Relayer],
     device_listener: StateProducer,
     session_manager: ClientSessionManager,
-) -> Tuple[Callable[[], Awaitable[None]], Callable[[], None], Set[FeatureName]]:
+) -> Optional[
+    Tuple[Callable[[], Awaitable[None]], Callable[[], None], Set[FeatureName]]
+]:
     """Set up a new MRP service."""
     service = config.get_service(Protocol.MRP)
     assert service is not None

--- a/pyatv/raop/__init__.py
+++ b/pyatv/raop/__init__.py
@@ -182,7 +182,9 @@ def setup(
     interfaces: Dict[Any, Relayer],
     device_listener: StateProducer,
     session_manager: ClientSessionManager,
-) -> Tuple[Callable[[], Awaitable[None]], Callable[[], None], Set[FeatureName]]:
+) -> Optional[
+    Tuple[Callable[[], Awaitable[None]], Callable[[], None], Set[FeatureName]]
+]:
     """Set up a new RAOP service."""
     service = config.get_service(Protocol.RAOP)
     assert service is not None

--- a/pyatv/scripts/atvproxy.py
+++ b/pyatv/scripts/atvproxy.py
@@ -286,6 +286,7 @@ class RemoteConnection(asyncio.Protocol):
     def data_received(self, data):
         """Receive data from host."""
         log_binary(_LOGGER, "Data from remote", Data=data)
+        print(data)
         self.callback.transport.write(data)
 
 
@@ -314,6 +315,7 @@ class RelayConnection(asyncio.Protocol):
     def data_received(self, data):
         """Receive data from host."""
         log_binary(_LOGGER, "Data from client", Data=data)
+        print(data)
         self.connection.transport.write(data)
 
 

--- a/tests/companion/test_companion_functional.py
+++ b/tests/companion/test_companion_functional.py
@@ -5,8 +5,10 @@ import logging
 
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 from deepdiff import DeepDiff
+import pytest
 
 import pyatv
+from pyatv import exceptions
 from pyatv.companion.server_auth import CLIENT_CREDENTIALS
 from pyatv.conf import AppleTV, CompanionService, MrpService
 from pyatv.const import Protocol
@@ -52,6 +54,14 @@ class CompanionFunctionalTest(AioHTTPTestCase):
         return await pyatv.connect(self.conf, loop=self.loop)
 
     @unittest_run_loop
+    async def test_connect_only_companion(self):
+        conf = AppleTV(IPv4Address("127.0.0.1"), "Test device")
+        conf.add_service(CompanionService(self.fake_atv.get_port(Protocol.Companion)))
+
+        with pytest.raises(exceptions.DeviceIdMissingError):
+            await pyatv.connect(conf, loop=self.loop)
+
+    @unittest_run_loop
     async def test_launch_app(self):
         await self.atv.apps.launch_app(TEST_APP)
         await until(lambda: self.state.active_app == TEST_APP)
@@ -80,3 +90,13 @@ class CompanionFunctionalTest(AioHTTPTestCase):
             self.atv.features.get_feature(FeatureName.AppList).state
             == FeatureState.Available
         )
+
+    @unittest_run_loop
+    async def test_power_functions(self):
+        assert self.state.powered_on
+
+        await self.atv.power.turn_off()
+        assert not self.state.powered_on
+
+        await self.atv.power.turn_on()
+        assert self.state.powered_on


### PR DESCRIPTION
These methods will now have priority over MRP if both are present. To
make that work, Companion will not be set up if no credentials are
present. Otherwise it would be problematic to connect using a config
obtained via scanning without filling in Companion credentials.

Relates to #1051

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1104"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

