### PR TITLE
gha: Re-run tox without cache if failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,9 @@ jobs:
         python -m pip install --upgrade setuptools pip wheel
         python -m pip install tox-gh-actions
     - name: Test with tox
-      run: tox -q -p auto || tox -q -p auto
+      # Run once and if that fails, run again but force to re-download packages again.
+      # For some reason the cache breaks sometimes, see https://github.com/postlund/pyatv/issues/1174
+      run: tox -q -p auto || PIP_ARGS="--no-cache-dir" tox -q -p auto
     - name: Regression
       run: tox -q -p auto -e regression
       if: matrix.python-version == '3.8' && runner.os == 'Linux'

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ passenv = TOXENV CI CODECOV_*
 setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}/pyatv
+install_command = python -m pip install {env:PIP_ARGS:} {opts} {packages}
 depends =
     py{36,37,38,39}: clean generated
     report: py{36,37,38,39}


### PR DESCRIPTION
I don't know for sure if this fixes or even improves the situation, but I'll give it a try for a while and see.

Relates to #1174

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1175"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

