### PR TITLE
gha: Fix running tox on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,7 @@ jobs:
       # Run once and if that fails, run again but force to re-download packages again.
       # For some reason the cache breaks sometimes, see https://github.com/postlund/pyatv/issues/1174
       run: ./scripts/tox.sh
+      shell: bash
     - name: Regression
       run: tox -q -p auto -e regression
       if: matrix.python-version == '3.8' && runner.os == 'Linux'


### PR DESCRIPTION
Seems like the tox script is not executed properly on Windows, so tests
are not executed there.

Relates to #1174

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1199"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

