### PR TITLE
dmap: Add support for HSCP service

### DIFF
--- a/docs/api/pyatv/helpers.html
+++ b/docs/api/pyatv/helpers.html
@@ -29,7 +29,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Various helper methods.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/helpers.py#L0-L68" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/helpers.py#L0-L71" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -50,7 +50,7 @@ device found, connects to it and passes it to a user provided handler. An
 optional error handler can be provided that is called when no device was found.
 Very inflexible in many cases, but can be handys sometimes when trying things.</p>
 <p>Note: both handler and not_found must be coroutines</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/helpers.py#L15-L47" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/helpers.py#L16-L48" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.helpers.get_unique_id">
 <code class="name flex">
@@ -63,7 +63,7 @@ Very inflexible in many cases, but can be handys sometimes when trying things.</
 <code>service_name</code> name of the service (e.g. <em>Office</em> or <em>Living Room</em>) and
 <code>properties</code> all key-value properties belonging to the service.</p>
 <p>The unique identifier is returned if available, otherwise <code>None</code> is returned.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/helpers.py#L50-L69" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/helpers.py#L51-L72" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 </section>

--- a/docs/documentation/supported_features.md
+++ b/docs/documentation/supported_features.md
@@ -133,7 +133,8 @@ app and power related functions.
 ## DMAP
 
 This protocol is the same protocol (suite) used by iTunes in the past and mainly deals with
-metadata and playback. Only used by legacy devices, like the Apple TV 3.
+metadata and playback. It is used by legacy devices, like Apple TV 3 and also to control the
+Music app in macOS.
 
 ### Supported Features
 
@@ -154,6 +155,9 @@ metadata and playback. Only used by legacy devices, like the Apple TV 3.
   support for this exists in the protocol
 * No support for different tap actions in conjunction with button (e.g. double tap or
   hold) as it's not supported by the protocol
