### PR TITLE
env: Only verify docs with py3.8

### DIFF
--- a/tests/support/test_mdns_functional.py
+++ b/tests/support/test_mdns_functional.py
@@ -168,7 +168,7 @@ async def test_multicast_has_valid_service(event_loop, udns_server, multicast_fa
 async def test_multicast_end_condition_met(
     event_loop, udns_server, multicast_fastexit, stub_ip_address
 ):
-    multicast_fastexit(responses=4, requests=10)
+    multicast_fastexit(responses=1, requests=10)
 
     actor = MagicMock()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean, py{36,37,38,39}, docs, generated, codestyle, pylint, typing, report
+envlist = clean, py{36,37,38,39}, api, docs, generated, codestyle, pylint, typing, report
 skip_missing_interpreters = True
 pysources = pyatv examples scripts
 cs_exclude_words = cann,cant
@@ -8,7 +8,7 @@ cs_exclude_words = cann,cant
 python =
   3.6: clean, py36, docs, generated, codestyle, pylint, typing, report
   3.7: clean, py37, docs, generated, codestyle, pylint, typing, report
-  3.8: clean, py38, docs, generated, codestyle, pylint, typing, report, regression
+  3.8: clean, py38, api, docs, generated, codestyle, pylint, typing, report, regression
   3.9: clean, py39, docs, generated, codestyle, pylint, typing, report
 
 [testenv]
@@ -38,12 +38,18 @@ deps = coverage
 skip_install = true
 commands = coverage erase
 
-[testenv:docs]
+[testenv:api]
 deps =
     {[testenv]deps}
     -r{toxinidir}/requirements_docs.txt
 commands =
     python scripts/api.py verify
+
+[testenv:docs]
+deps =
+    {[testenv]deps}
+    -r{toxinidir}/requirements_docs.txt
+commands =
     codespell -q 4 -L {[tox]cs_exclude_words} --skip="*.pyc,*.pyi,*~" {[tox]pysources} tests
     codespell -q 6 -L cann,cant -S "lib,vendor,_site,api,assets,*~,.sass-cache,*.lock" docs
 


### PR DESCRIPTION
In some peculiar cases pdoc3 generates different output depending on
which python version it is run with. Just settle with one version to
circumvent errors on CI runs.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1216"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

