### PR TITLE
gha: Another attempt to re-run tox on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Test with tox
       # Run once and if that fails, run again but force to re-download packages again.
       # For some reason the cache breaks sometimes, see https://github.com/postlund/pyatv/issues/1174
-      run: tox -q -p auto || PIP_ARGS="--no-cache-dir" tox -q -p auto
+      run: ./scripts/tox.sh
     - name: Regression
       run: tox -q -p auto -e regression
       if: matrix.python-version == '3.8' && runner.os == 'Linux'

--- a/scripts/tox.sh
+++ b/scripts/tox.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This script is supposed to be run by GitHub actions. It will
+# re-run tox with pip cache disabled in case of error.
+tox -q -p auto || PIP_ARGS="--no-cache-dir" tox -q -p auto


### PR DESCRIPTION
It was not possible to set an environment variable mid-command:

    tox ... || SOME_ENV tox ...

So the command has moved to a script now.

Relates to #1174

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1180"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

