### PR TITLE
gitpod: Unset PIP_USER flag

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,6 @@
 image: gitpod/workspace-full
 tasks:
+  - before: "echo 'export PIP_USER=no' >> ~/.bashrc && export PIP_USER=no"
   - name: Documentation
     command: ./scripts/build_docs.sh
   - name: Development


### PR DESCRIPTION
It breaks `pip install ...` in the virtual environment.

See https://github.com/gitpod-io/gitpod/issues/1552

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1149"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

