### PR TITLE
cq: Clean up usage of ensure_future

### DIFF
--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -516,13 +516,13 @@ class DmapPushUpdater(PushUpdater):
         first_call = True
 
         while True:
-            # Sleep some time before waiting for updates
-            if not first_call and self._initial_delay > 0:
-                _LOGGER.debug("Initial delay set to %d", self._initial_delay)
-                await asyncio.sleep(self._initial_delay)
-                first_call = False
-
             try:
+                # Sleep some time before waiting for updates
+                if not first_call and self._initial_delay > 0:
+                    _LOGGER.debug("Initial delay set to %d", self._initial_delay)
+                    await asyncio.sleep(self._initial_delay)
+                    first_call = False
+
                 _LOGGER.debug("Waiting for playstatus updates")
                 playstatus = await self._atv.playstatus(use_revision=True, timeout=0)
 

--- a/pyatv/mrp/__init__.py
+++ b/pyatv/mrp/__init__.py
@@ -615,6 +615,8 @@ class MrpPushUpdater(PushUpdater):
         try:
             playstatus = await self.metadata.playing()
             self.post_update(playstatus)
+        except asyncio.CancelledError:
+            pass
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.debug("Playstatus error occurred: %s", ex)
             self.loop.call_soon(self.listener.playstatus_error, self, ex)

--- a/pyatv/scripts/atvproxy.py
+++ b/pyatv/scripts/atvproxy.py
@@ -180,8 +180,13 @@ class CompanionAppleTVProxy(CompanionServerAuth, asyncio.Protocol):
     async def _process_task(self) -> None:
         while True:
             _LOGGER.debug("Waiting for data from client")
-            await self._receive_event.wait()
-            await self._process_buffer()
+            try:
+                await self._receive_event.wait()
+                await self._process_buffer()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                _LOGGER.exception("error processing incoming messages")
 
     async def _process_buffer(self) -> None:
         _LOGGER.debug("Process buffer (size: %d)", len(self.buffer))


### PR DESCRIPTION
This commit makes sure futures are properly cancelled and not laying
around after closing connection to a device.

Relates to #1123

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1124"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