+* It is possible to discover and control a Music app running on macOS, assuming macOS
+  version is at most 11.3. From 11.4, FairPlay authentication is required, which no one
+  has reverse engnieered yet (ar least publicly and not relying on Apple binaries).
 
 ## MRP
 

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -567,11 +567,26 @@ def dmap_service_handler(
     return name, service
 
 
+def hscp_service_handler(
+    mdns_service: mdns.Service, response: mdns.Response
+) -> ScanHandlerReturn:
+    """Parse and return a new HSCP service."""
+    name = mdns_service.properties.get("Machine Name", "Unknown")
+    service = conf.DmapService(
+        get_unique_id(mdns_service.type, mdns_service.name, mdns_service.properties),
+        mdns_service.properties.get("hG"),
+        port=mdns_service.port,
+        properties=mdns_service.properties,
+    )
+    return name, service
+
+
 def scan() -> Mapping[str, ScanHandler]:
     """Return handlers used for scanning."""
     return {
         "_appletv-v2._tcp.local": homesharing_service_handler,
         "_touch-able._tcp.local": dmap_service_handler,
+        "_hscp._tcp.local": hscp_service_handler,
     }
 
 

--- a/pyatv/dmap/tag_definitions.py
+++ b/pyatv/dmap/tag_definitions.py
@@ -2,10 +2,15 @@
 
 import logging
 
-# TODO: pylint seems to mix up "parser" with some other deprecated
-# module (python 3.8 and later)?
-from .parser import DmapTag  # pylint: disable=deprecated-module
-from .tags import read_bool, read_bplist, read_bytes, read_ignore, read_str, read_uint
+from pyatv.dmap.parser import DmapTag
+from pyatv.dmap.tags import (
+    read_bool,
+    read_bplist,
+    read_bytes,
+    read_ignore,
+    read_str,
+    read_uint,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,12 +22,16 @@ def _read_unknown(data, start, length):
 
 # These are the tags that we know about so far
 _TAGS = {
+    "aels": DmapTag(read_uint, "com.apple.itunes.liked-state"),
     "aeFP": DmapTag(read_uint, "com.apple.itunes.req-fplay"),
+    "aeGs": DmapTag(read_bool, "com.apple.itunes.can-be-genius-seed"),
     "aeSV": DmapTag(read_uint, "com.apple.itunes.music-sharing-version"),
     "apro": DmapTag(read_uint, "daap.protocolversion"),
+    "asai": DmapTag(read_uint, "daap.songalbumid"),
     "asal": DmapTag(read_str, "daap.songalbum"),
     "asar": DmapTag(read_str, "daap.songartist"),
     "asgr": DmapTag(read_uint, "com.apple.itunes.gapless-resy"),
+    "astm": DmapTag(read_uint, "daap.songtime"),
     "ated": DmapTag(read_bool, "daap.supportsextradata"),
     "caar": DmapTag(read_uint, "dacp.albumrepeat"),
     "caas": DmapTag(read_uint, "dacp.albumshuffle"),
@@ -44,9 +53,8 @@ _TAGS = {
     "cavc": DmapTag(read_bool, "dacp.volumecontrollable"),
     "cave": DmapTag(read_bool, "dacp.dacpvisualizerenabled"),
     "cavs": DmapTag(read_uint, "dacp.visualizer"),
-    "ceQR": DmapTag(
-        "container", "com.apple.itunes.playqueue-contents-response"
-    ),  # NOQA
+    "ceGS": DmapTag(read_str, "com.apple.itunes.genius-selectable"),
+    "ceQR": DmapTag("container", "com.apple.itunes.playqueue-contents-response"),
     "ceSD": DmapTag(read_bplist, "playing metadata"),
     "cmcp": DmapTag("container", "dmcp.controlprompt"),
     "cmmk": DmapTag(read_uint, "dmcp.mediakind"),
@@ -99,6 +107,7 @@ _TAGS = {
     "ceMQ": DmapTag(read_bool, "unknown tag"),
     "ceNQ": DmapTag(read_uint, "unknown tag"),
     "ceNR": DmapTag(read_bytes, "unknown tag"),
+    "ceQu": DmapTag(read_bool, "unknown tag"),
     "cmbe": DmapTag(read_str, "unknown tag"),
     "cmcc": DmapTag(read_str, "unknown tag"),
     "cmce": DmapTag(read_str, "unknown tag"),
@@ -116,6 +125,6 @@ _TAGS = {
 def lookup_tag(name):
     """Look up a tag based on its key. Returns a DmapTag."""
     return next(
-        (value for tag, value in _TAGS.items() if tag == name),
+        (tag for tag_name, tag in _TAGS.items() if tag_name == name),
         DmapTag(_read_unknown, "unknown tag"),
     )

--- a/pyatv/helpers.py
+++ b/pyatv/helpers.py
@@ -10,6 +10,7 @@ DEVICE_SERVICE: str = "_touch-able._tcp.local"
 MEDIAREMOTE_SERVICE: str = "_mediaremotetv._tcp.local"
 AIRPLAY_SERVICE: str = "_airplay._tcp.local"
 RAOP_SERVICE: str = "_raop._tcp.local"
+HSCP_SERVICE: str = "_hscp._tcp.local"
 
 
 async def auto_connect(
@@ -60,6 +61,8 @@ def get_unique_id(
     """
     if service_type in [DEVICE_SERVICE, HOMESHARING_SERVICE]:
         return service_name.split("_")[0]
+    if service_type == HSCP_SERVICE:
+        return properties.get("Machine ID")
     if service_type == MEDIAREMOTE_SERVICE:
         return properties.get("UniqueIdentifier")
     if service_type == AIRPLAY_SERVICE:

--- a/tests/dmap/test_dmap.py
+++ b/tests/dmap/test_dmap.py
@@ -8,13 +8,15 @@ from pyatv.support import mdns
 
 HOMESHARING_SERVICE = "_appletv-v2._tcp.local"
 DMAP_SERVICE = "_touch-able._tcp.local"
+HSCP_SERVICE: str = "_hscp._tcp.local"
 
 
 def test_dmap_scan_handlers_present():
     handlers = scan()
-    assert len(handlers) == 2
+    assert len(handlers) == 3
     assert HOMESHARING_SERVICE in handlers
     assert DMAP_SERVICE in handlers
+    assert HSCP_SERVICE in handlers
 
 
 def test_homesharing_handler_to_service():

--- a/tests/dmap/test_dmap_scan.py
+++ b/tests/dmap/test_dmap_scan.py
@@ -68,6 +68,26 @@ async def test_multicast_scan_home_sharing_merge(udns_server, multicast_scan):
     )
 
 
+async def test_multicast_scan_hscp_device(udns_server, multicast_scan):
+    udns_server.add_service(
+        fake_udns.hscp_service(
+            DMAP_NAME, DMAP_SERVICE_NAME, DMAP_HSGID, addresses=[IP_1], port=3689
+        )
+    )
+
+    atvs = await multicast_scan()
+    assert len(atvs) == 1
+    assert_device(
+        atvs[0],
+        DMAP_NAME,
+        ip_address(IP_1),
+        DMAP_SERVICE_NAME,
+        Protocol.DMAP,
+        3689,
+        DMAP_HSGID,
+    )
+
+
 async def test_unicast_scan_homesharing(udns_server, unicast_scan):
     udns_server.add_service(
         fake_udns.homesharing_service(
@@ -104,4 +124,24 @@ async def test_unicast_scan_no_homesharing(udns_server, unicast_scan):
         DMAP_SERVICE_NAME,
         Protocol.DMAP,
         3689,
+    )
+
+
+async def test_unicast_scan_hscp_device(udns_server, unicast_scan):
+    udns_server.add_service(
+        fake_udns.hscp_service(
+            DMAP_NAME, DMAP_SERVICE_NAME, DMAP_HSGID, addresses=[IP_1], port=3689
+        )
+    )
+
+    atvs = await unicast_scan()
+    assert len(atvs) == 1
+    assert_device(
+        atvs[0],
+        DMAP_NAME,
+        ip_address(IP_1),
+        DMAP_SERVICE_NAME,
+        Protocol.DMAP,
+        3689,
+        DMAP_HSGID,
     )

--- a/tests/fake_udns.py
+++ b/tests/fake_udns.py
@@ -129,6 +129,28 @@ def raop_service(
     return ("_raop._tcp.local", service)
 
 
+def hscp_service(
+    name: str,
+    identifier: str,
+    hsgid: str,
+    addresses: List[str] = ["127.0.0.1"],
+    port: int = 0,
+    model: Optional[str] = None,
+) -> Tuple[str, FakeDnsService]:
+    service = FakeDnsService(
+        name="HSCP Name",
+        addresses=addresses,
+        port=port,
+        properties={
+            "Machine Name": name.encode("utf-8"),
+            "Machine ID": identifier.encode("utf-8"),
+            "hG": hsgid.encode("utf-8"),
+        },
+        model=model,
+    )
+    return ("_hscp._tcp.local", service)
+
+
 def _lookup_service(
     question: dns.DnsQuestion,
     services: Dict[str, FakeDnsService],

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -81,6 +81,7 @@ async def test_auto_connect_with_device(mock_scan, mock_connect):
         ("_airplay._tcp.local", "name", {"deviceid": "test"}, "test"),
         ("_raop._tcp.local", "abcd@name", {}, "abcd"),
         ("_raop._tcp.local", "abcd@name", {}, "abcd"),
+        ("_hscp._tcp.local", "name", {"Machine ID": "abcd"}, "abcd"),
     ],
 )
 def test_get_unique_id_(service_type, service_name, properties, expected_id):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = clean, py{36,37,38,39}, api, docs, generated, codestyle, pylint, typing, report
 skip_missing_interpreters = True
 pysources = pyatv examples scripts
-cs_exclude_words = cann,cant
+cs_exclude_words = cann,cant,asai
 
 [gh-actions]
 python =


### PR DESCRIPTION
This commit adds support for the HSCP service used by the Music app (on
macOS). It's exactly the same as DMAP with Home Sharing, just a few
different zeroconf properties.

Relates to #1172

Not entirely ready yet as documentation is needed and I also need to decide what the device info API should return.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1182"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

