### PR TITLE
scan: Support scanning for specific protocols

### DIFF
--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -27,6 +27,17 @@ link_group: api
 <li><code><a title="pyatv.scan" href="#pyatv.scan">scan</a></code></li>
 </ul>
 </li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="pyatv.ProtocolImpl" href="#pyatv.ProtocolImpl">ProtocolImpl</a></code></h4>
+<ul class="">
+<li><code><a title="pyatv.ProtocolImpl.scan" href="#pyatv.ProtocolImpl.scan">scan</a></code></li>
+<li><code><a title="pyatv.ProtocolImpl.setup" href="#pyatv.ProtocolImpl.setup">setup</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
 </ul>
 </nav>
 <article id="content">
@@ -35,7 +46,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Main routines for interacting with an Apple TV.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L0-L137" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L0-L153" class="git-link">Browse git</a></div>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -78,7 +89,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Connect to a device based on a configuration.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L80-L113" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L94-L129" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.pair">
 <code class="name flex">
@@ -87,20 +98,46 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Pair a protocol for an Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L116-L138" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L132-L154" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.scan">
 <code class="name flex">
-<span>async def <span class="ident">scan</span></span>(<span>loop: asyncio.events.AbstractEventLoop, timeout: int = 5, identifier: str = None, protocol: <a title="pyatv.const.Protocol" href="const#pyatv.const.Protocol">Protocol</a> = None, hosts: List[str] = None) -> List[<a title="pyatv.conf.AppleTV" href="conf#pyatv.conf.AppleTV">AppleTV</a>]</span>
+<span>async def <span class="ident">scan</span></span>(<span>loop: asyncio.events.AbstractEventLoop, timeout: int = 5, identifier: str = None, protocol: Optional[<a title="pyatv.const.Protocol" href="const#pyatv.const.Protocol">Protocol</a>, Set[<a title="pyatv.const.Protocol" href="const#pyatv.const.Protocol">Protocol</a>]] = None, hosts: List[str] = None) -> List[<a title="pyatv.conf.AppleTV" href="conf#pyatv.conf.AppleTV">AppleTV</a>]</span>
 </code>
 </dt>
 <dd>
 <section class="desc"><p>Scan for Apple TVs on network and return their configurations.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L45-L77" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L54-L91" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 </section>
 <section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="pyatv.ProtocolImpl"><code class="flex name class">
+<span>class <span class="ident">ProtocolImpl</span></span>
+<span>(</span><span>setup: Callable[[asyncio.events.AbstractEventLoop, <a title="pyatv.conf.AppleTV" href="conf#pyatv.conf.AppleTV">AppleTV</a>, Dict[Any, pyatv.support.relayer.Relayer], <a title="pyatv.interface.StateProducer" href="interface#pyatv.interface.StateProducer">StateProducer</a>, pyatv.support.http.ClientSessionManager], Optional[Tuple[Callable[[], Awaitable[NoneType]], Callable[[]], Set[<a title="pyatv.const.FeatureName" href="const#pyatv.const.FeatureName">FeatureName</a>]]]], scan: Callable[[], Mapping[str, Callable[[pyatv.support.mdns.Service, pyatv.support.mdns.Response], Optional[Tuple[str, <a title="pyatv.interface.BaseService" href="interface#pyatv.interface.BaseService">BaseService</a>]]]]])</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Represent implementation of a protocol.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L35-L39" class="git-link">Browse git</a></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.tuple</li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="pyatv.ProtocolImpl.scan"><code class="name">var <span class="ident">scan</span> -> Callable[[], Mapping[str, Callable[[pyatv.support.mdns.Service, pyatv.support.mdns.Response], Optional[Tuple[str, <a title="pyatv.interface.BaseService" href="interface#pyatv.interface.BaseService">BaseService</a>]]]]]</code></dt>
+<dd>
+<section class="desc"><p>Alias for field number 1</p></section>
+</dd>
+<dt id="pyatv.ProtocolImpl.setup"><code class="name">var <span class="ident">setup</span> -> Callable[[asyncio.events.AbstractEventLoop, <a title="pyatv.conf.AppleTV" href="conf#pyatv.conf.AppleTV">AppleTV</a>, Dict[Any, pyatv.support.relayer.Relayer], <a title="pyatv.interface.StateProducer" href="interface#pyatv.interface.StateProducer">StateProducer</a>, pyatv.support.http.ClientSessionManager], Optional[Tuple[Callable[[], Awaitable[NoneType]], Callable[[]], Set[<a title="pyatv.const.FeatureName" href="const#pyatv.const.FeatureName">FeatureName</a>]]]]</code></dt>
+<dd>
+<section class="desc"><p>Alias for field number 0</p></section>
+</dd>
+</dl>
+</dd>
+</dl>
 </section>
 </article>
 <footer id="footer">

