### PR TITLE
raop: Fallback to AirPlay credentials

### DIFF
--- a/docs/documentation/supported_features.md
+++ b/docs/documentation/supported_features.md
@@ -192,6 +192,9 @@ AirTunes).
 * Push Updates
 * Volume controls (volume level, set_volume, volume_up, volume_down)
 * One stream can be played at the time (second call raises {% include api i="exceptions.InvalidStateError" %})
+* If the device requires pairing, e.g. Apple TV 4 or later, the same pairing
+  procedure and credentials as AirPlay is to be used. If AirPlay credentials
+  are present, they will be used if no RAOP credentials are given.
 
 ### Limitations and notes
 


### PR DESCRIPTION
If no RAOP credentials are provided, use the ones from AirPlay if they
are present. It's the same credentials in the end.

Relates to #1078

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1146"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

