### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Want to help out with `pyatv`? Press the button below to get a fully prepared de
 
 To save you some time, here are some shortcuts:
 
-* [Getting started](https://pyatv.dev/getting-started)
+* [Getting started](https://pyatv.dev/documentation/getting-started/)
 * [Documentation](https://pyatv.dev/documentation)
 * [Development](https://pyatv.dev/development)
 * [API Reference](https://pyatv.dev/api)


### PR DESCRIPTION
fixed getting started link on README.md.
I always come here to actually get started with the library,
almost everytime.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1208"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