--- a/docs/development/scan_pair_and_connect.md
+++ b/docs/development/scan_pair_and_connect.md
@@ -23,8 +23,8 @@ async def scan(loop, timeout=5, identifier=None, protocol=None, hosts=None):
 
 **identifier:** filter to scan for *one* particular device
 
-**protocol:** filter for devices with a particular protocol
-(one from {% include api i="const.Protocol" %})
+**protocol:** scan for one or more specific protocols
+({% include api i="const.Protocol" %})
 
 **hosts:** list of hosts to specifically scan for, e.g. `['10.0.0.1', '10.0.0.2']`
 
@@ -51,13 +51,20 @@ atvs = scan(loop, identifier='AA:BB:CC:DD:EE:FF')
 # Scan for a specific device by IP (unicast)
 atvs = scan(loop, hosts=['10.0.0.1'])
 
-# Only scan for MRP capable devices
+# Only scan for MRP services
 atvs = scan(loop, protocol=Protocol.MRP)
+
+# Include both MRP and AirPlay
+atvs = scan(loop, protocol={Protocol.MRP, Protocol.AirPlay})
 ```
 
 A list is always returned, even if a filter is applied. See
 {% include api i="conf.AppleTV" %} for what you can do with a configuration
 (e.g. extract deep sleep state or available services).
+
+When scanning for one or more protocols with `protocols`, only the listed
+protocols are added to the configuration regardless if more protocols are
+supported.
 
 ## Pairing
 

--- a/docs/documentation/atvremote.md
+++ b/docs/documentation/atvremote.md
@@ -90,6 +90,33 @@ The `--scan-hosts` flag can be used with any other command as well:
 $ atvremote --scan-hosts 10.0.0.10 -n Kitchen <some command>
 ```
 
+## Discovering specific protocols
+
+By default, pyatv will scan for all protocols supported by a device. It is however possible
+to be more specific about which protocols to scan for with `--scan-protocols`:
+
+```raw
+$  atvremote --scan-protocols mrp scan
+Scan Results
+========================================
+       Name: Vardagsrum
+   Model/SW: Gen4K tvOS 14.x build 18L569
+    Address: 10.0.0.10
+        MAC: AA:BB:CC:DD:EE:FF
+ Deep Sleep: False
+Identifiers:
+ - 01234567-89AB-CDEF-0123-4567890ABCDE
+Services:
+ - Protocol: MRP, Port: 49153, Credentials: None
+```
+
+Only the specified protocols are scanned for. Multiple protocols can be specified
+as a comma-separated list:
+
+```raw
+$ atvremote --scan-protocols mrp,raop,companion scan
+```
+
 ## Specifying a device
 
 In order for `atvremote` to know which device you want to control, you must specify the

--- a/pyatv/scripts/__init__.py
+++ b/pyatv/scripts/__init__.py
@@ -40,6 +40,25 @@ class VerifyScanHosts(argparse.Action):
 
 
 # pylint: disable=too-few-public-methods
