### PR TITLE
scan: Move scan code to protocols

### DIFF
--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -35,7 +35,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Main routines for interacting with an Apple TV.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L0-L125" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L0-L137" class="git-link">Browse git</a></div>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -78,7 +78,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Connect to a device based on a configuration.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L68-L101" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L80-L113" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.pair">
 <code class="name flex">
@@ -87,7 +87,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Pair a protocol for an Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L104-L126" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L116-L138" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.scan">
 <code class="name flex">
@@ -96,7 +96,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Scan for Apple TVs on network and return their configurations.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L37-L65" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L45-L77" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 </section>

--- a/docs/api/pyatv/conf.html
+++ b/docs/api/pyatv/conf.html
@@ -64,7 +64,7 @@ possible to manually create a configuration, but generally scanning for devices 
 provide configurations for you.</p>
 <p>For a configuration to be usable ("ready") it must have either a <code>DMAP</code> or <code>MRP</code>
 configuration (or both), as connecting to plain <code>AirPlay</code> devices it not supported.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L0-L293" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L0-L290" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -82,7 +82,7 @@ configuration (or both), as connecting to plain <code>AirPlay</code> devices it 
 <dd>
 <section class="desc"><p>Representation of an AirPlay service.</p>
 <p>Initialize a new AirPlayService.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L251-L263" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L248-L260" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="pyatv.interface.BaseService" href="interface#pyatv.interface.BaseService">BaseService</a></li>
@@ -99,7 +99,7 @@ configuration (or both), as connecting to plain <code>AirPlay</code> devices it 
 </dd>
 <dt id="pyatv.conf.AppleTV"><code class="flex name class">
 <span>class <span class="ident">AppleTV</span></span>
-<span>(</span><span>address: ipaddress.IPv4Address, name: str, deep_sleep: bool = False, model: <a title="pyatv.const.DeviceModel" href="const#pyatv.const.DeviceModel">DeviceModel</a> = DeviceModel.Unknown, properties: Optional[Mapping[str, str]] = None)</span>
+<span>(</span><span>address: ipaddress.IPv4Address, name: str, deep_sleep: bool = False, model: <a title="pyatv.const.DeviceModel" href="const#pyatv.const.DeviceModel">DeviceModel</a> = DeviceModel.Unknown, properties: Optional[Mapping[str, Mapping[str, str]]] = None)</span>
 </code></dt>
 <dd>
 <section class="desc"><p>Representation of an Apple TV configuration.</p>
@@ -107,7 +107,7 @@ configuration (or both), as connecting to plain <code>AirPlay</code> devices it 
 several services depending on the protocols it supports, e.g. DMAP or
 AirPlay.</p>
 <p>Initialize a new AppleTV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L19-L210" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L19-L207" class="git-link">Browse git</a></div>
 <h3>Instance variables</h3>
 <dl>
 <dt id="pyatv.conf.AppleTV.address"><code class="name">var <span class="ident">address</span> -> ipaddress.IPv4Address</code></dt>
@@ -118,7 +118,7 @@ AirPlay.</p>
 <dt id="pyatv.conf.AppleTV.all_identifiers"><code class="name">var <span class="ident">all_identifiers</span> -> List[str]</code></dt>
 <dd>
 <section class="desc"><p>Return all unique identifiers for this device.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L79-L82" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L75-L78" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.conf.AppleTV.deep_sleep"><code class="name">var <span class="ident">deep_sleep</span> -> bool</code></dt>
 <dd>
@@ -128,12 +128,12 @@ AirPlay.</p>
 <dt id="pyatv.conf.AppleTV.device_info"><code class="name">var <span class="ident">device_info</span> -> <a title="pyatv.interface.DeviceInfo" href="interface#pyatv.interface.DeviceInfo">DeviceInfo</a></code></dt>
 <dd>
 <section class="desc"><p>Return general device information.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L133-L180" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L129-L176" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.conf.AppleTV.identifier"><code class="name">var <span class="ident">identifier</span> -> Optional[str]</code></dt>
 <dd>
 <section class="desc"><p>Return the main identifier associated with this device.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L70-L77" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L66-L73" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.conf.AppleTV.name"><code class="name">var <span class="ident">name</span> -> str</code></dt>
 <dd>
@@ -142,13 +142,13 @@ AirPlay.</p>
 </dd>
 <dt id="pyatv.conf.AppleTV.ready"><code class="name">var <span class="ident">ready</span> -> bool</code></dt>
 <dd>
-<section class="desc"><p>Return if configuration is ready, i.e. has a main service.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L58-L68" class="git-link">Browse git</a></div>
+<section class="desc"><p>Return if configuration is ready, (at least one service with identifier).</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L58-L64" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.conf.AppleTV.services"><code class="name">var <span class="ident">services</span> -> List[<a title="pyatv.interface.BaseService" href="interface#pyatv.interface.BaseService">BaseService</a>]</code></dt>
 <dd>
 <section class="desc"><p>Return all supported services.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L103-L106" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L99-L102" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 <h3>Methods</h3>
@@ -161,7 +161,7 @@ AirPlay.</p>
 <dd>
 <section class="desc"><p>Add a new service.</p>
 <p>If the service already exists, it will be merged.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L84-L93" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L80-L89" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.conf.AppleTV.get_service">
 <code class="name flex">
@@ -172,7 +172,7 @@ AirPlay.</p>
 <section class="desc"><p>Look up a service based on protocol.</p>
 <p>If a service with the specified protocol is not available, None is
 returned.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L95-L101" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L91-L97" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.conf.AppleTV.main_service">
 <code class="name flex">
@@ -181,7 +181,7 @@ returned.</p></section>
 </dt>
 <dd>
 <section class="desc"><p>Return suggested service used to establish connection.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L108-L121" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L104-L117" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.conf.AppleTV.set_credentials">
 <code class="name flex">
@@ -190,7 +190,7 @@ returned.</p></section>
 </dt>
 <dd>
 <section class="desc"><p>Set credentials for a protocol if it exists.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L123-L129" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L119-L125" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 </dd>
