### PR TITLE
debug: Include zeroconf properties in debug log

### DIFF
--- a/pyatv/support/scan.py
+++ b/pyatv/support/scan.py
@@ -183,11 +183,12 @@ class BaseScanner(ABC):  # pylint: disable=too-few-public-methods
         response: mdns.Response,
     ) -> None:
         _LOGGER.debug(
-            "Auto-discovered %s at %s:%d (%s)",
+            "Auto-discovered %s at %s:%d via %s (%s)",
             name,
             address,
             service.port,
             service.protocol,
+            service.properties,
         )
 
         if address not in self._found_devices:


### PR DESCRIPTION
Relates to #1194

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1200"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

