### PR TITLE
raop: Use perf_counter instead of monotonic

### DIFF
--- a/pyatv/raop/timing.py
+++ b/pyatv/raop/timing.py
@@ -4,19 +4,19 @@ The timing routines in this module is based on the excellent work of RAOP-Player
 https://github.com/philippe44/RAOP-Player
 """
 
-from time import monotonic
+from time import perf_counter
 from typing import Tuple
 
 
-# TODO: Replace with time.monotonic_ns when python 3.6 is dropped
-def monotonic_ns():
-    """Return a monotonic time in nanoseconds."""
-    return int(monotonic() * 10 ** 9)
+# TODO: Replace with time.perf_counter_ns when python 3.6 is dropped
+def perf_counter_ns():
+    """Return a perf_counter time in nanoseconds."""
+    return int(perf_counter() * 10 ** 9)
 
 
 def ntp_now() -> int:
     """Return current time in NTP format."""
-    now_us = monotonic_ns() / 1000
+    now_us = perf_counter_ns() / 1000
     seconds = int(now_us / 1000000)
     frac = int(now_us - seconds * 1000000)
     return (seconds + 0x83AA7E80) << 32 | (int((frac << 32) / 1000000))


### PR DESCRIPTION
The implementation of monotonic on Windows has very low resolution, so
streaming doesn't work. So switch to perf_counter as it has much higher
resolution. On all platforms except for Windows, these function are
exactly the same.

Relates to #1169

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1171"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