@@ -201,7 +201,7 @@ returned.</p></section>
 <dd>
 <section class="desc"><p>Representation of a Companion link service.</p>
 <p>Initialize a new CompaniomService.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L267-L278" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L264-L275" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="pyatv.interface.BaseService" href="interface#pyatv.interface.BaseService">BaseService</a></li>
@@ -223,7 +223,7 @@ returned.</p></section>
 <dd>
 <section class="desc"><p>Representation of a DMAP service.</p>
 <p>Initialize a new DmapService.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L214-L231" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L211-L228" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="pyatv.interface.BaseService" href="interface#pyatv.interface.BaseService">BaseService</a></li>
@@ -245,7 +245,7 @@ returned.</p></section>
 <dd>
 <section class="desc"><p>Representation of a MediaRemote Protocol (MRP) service.</p>
 <p>Initialize a new MrpService.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L235-L247" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L232-L244" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="pyatv.interface.BaseService" href="interface#pyatv.interface.BaseService">BaseService</a></li>
@@ -267,7 +267,7 @@ returned.</p></section>
 <dd>
 <section class="desc"><p>Representation of an RAOP service.</p>
 <p>Initialize a new RaopService.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L282-L294" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/conf.py#L279-L291" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="pyatv.interface.BaseService" href="interface#pyatv.interface.BaseService">BaseService</a></li>

--- a/pyatv/conf.py
+++ b/pyatv/conf.py
@@ -30,7 +30,7 @@ class AppleTV:
         name: str,
         deep_sleep: bool = False,
         model: DeviceModel = DeviceModel.Unknown,
-        properties: Optional[Mapping[str, str]] = None,
+        properties: Optional[Mapping[str, Mapping[str, str]]] = None,
     ) -> None:
         """Initialize a new AppleTV."""
         self._address = address
@@ -38,7 +38,7 @@ class AppleTV:
         self._deep_sleep = deep_sleep
         self._model = model
         self._services: Dict[Protocol, BaseService] = {}
-        self._properties: Mapping[str, str] = properties or {}
+        self._properties: Mapping[str, Mapping[str, str]] = properties or {}
 
     @property
     def address(self) -> IPv4Address:
@@ -57,15 +57,11 @@ class AppleTV:
 
     @property
     def ready(self) -> bool:
-        """Return if configuration is ready, i.e. has a main service."""
-        ready_protocols = set(list(Protocol))
-
-        # Companion has no unique identifier so it's the only protocol that can't be
-        # used independently for now
-        ready_protocols.remove(Protocol.Companion)
-
-        intersection = ready_protocols.intersection(self._services.keys())
-        return len(intersection) > 0
+        """Return if configuration is ready, (at least one service with identifier)."""
+        for service in self.services:
+            if service.identifier:
+                return True
+        return False
 
     @property
     def identifier(self) -> Optional[str]:
@@ -181,7 +177,8 @@ class AppleTV:
 
     def _all_properties(self) -> Mapping[str, str]:
         properties: Dict[str, str] = {}
-        properties.update(self._properties)
+        for props in self._properties.values():
+            properties.update(props)
         for service in self.services:
             properties.update(service.properties)
         return properties

--- a/pyatv/support/scan.py
+++ b/pyatv/support/scan.py
@@ -5,35 +5,20 @@ import asyncio
 from ipaddress import IPv4Address
 import logging
 import os
-from typing import Dict, Generator, List, Mapping, Optional
+from typing import Callable, Dict, Generator, List, Mapping, NamedTuple, Optional, Tuple
 
 from pyatv import conf, interface
+from pyatv.const import DeviceModel
 from pyatv.helpers import get_unique_id
 from pyatv.support import knock, mdns
 from pyatv.support.device_info import lookup_internal_name
 
 _LOGGER = logging.getLogger(__name__)
 
-HOMESHARING_SERVICE: str = "_appletv-v2._tcp.local"
-DEVICE_SERVICE: str = "_touch-able._tcp.local"
-MEDIAREMOTE_SERVICE: str = "_mediaremotetv._tcp.local"
-AIRPLAY_SERVICE: str = "_airplay._tcp.local"
-COMPANION_SERVICE: str = "_companion-link._tcp.local"
-RAOP_SERVICE: str = "_raop._tcp.local"
-AIRPORT_ADMIN_SERVICE: str = "_airport._tcp.local"
+ScanHandlerReturn = Tuple[str, interface.BaseService]
+ScanHandler = Callable[[mdns.Service, mdns.Response], Optional[ScanHandlerReturn]]
 
-# These corresponds to services mapped to a protocol
-ALL_SERVICES: List[str] = [
-    HOMESHARING_SERVICE,
-    DEVICE_SERVICE,
-    MEDIAREMOTE_SERVICE,
-    AIRPLAY_SERVICE,
-    COMPANION_SERVICE,
-    RAOP_SERVICE,
-]
-
-# Services that does not map to a protocol but provides additional metadata
-EXTRA_SERVICES: List[str] = [AIRPORT_ADMIN_SERVICE]
+DEVICE_INFO: str = "_device-info._tcp.local"
 
 # These ports have been "arbitrarily" chosen (see issue #580) because a device normally
 # listen on them (more or less). They are used as best-effort when for unicast scanning
@@ -41,13 +26,15 @@ EXTRA_SERVICES: List[str] = [AIRPORT_ADMIN_SERVICE]
 KNOCK_PORTS: List[int] = [3689, 7000, 49152, 32498]
 
 