+class VerifyScanProtocols(argparse.Action):
+    """Transform scan protocols into an array."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Split protocols and save as array."""
+        protocols = {proto.name.lower(): proto for proto in const.Protocol}
+
+        parsed_protocols = set()
+        for protocol in values.split(","):
+            if protocol in protocols:
+                parsed_protocols.add(protocols[protocol])
+            else:
+                raise argparse.ArgumentTypeError(
+                    "Valid protocols are: " + ", ".join(protocols.keys())
+                )
+        setattr(namespace, self.dest, parsed_protocols)
+
+
+# pylint: disable=too-few-public-methods
 class TransformOutput(argparse.Action):
     """Transform output format to function."""
 

--- a/pyatv/scripts/atvremote.py
+++ b/pyatv/scripts/atvremote.py
@@ -27,7 +27,7 @@ from pyatv.const import (
     ShuffleState,
 )
 from pyatv.interface import retrieve_commands
-from pyatv.scripts import TransformProtocol, VerifyScanHosts
+from pyatv.scripts import TransformProtocol, VerifyScanHosts, VerifyScanProtocols
 
 
 def _print_commands(title, api):
@@ -132,7 +132,10 @@ class GlobalCommands:
     async def scan(self):
         """Scan for Apple TVs on the network."""
         atvs = await scan(
-            self.loop, hosts=self.args.scan_hosts, timeout=self.args.scan_timeout
+            self.loop,
+            hosts=self.args.scan_hosts,
+            timeout=self.args.scan_timeout,
+            protocol=self.args.scan_protocols,
         )
         _print_found_apple_tvs(atvs, sys.stdout)
 
@@ -392,6 +395,13 @@ async def cli_handler(loop):
         action=VerifyScanHosts,
     )
     parser.add_argument(
+        "--scan-protocols",
+        help="scan for specific protocols",
+        dest="scan_protocols",
+        default=None,
+        action=VerifyScanProtocols,
+    )
+    parser.add_argument(
         "--version",
         action="version",
         help="version of atvremote and pyatv",
@@ -503,7 +513,7 @@ def _print_found_apple_tvs(atvs, outstream):
 
 async def _autodiscover_device(args, loop):
     apple_tv = await _scan_for_device(
-        args, args.scan_timeout, loop, protocol=args.protocol
+        args, args.scan_timeout, loop, protocol=args.scan_protocols
     )
     if not apple_tv:
         return None

--- a/pyatv/support/scan.py
+++ b/pyatv/support/scan.py
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ScanHandlerReturn = Tuple[str, interface.BaseService]
 ScanHandler = Callable[[mdns.Service, mdns.Response], Optional[ScanHandlerReturn]]
+ScanMethod = Callable[[], Mapping[str, ScanHandler]]
 
 DEVICE_INFO: str = "_device-info._tcp.local"
 

--- a/tests/companion/test_companion_scan.py
+++ b/tests/companion/test_companion_scan.py
@@ -46,7 +46,7 @@ async def test_multicast_scan_mrp_with_companion(udns_server, multicast_scan: Sc
         )
     )
 
-    atvs = await multicast_scan(protocol=Protocol.MRP)
+    atvs = await multicast_scan()
     assert len(atvs) == 1
 
     dev = atvs[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,9 +131,15 @@ async def multicast_scan_fixture(event_loop, udns_server):
 
 @pytest.fixture(name="unicast_scan")
 async def unicast_scan_fixture(event_loop, udns_server):
-    async def _scan(timeout=1):
+    async def _scan(timeout=1, identifier=None, protocol=None):
         port = str(udns_server.port)
         with patch.dict("os.environ", {"PYATV_UDNS_PORT": port}):
-            return await pyatv.scan(event_loop, hosts=["127.0.0.1"], timeout=timeout)
+            return await pyatv.scan(
+                event_loop,
+                hosts=["127.0.0.1"],
+                timeout=timeout,
+                identifier=identifier,
+                protocol=protocol,
+            )
 
     yield _scan


### PR DESCRIPTION
This commit is two-fold:

* It allows "protocol" passed to scan to either be a single protocol or
  a set of protocols
* Only the specified protocols will be added to configurations of found
  devices, even if they support additional protocols

The intention here is to support scanning only for the protocols of
interest, e.g. to ignore a protocol. The --scan-protocols option has
been added to atvremote to support this.

Relates to #1211

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1213"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