-def _get_service_properties(
-    services: List[mdns.Service], service_type
-) -> Mapping[str, str]:
-    for service in services:
-        if service.type == service_type:
-            return service.properties
-    return {}
+class FoundDevice(NamedTuple):
+    """Represent a device found during scanning."""
+
+    name: str
+    address: IPv4Address
+    deep_sleep: bool
+    model: DeviceModel
+    services: List[interface.BaseService]
+    service_properties: Dict[str, Dict[str, str]]
 
 
 def get_unique_identifiers(
@@ -60,154 +47,97 @@ def get_unique_identifiers(
             yield unique_id
 
 
-class BaseScanner(ABC):  # pylint: disable=too-few-public-methods
+class BaseScanner(ABC):
     """Base scanner for service discovery."""
 
     def __init__(self) -> None:
         """Initialize a new BaseScanner."""
-        self._found_devices: Dict[IPv4Address, conf.AppleTV] = {}
+        self._services: Dict[str, ScanHandler] = {
+            DEVICE_INFO: lambda service, response: None
+        }
+        self._found_devices: Dict[IPv4Address, FoundDevice] = {}
+        self._properties: Dict[IPv4Address, Dict[str, Mapping[str, str]]] = {}
+
+    def add_service(self, service_type: str, handler: ScanHandler):
+        """Add service type to discover."""
+        self._services[service_type] = handler
+
+    @property
+    def services(self) -> List[str]:
+        """Return list of service types to scan for."""
+        return list(self._services.keys())
+
+    async def discover(self, timeout: int) -> Mapping[IPv4Address, conf.AppleTV]:
+        """Start discovery of devices and services."""
+        await self.process(timeout)
+
+        devices = {}
+        for address, found_device in self._found_devices.items():
+            devices[address] = conf.AppleTV(
+                address,
+                found_device.name,
+                deep_sleep=found_device.deep_sleep,
+                model=found_device.model,
+                properties=self._properties[address],
+            )
+            for service in found_device.services:
+                devices[address].add_service(service)
+        return devices
 
     @abstractmethod
-    async def discover(self, timeout: int):
-        """Start discovery of devices and services."""
+    async def process(self, timeout: int) -> None:
+        """Start to process devices and services."""
 
     def handle_response(self, response: mdns.Response):
         """Call when an MDNS response was received."""
         for service in response.services:
-            if service.address and service.port != 0:
-                try:
-                    self._service_discovered(service, response)
-                except Exception:
-                    _LOGGER.warning("Failed to parse service: %s", service)
+            if service.type not in self._services:
+                _LOGGER.warning(
+                    "Discovered unsupported service %s for device %s",
+                    service.name,
+                    service.type,
+                )
+                continue
+
+            try:
+                self._service_discovered(service, response)
+            except Exception:
+                _LOGGER.exception("Failed to parse service: %s", service)
 
     def _service_discovered(
         self, service: mdns.Service, response: mdns.Response
     ) -> None:
-        {
-            HOMESHARING_SERVICE: self._hs_service,
-            DEVICE_SERVICE: self._non_hs_service,
-            MEDIAREMOTE_SERVICE: self._mrp_service,
-            AIRPLAY_SERVICE: self._airplay_service,
-            COMPANION_SERVICE: self._companion_service,
-            RAOP_SERVICE: self._raop_service,
-        }.get(service.type, self._unsupported_service)(service, response)
+        if service.address is None or service.port == 0:
+            return
 
-    def _hs_service(self, mdns_service: mdns.Service, response: mdns.Response) -> None:
-        """Add a new device to discovered list."""
-        name = mdns_service.properties.get("Name", "Unknown")
-        service = conf.DmapService(
-            get_unique_id(
-                mdns_service.type, mdns_service.name, mdns_service.properties
-            ),
-            mdns_service.properties.get("hG"),
-            port=mdns_service.port,
-            properties=mdns_service.properties,
-        )
-        self._handle_service(mdns_service.address, name, service, response)
-
-    def _non_hs_service(
-        self, mdns_service: mdns.Service, response: mdns.Response
-    ) -> None:
-        """Add a new device without Home Sharing to discovered list."""
-        name = mdns_service.properties.get("CtlN", "Unknown")
-        service = conf.DmapService(
-            get_unique_id(
-                mdns_service.type, mdns_service.name, mdns_service.properties
-            ),
-            None,
-            port=mdns_service.port,
-            properties=mdns_service.properties,
-        )
-        self._handle_service(mdns_service.address, name, service, response)
-
-    def _mrp_service(self, mdns_service: mdns.Service, response: mdns.Response) -> None:
-        """Add a new MediaRemoteProtocol device to discovered list."""
-        name = mdns_service.properties.get("Name", "Unknown")
-        service = conf.MrpService(
-            get_unique_id(
-                mdns_service.type, mdns_service.name, mdns_service.properties
-            ),
-            mdns_service.port,
-            properties=mdns_service.properties,
-        )
-        self._handle_service(mdns_service.address, name, service, response)
-
-    def _airplay_service(
-        self, mdns_service: mdns.Service, response: mdns.Response
-    ) -> None:
-        """Add a new AirPlay device to discovered list."""
-        service = conf.AirPlayService(
-            get_unique_id(
-                mdns_service.type, mdns_service.name, mdns_service.properties
-            ),
-            mdns_service.port,
-            properties=mdns_service.properties,
-        )
-        self._handle_service(mdns_service.address, mdns_service.name, service, response)
-
-    def _companion_service(self, mdns_service: mdns.Service, response: mdns.Response):
-        """Add a new companion device to discovered list."""
-        service = conf.CompanionService(
-            mdns_service.port,
-            properties=mdns_service.properties,
-        )
-        self._handle_service(mdns_service.address, mdns_service.name, service, response)
-
-    def _raop_service(self, mdns_service: mdns.Service, response: mdns.Response):
-        """Add a new RAOP device to discovered list."""
-        _, name = mdns_service.name.split("@", maxsplit=1)
-        service = conf.RaopService(
-            get_unique_id(
-                mdns_service.type, mdns_service.name, mdns_service.properties
-            ),
-            mdns_service.port,
-            properties=mdns_service.properties,
-        )
-        self._handle_service(mdns_service.address, name, service, response)
-
-    @staticmethod
-    def _unsupported_service(mdns_service: mdns.Service, _: mdns.Response) -> None:
-        """Handle unsupported service."""
-        if mdns_service.type not in EXTRA_SERVICES:
-            _LOGGER.warning(
-                "Discovered unknown device %s (%s)",
-                mdns_service.name,
-                mdns_service.type,
+        result = self._services[service.type](service, response)
+        if result:
+            name, base_service = result
+            _LOGGER.debug(
+                "Auto-discovered %s at %s:%d via %s (%s)",
+                service.name,
+                service.address,
+                service.port,
+                base_service.protocol,
+                service.properties,
             )
 
-    def _handle_service(
-        self,
-        address,
-        name: str,
-        service: interface.BaseService,
-        response: mdns.Response,
-    ) -> None:
-        _LOGGER.debug(
-            "Auto-discovered %s at %s:%d via %s (%s)",
-            name,
-            address,
-            service.port,
-            service.protocol,
-            service.properties,
-        )
-
-        if address not in self._found_devices:
-            # Extract properties from extra services that might be of interest
-            extra_properties: Dict[str, str] = {}
-            for extra_service in EXTRA_SERVICES:
-                extra_properties.update(
-                    _get_service_properties(response.services, extra_service)
+            if service.address not in self._found_devices:
+                self._found_devices[service.address] = FoundDevice(
+                    name,
+                    service.address,
+                    response.deep_sleep,
+                    lookup_internal_name(response.model),
+                    [],
+                    {},
                 )
+            self._found_devices[service.address].services.append(base_service)
 
-            self._found_devices[address] = conf.AppleTV(
-                address,
-                name,
-                deep_sleep=response.deep_sleep,
-                model=lookup_internal_name(response.model),
-                properties=extra_properties,
-            )
-
-        self._found_devices[address].add_service(service)
+        # Save properties for all services belonging to a device/address
+        if service.address is not None:
+            if service.address not in self._properties:
+                self._properties[service.address] = {}
+            self._properties[service.address][service.type] = service.properties
 
 
 class UnicastMdnsScanner(BaseScanner):
@@ -221,15 +151,14 @@ class UnicastMdnsScanner(BaseScanner):
         self.hosts = hosts
         self.loop = loop
 
-    async def discover(self, timeout: int):
-        """Start discovery of devices and services."""
+    async def process(self, timeout: int) -> None:
+        """Start to process devices and services."""
         responses = await asyncio.gather(
             *[self._get_services(host, timeout) for host in self.hosts]
         )
 
         for response in responses:
             self.handle_response(response)
-        return self._found_devices
 
     async def _get_services(self, host: IPv4Address, timeout: int) -> mdns.Response:
         port = int(os.environ.get("PYATV_UDNS_PORT", 5353))  # For testing purposes
@@ -239,7 +168,7 @@ class UnicastMdnsScanner(BaseScanner):
             response = await mdns.unicast(
                 self.loop,
                 str(host),
-                ALL_SERVICES + EXTRA_SERVICES,
+                self.services,
                 port=port,
                 timeout=timeout,
             )
@@ -262,17 +191,16 @@ class MulticastMdnsScanner(BaseScanner):
         self.loop = loop
         self.identifier = identifier
 
-    async def discover(self, timeout: int):
-        """Start discovery of devices and services."""
+    async def process(self, timeout: int) -> None:
+        """Start to process devices and services."""
         responses = await mdns.multicast(
             self.loop,
-            ALL_SERVICES + EXTRA_SERVICES,
+            self.services,
             timeout=timeout,
             end_condition=self._end_if_identifier_found if self.identifier else None,
         )
         for _, response in responses.items():
             self.handle_response(response)
-        return self._found_devices
 
     def _end_if_identifier_found(self, response: mdns.Response):
         return self.identifier in get_unique_identifiers(response)

--- a/tests/airplay/test_airplay.py
+++ b/tests/airplay/test_airplay.py
@@ -1,0 +1,30 @@
+"""Unit tests for pyatv.airplay."""
+from ipaddress import ip_address
+
+from deepdiff import DeepDiff
+
+from pyatv.airplay import scan
+from pyatv.support import mdns
+
+AIRPLAY_SERVICE = "_airplay._tcp.local"
+
+
+def test_airplay_scan_handlers_present():
+    handlers = scan()
+    assert len(handlers) == 1
+    assert AIRPLAY_SERVICE in handlers
+
+
+def test_airplay_handler_to_service():
+    handler = scan()[AIRPLAY_SERVICE]
+
+    mdns_service = mdns.Service(
+        AIRPLAY_SERVICE, "foo", ip_address("127.0.0.1"), 1234, {"foo": "bar"}
+    )
+    mdns_response = mdns.Response([], False, None)
+
+    name, service = handler(mdns_service, mdns_response)
+    assert name == "foo"
+    assert service.port == 1234
+    assert service.credentials is None
+    assert not DeepDiff(service.properties, {"foo": "bar"})

--- a/tests/airplay/test_airplay_scan.py
+++ b/tests/airplay/test_airplay_scan.py
@@ -1,0 +1,48 @@
+"""Scanning tests with fake mDNS responder.."""
+
+from ipaddress import ip_address
+
+import pytest
+
+from pyatv.const import Protocol
+
+from tests import fake_udns
+from tests.conftest import Scanner
+from tests.utils import assert_device
+
+IP_1 = "10.0.0.1"
+
+AIRPLAY_NAME = "AirPlay ATV"
+AIRPLAY_ID = "AA:BB:CC:DD:EE:FF"
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_multicast_scan_airplay_device(udns_server, multicast_scan: Scanner):
+    udns_server.add_service(
+        fake_udns.airplay_service(AIRPLAY_NAME, AIRPLAY_ID, addresses=[IP_1])
+    )
+
+    atvs = await multicast_scan()
+    assert len(atvs) == 1
+    assert atvs[0].name == AIRPLAY_NAME
+    assert atvs[0].identifier == AIRPLAY_ID
+    assert atvs[0].address == ip_address(IP_1)
+
+
+async def test_unicast_scan_airplay(udns_server, unicast_scan: Scanner):
+    udns_server.add_service(
+        fake_udns.airplay_service(AIRPLAY_NAME, AIRPLAY_ID, addresses=[IP_1], port=7000)
+    )
+
+    atvs = await unicast_scan()
+    assert len(atvs) == 1
+
+    assert_device(
+        atvs[0],
+        AIRPLAY_NAME,
+        ip_address(IP_1),
+        AIRPLAY_ID,
+        Protocol.AirPlay,
+        7000,
+    )

--- a/tests/companion/test_companion.py
+++ b/tests/companion/test_companion.py
@@ -1,0 +1,30 @@
+"""Unit tests for pyatv.companion."""
+from ipaddress import ip_address
+
+from deepdiff import DeepDiff
+
+from pyatv.companion import scan
+from pyatv.support import mdns
+
+COMPANION_SERVICE = "_companion-link._tcp.local"
+
+
+def test_companion_scan_handlers_present():
+    handlers = scan()
+    assert len(handlers) == 1
+    assert COMPANION_SERVICE in handlers
+
+
+def test_companion_handler_to_service():
+    handler = scan()[COMPANION_SERVICE]
+
+    mdns_service = mdns.Service(
+        COMPANION_SERVICE, "foo", ip_address("127.0.0.1"), 1234, {"foo": "bar"}
+    )
+    mdns_response = mdns.Response([], False, None)
+
+    name, service = handler(mdns_service, mdns_response)
+    assert name == "foo"
+    assert service.port == 1234
+    assert service.credentials is None
+    assert not DeepDiff(service.properties, {"foo": "bar"})

--- a/tests/companion/test_companion_scan.py
+++ b/tests/companion/test_companion_scan.py
@@ -1,0 +1,68 @@
+"""Functional tests for Companion scanning.."""
+
+from ipaddress import ip_address
+
+import pytest
+
+from pyatv.const import Protocol
+
+from tests import fake_udns
+from tests.conftest import Scanner
+
+IP_1 = "10.0.0.1"
+
+COMPANIOM_NAME = "Companion"
+MRP_ID = "mrp_id_1"
+MRP_SERVICE_NAME = "MRP Service"
+
+COMPANION_PORT = 1234
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_multicast_scan_companion_device(udns_server, multicast_scan: Scanner):
+    udns_server.add_service(
+        fake_udns.companion_service(
+            COMPANIOM_NAME, addresses=[IP_1], port=COMPANION_PORT
+        )
+    )
+
+    atvs = await multicast_scan()
+    assert len(atvs) == 0
+
+
+# Companion does not have a unique id we can use, so it's not possible to discover
+# on its own. It needs another protocol with an identifier and MRP is borrowed here,
+# but any other protocol would do as well.
+async def test_multicast_scan_mrp_with_companion(udns_server, multicast_scan: Scanner):
+    udns_server.add_service(
+        fake_udns.mrp_service(
+            MRP_SERVICE_NAME, COMPANIOM_NAME, MRP_ID, addresses=[IP_1]
+        )
+    )
+    udns_server.add_service(
+        fake_udns.companion_service(
+            COMPANIOM_NAME, addresses=[IP_1], port=COMPANION_PORT
+        )
+    )
+
+    atvs = await multicast_scan(protocol=Protocol.MRP)
+    assert len(atvs) == 1
+
+    dev = atvs[0]
+    assert dev
+    assert dev.name == COMPANIOM_NAME
+    assert dev.get_service(Protocol.MRP)
+
+    companion = dev.get_service(Protocol.Companion)
+    assert companion
+    assert companion.port == COMPANION_PORT
+
+
+async def test_unicast_scan_comapnion(udns_server, unicast_scan: Scanner):
+    udns_server.add_service(
+        fake_udns.companion_service(COMPANIOM_NAME, IP_1, COMPANION_PORT)
+    )
+
+    atvs = await unicast_scan()
+    assert len(atvs) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,22 @@
 from types import SimpleNamespace
+import typing
 from unittest.mock import Mock, patch
 
 import netifaces
 import pytest
 
+import pyatv
+from pyatv import conf
 from pyatv.support.http import create_session
 from pyatv.support.net import unused_port
 
+from tests import fake_udns
 from tests.fake_knock import create_knock_server
 from tests.utils import stub_sleep, unstub_sleep
+
+#: A type alias for the [multi,uni]cast_scan fixtures.
+# There isn't a way to type-hint optional arguments, so instead we leave it unspecified.
+Scanner = typing.Callable[..., typing.Awaitable[typing.List[conf.AppleTV]]]
 
 
 def pytest_configure(config):
@@ -98,3 +106,34 @@ def stub_knock_server():
 
         knock.side_effect = _stub_knock
         yield info
+
+
+# stub_knock_server is added here to make sure all UDNS tests uses a stubbed
+# knock server
+@pytest.fixture
+async def udns_server(event_loop, stub_knock_server):
+    server = fake_udns.FakeUdns(event_loop)
+    await server.start()
+    yield server
+    server.close()
+
+
+@pytest.fixture(name="multicast_scan")
+async def multicast_scan_fixture(event_loop, udns_server):
+    async def _scan(timeout=1, identifier=None, protocol=None):
+        with fake_udns.stub_multicast(udns_server, event_loop):
+            return await pyatv.scan(
+                event_loop, identifier=identifier, protocol=protocol, timeout=timeout
+            )
+
+    yield _scan
+
+
+@pytest.fixture(name="unicast_scan")
+async def unicast_scan_fixture(event_loop, udns_server):
+    async def _scan(timeout=1):
+        port = str(udns_server.port)
+        with patch.dict("os.environ", {"PYATV_UDNS_PORT": port}):
+            return await pyatv.scan(event_loop, hosts=["127.0.0.1"], timeout=timeout)
+
+    yield _scan

--- a/tests/dmap/test_dmap.py
+++ b/tests/dmap/test_dmap.py
@@ -1,0 +1,47 @@
+"""Unit tests for pyatv.airplay."""
+from ipaddress import ip_address
+
+from deepdiff import DeepDiff
+
+from pyatv.dmap import scan
+from pyatv.support import mdns
+
+HOMESHARING_SERVICE = "_appletv-v2._tcp.local"
+DMAP_SERVICE = "_touch-able._tcp.local"
+
+
+def test_dmap_scan_handlers_present():
+    handlers = scan()
+    assert len(handlers) == 2
+    assert HOMESHARING_SERVICE in handlers
+    assert DMAP_SERVICE in handlers
+
+
+def test_homesharing_handler_to_service():
+    handler = scan()[HOMESHARING_SERVICE]
+
+    mdns_service = mdns.Service(
+        HOMESHARING_SERVICE, "foo", ip_address("127.0.0.1"), 1234, {"Name": "bar"}
+    )
+    mdns_response = mdns.Response([], False, None)
+
+    name, service = handler(mdns_service, mdns_response)
+    assert name == "bar"
+    assert service.port == 1234
+    assert service.credentials is None
+    assert not DeepDiff(service.properties, {"Name": "bar"})
+
+
+def test_dmap_handler_to_service():
+    handler = scan()[DMAP_SERVICE]
+
+    mdns_service = mdns.Service(
+        DMAP_SERVICE, "foo", ip_address("127.0.0.1"), 1234, {"CtlN": "bar"}
+    )
+    mdns_response = mdns.Response([], False, None)
+
+    name, service = handler(mdns_service, mdns_response)
+    assert name == "bar"
+    assert service.port == 1234
+    assert service.credentials is None
+    assert not DeepDiff(service.properties, {"CtlN": "bar"})

--- a/tests/dmap/test_dmap_scan.py
+++ b/tests/dmap/test_dmap_scan.py
@@ -1,0 +1,107 @@
+"""Functional tests for DMAP scan."""
+from ipaddress import ip_address
+
+import pytest
+
+import pyatv
+from pyatv import conf
+from pyatv.const import Protocol
+
+from tests import fake_udns
+from tests.conftest import Scanner
+from tests.utils import assert_device
+
+IP_1 = "10.0.0.1"
+
+DMAP_SERVICE_NAME = "DMAP service"
+DMAP_NAME = "DMAP ATV"
+DMAP_HSGID = "hsgid"
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_multicast_scan_home_sharing_merge(udns_server, multicast_scan):
+    udns_server.add_service(
+        fake_udns.device_service(DMAP_SERVICE_NAME, DMAP_NAME, addresses=[IP_1])
+    )
+    udns_server.add_service(
+        fake_udns.homesharing_service(
+            DMAP_SERVICE_NAME, DMAP_NAME, DMAP_HSGID, addresses=[IP_1]
+        )
+    )
+
+    atvs = await multicast_scan()
+    assert len(atvs) == 1
+
+    assert_device(
+        atvs[0],
+        DMAP_NAME,
+        ip_address(IP_1),
+        DMAP_SERVICE_NAME,
+        Protocol.DMAP,
+        3689,
+        DMAP_HSGID,
+    )
+
+
+async def test_multicast_scan_home_sharing_merge(udns_server, multicast_scan):
+    udns_server.add_service(
+        fake_udns.device_service(DMAP_SERVICE_NAME, DMAP_NAME, addresses=[IP_1])
+    )
+    udns_server.add_service(
+        fake_udns.homesharing_service(
+            DMAP_SERVICE_NAME, DMAP_NAME, DMAP_HSGID, addresses=[IP_1]
+        )
+    )
+
+    atvs = await multicast_scan()
+    assert len(atvs) == 1
+
+    assert_device(
+        atvs[0],
+        DMAP_NAME,
+        ip_address(IP_1),
+        DMAP_SERVICE_NAME,
+        Protocol.DMAP,
+        3689,
+        DMAP_HSGID,
+    )
+
+
+async def test_unicast_scan_homesharing(udns_server, unicast_scan):
+    udns_server.add_service(
+        fake_udns.homesharing_service(
+            DMAP_SERVICE_NAME, DMAP_NAME, DMAP_HSGID, addresses=[IP_1]
+        )
+    )
+
+    atvs = await unicast_scan()
+    assert len(atvs) == 1
+
+    assert_device(
+        atvs[0],
+        DMAP_NAME,
+        ip_address(IP_1),
+        DMAP_SERVICE_NAME,
+        Protocol.DMAP,
+        3689,
+        DMAP_HSGID,
+    )
+
+
+async def test_unicast_scan_no_homesharing(udns_server, unicast_scan):
+    udns_server.add_service(
+        fake_udns.device_service(DMAP_SERVICE_NAME, DMAP_NAME, addresses=[IP_1])
+    )
+
+    atvs = await unicast_scan()
+    assert len(atvs) == 1
+
+    assert_device(
+        atvs[0],
+        DMAP_NAME,
+        ip_address(IP_1),
+        DMAP_SERVICE_NAME,
+        Protocol.DMAP,
+        3689,
+    )

--- a/tests/mrp/test_mrp.py
+++ b/tests/mrp/test_mrp.py
@@ -1,0 +1,30 @@
+"""Unit tests for pyatv.mrp."""
+from ipaddress import ip_address
+
+from deepdiff import DeepDiff
+
+from pyatv.mrp import scan
+from pyatv.support import mdns
+
+MRP_SERVICE = "_mediaremotetv._tcp.local"
+
+
+def test_companion_scan_handlers_present():
+    handlers = scan()
+    assert len(handlers) == 1
+    assert MRP_SERVICE in handlers
+
+
+def test_mrp_handler_to_service():
+    handler = scan()[MRP_SERVICE]
+
+    mdns_service = mdns.Service(
+        MRP_SERVICE, "foo", ip_address("127.0.0.1"), 1234, {"Name": "test"}
+    )
+    mdns_response = mdns.Response([], False, None)
+
+    name, service = handler(mdns_service, mdns_response)
+    assert name == "test"
+    assert service.port == 1234
+    assert service.credentials is None
+    assert not DeepDiff(service.properties, {"Name": "test"})

--- a/tests/mrp/test_mrp_scan.py
+++ b/tests/mrp/test_mrp_scan.py
@@ -1,0 +1,47 @@
+"""Functional tests for MRP scanning.."""
+
+from ipaddress import ip_address
+
+import pytest
+
+from pyatv.const import DeviceModel, Protocol
+
+from tests import fake_udns
+from tests.conftest import Scanner
+from tests.utils import assert_device
+
+IP_1 = "10.0.0.1"
+
+MRP_ID = "mrp_id_1"
+MRP_NAME = "MRP ATV"
+MRP_SERVICE_NAME = "MRP Service"
+
+MRP_PORT = 49152
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_multicast_scan_mrp_with_companion(udns_server, multicast_scan):
+    udns_server.add_service(
+        fake_udns.mrp_service(
+            MRP_SERVICE_NAME, MRP_NAME, MRP_ID, addresses=[IP_1], port=MRP_PORT
+        )
+    )
+
+    atvs = await multicast_scan(protocol=Protocol.MRP)
+    assert len(atvs) == 1
+
+    assert_device(atvs[0], MRP_NAME, ip_address(IP_1), MRP_ID, Protocol.MRP, MRP_PORT)
+
+
+async def test_unicast_scan_mrp(udns_server, unicast_scan):
+    udns_server.add_service(
+        fake_udns.mrp_service(
+            MRP_SERVICE_NAME, MRP_NAME, MRP_ID, addresses=[IP_1], port=MRP_PORT
+        )
+    )
+
+    atvs = await unicast_scan()
+    assert len(atvs) == 1
+
+    assert_device(atvs[0], MRP_NAME, ip_address(IP_1), MRP_ID, Protocol.MRP, MRP_PORT)

--- a/tests/raop/test_raop.py
+++ b/tests/raop/test_raop.py
@@ -1,0 +1,42 @@
+"""Unit tests for pyatv.raop."""
+from ipaddress import ip_address
+
+from deepdiff import DeepDiff
+
+from pyatv.raop import scan
+from pyatv.support import mdns
+
+RAOP_SERVICE = "_raop._tcp.local"
+AIRPORT_SERVICE = "_airport._tcp.local"
+
+
+def test_raop_scan_handlers_present():
+    handlers = scan()
+    assert len(handlers) == 2
+    assert RAOP_SERVICE in handlers
+
+
+def test_raop_handler_to_service():
+    handler = scan()[RAOP_SERVICE]
+
+    mdns_service = mdns.Service(
+        RAOP_SERVICE, "foo@bar", ip_address("127.0.0.1"), 1234, {"foo": "bar"}
+    )
+    mdns_response = mdns.Response([], False, None)
+
+    name, service = handler(mdns_service, mdns_response)
+    assert name == "bar"
+    assert service.port == 1234
+    assert service.credentials is None
+    assert not DeepDiff(service.properties, {"foo": "bar"})
+
+
+def test_airport_handler():
+    handler = scan()[AIRPORT_SERVICE]
+
+    mdns_service = mdns.Service(
+        RAOP_SERVICE, "foo@bar", ip_address("127.0.0.1"), 1234, {"foo": "bar"}
+    )
+    mdns_response = mdns.Response([], False, None)
+
+    assert not handler(mdns_service, mdns_response)

--- a/tests/raop/test_raop_scan.py
+++ b/tests/raop/test_raop_scan.py
@@ -1,0 +1,46 @@
+"""Functional tests for RAOP scanning.."""
+
+from ipaddress import ip_address
+
+import pytest
+
+from pyatv.const import Protocol
+
+from tests import fake_udns
+from tests.conftest import Scanner
+from tests.utils import assert_device
+
+IP_1 = "10.0.0.1"
+
+RAOP_ID = "AABBCCDDEEFF"
+RAOP_NAME = "RAOP ATV"
+
+RAOP_PORT = 4567
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_multicast_scan_raop_device(udns_server, multicast_scan):
+    udns_server.add_service(
+        fake_udns.raop_service(RAOP_NAME, RAOP_ID, addresses=[IP_1], port=RAOP_PORT)
+    )
+
+    atvs = await multicast_scan()
+    assert len(atvs) == 1
+
+    assert_device(
+        atvs[0], RAOP_NAME, ip_address(IP_1), RAOP_ID, Protocol.RAOP, RAOP_PORT
+    )
+
+
+async def test_unicast_scan_raop(udns_server, unicast_scan):
+    udns_server.add_service(
+        fake_udns.raop_service(RAOP_NAME, RAOP_ID, addresses=[IP_1], port=RAOP_PORT)
+    )
+
+    atvs = await unicast_scan()
+    assert len(atvs) == 1
+
+    assert_device(
+        atvs[0], RAOP_NAME, ip_address(IP_1), RAOP_ID, Protocol.RAOP, RAOP_PORT
+    )

--- a/tests/support/test_mdns_functional.py
+++ b/tests/support/test_mdns_functional.py
@@ -33,14 +33,6 @@ def mdns_debug():
     yield
 
 
-@pytest.fixture
-async def udns_server(event_loop):
-    server = fake_udns.FakeUdns(event_loop, TEST_SERVICES)
-    await server.start()
-    yield server
-    server.close()
-
-
 @pytest.fixture(autouse=True)
 def stub_local_addresses():
     with patch("pyatv.support.net.get_private_addresses") as mock:
@@ -62,6 +54,7 @@ def stub_ip_address():
 # i.e. 5353 since data from other places can leak into the test
 @pytest.fixture(autouse=True)
 def redirect_mcast(udns_server):
+    udns_server.services = TEST_SERVICES
     real_mcast_socket = net.mcast_socket
     with patch("pyatv.support.net.mcast_socket") as mock:
         mock.side_effect = lambda addr, port=0: real_mcast_socket(

--- a/tests/support/test_scan.py
+++ b/tests/support/test_scan.py
@@ -1,24 +1,16 @@
 """Unit tests for scan module."""
 
+from unittest.mock import patch
+
 import pytest
 
 from pyatv.support.mdns import Response, Service
-from pyatv.support.scan import (
-    AIRPLAY_SERVICE,
-    COMPANION_SERVICE,
-    DEVICE_SERVICE,
-    HOMESHARING_SERVICE,
-    MEDIAREMOTE_SERVICE,
-    RAOP_SERVICE,
-    get_unique_identifiers,
-)
+from pyatv.support.scan import BaseScanner, get_unique_identifiers
 
-HS = Service(HOMESHARING_SERVICE, "hsname", None, 0, {"hG": "hs_id"})
-DEVICE = Service(DEVICE_SERVICE, "devid", None, 0, {})
-MRP = Service(MEDIAREMOTE_SERVICE, "name", None, 0, {"UniqueIdentifier": "mrp_id"})
-AIRPLAY = Service(AIRPLAY_SERVICE, "name", None, 0, {"deviceid": "airplay_id"})
-COMPANION = Service(COMPANION_SERVICE, "name", None, 0, {})
-RAOP = Service(RAOP_SERVICE, "raop_id@name", None, 0, {})
+TEST_SERVICE1 = Service("_service1._tcp.local", "service1", None, 0, {"a": "b"})
+TEST_SERVICE2 = Service("_service2._tcp.local", "service2", None, 0, {"c": "d"})
+
+# class TestScanner(BaseScanner):
 
 
 @pytest.fixture
@@ -30,58 +22,17 @@ def test_unique_identifier_empty(response):
     assert len(list(get_unique_identifiers(response))) == 0
 
 
-def test_unique_identifier_home_sharing(response):
-    response.services.append(HS)
+@patch("pyatv.support.scan.get_unique_id")
+def test_unique_identifiers(unique_id_mock, response):
+    response.services.append(TEST_SERVICE1)
+    response.services.append(TEST_SERVICE2)
 
-    identifiers = list(get_unique_identifiers(response))
-    assert len(identifiers) == 1
-    assert "hsname" in identifiers
+    unique_id_mock.side_effect = ["id1", "id2"]
 
+    identifiers = get_unique_identifiers(response)
 
-def test_unique_identifier_device(response):
-    response.services.append(DEVICE)
-
-    identifiers = list(get_unique_identifiers(response))
-    assert len(identifiers) == 1
-    assert "devid" in identifiers
-
-
-def test_unique_identifier_mrp(response):
-    response.services.append(MRP)
-
-    identifiers = list(get_unique_identifiers(response))
-    assert len(identifiers) == 1
-    assert "mrp_id" in identifiers
-
-
-def test_unique_identifier_airplay(response):
-    response.services.append(AIRPLAY)
-
-    identifiers = list(get_unique_identifiers(response))
-    assert len(identifiers) == 1
-    assert "airplay_id" in identifiers
-
-
-def test_unique_identifier_raop(response):
-    response.services.append(RAOP)
-
-    identifiers = list(get_unique_identifiers(response))
-    assert len(identifiers) == 1
-    assert "raop_id" in identifiers
-
-
-def test_unique_identifier_multiple(response):
-    response.services.append(HS)
-    response.services.append(DEVICE)
-    response.services.append(MRP)
-    response.services.append(AIRPLAY)
-    response.services.append(COMPANION)
-    response.services.append(RAOP)
-
-    identifiers = list(get_unique_identifiers(response))
-    assert len(identifiers) == 5
-    assert "hsname" in identifiers
-    assert "devid" in identifiers
-    assert "mrp_id" in identifiers
-    assert "airplay_id" in identifiers
-    assert "raop_id" in identifiers
+    assert "id1" == next(identifiers)
+    unique_id_mock.assert_called_with("_service1._tcp.local", "service1", {"a": "b"})
+    assert "id2" == next(identifiers)
+    unique_id_mock.assert_called_with("_service2._tcp.local", "service2", {"c": "d"})
+    assert not next(identifiers, None)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -223,13 +223,18 @@ def test_airport_express_info(config):
 
 
 def test_airport_express_extra_properties():
-    extra_properties = {
+    airport_properties = {
         # MAC, raMA=2.4GHz MAC, raM2=5GHz MAC
         "wama": "AA-AA-AA-AA-AA-AA,raMA=BB-BB-BB-BB-BB-BB,raM2=CC-CC-CC-CC-CC-CC,"
         + "raNm=MySsid,raCh=11,rCh2=112,raSt=1,raNA=0,syFl=0x80C,syAP=115,syVs=7.8.1,"
         + "srcv=78100.3,bjSd=2"
     }
-    config = conf.AppleTV(ADDRESS_1, NAME, deep_sleep=True, properties=extra_properties)
+    config = conf.AppleTV(
+        ADDRESS_1,
+        NAME,
+        deep_sleep=True,
+        properties={"_airport._tcp.local": airport_properties},
+    )
     config.add_service(AIRPORT_SERVICE)
 
     device_info = config.device_info

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -137,3 +137,12 @@ def data_path(filename: str) -> str:
     if not os.path.exists(abs_path):
         raise FileNotFoundError(f"test file does not exist: {filename}")
     return abs_path
+
+
+def assert_device(atv, name, address, identifier, protocol, port, creds=None):
+    assert atv.name == name
+    assert atv.address == address
+    assert atv.identifier == identifier
+    assert atv.get_service(protocol)
+    assert atv.get_service(protocol).port == port
+    assert atv.get_service(protocol).credentials == creds


### PR DESCRIPTION
This commit moves scan related code out to the protocols by letting
protocols procvide which zeroconf services they need as well as handlers
for found services. Functional tests have also been pushed back to the
protocols, making the "core" fairly protocol agnostic.

Relates to #1202

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1207"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

