### PR TITLE
Send MDNS service requests over several messages

### DIFF
--- a/pyatv/support/mdns.py
+++ b/pyatv/support/mdns.py
@@ -455,11 +455,11 @@ class MulticastDnsSdClientProtocol:  # pylint: disable=too-many-instance-attribu
                 [service.name + "." + service.type for service in services],
                 QueryType.ANY,
             )
-        else:
+        elif query_resp.count >= len(self.queries):
             response = Response(
-                services=services,
+                services=query_resp.parser.parse(),
                 deep_sleep=query_resp.deep_sleep,
-                model=_get_model(services),
+                model=_get_model(query_resp.parser.parse()),
             )
 
             if self.end_condition(response):

--- a/pyatv/support/mdns.py
+++ b/pyatv/support/mdns.py
@@ -25,6 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 # Number of services to include in each request
 SERVICES_PER_MSG = 3
 
+SLEEP_PROXY_SERVICE = "_sleep-proxy._udp.local"
+
 # This module produces a lot of debug output, use a dedicated log level.
 # Maybe move this to top-level support later?
 TRAFFIC_LEVEL = logging.DEBUG - 5
@@ -87,7 +89,7 @@ def create_service_queries(services: typing.List[str]) -> typing.List[bytes]:
 
         msg = DnsMessage(0x35FF)
         msg.questions += [DnsQuestion(s, QueryType.PTR, 0x8001) for s in service_chunk]
-
+        msg.questions += [DnsQuestion(SLEEP_PROXY_SERVICE, QueryType.PTR, 0x8001)]
         queries.append(msg.pack())
     return queries
 

--- a/pyatv/support/mdns.py
+++ b/pyatv/support/mdns.py
@@ -104,7 +104,9 @@ class ServiceParser:
                 entry = self.table.setdefault(record.qname, {})
                 if record.qtype not in entry:
                     entry[record.qtype] = []
-                entry[record.qtype].append(record)
+
+                if record not in entry[record.qtype]:
+                    entry[record.qtype].append(record)
 
     def parse(self) -> typing.List[Service]:
         """Parse records and return services."""

--- a/pyatv/support/scan.py
+++ b/pyatv/support/scan.py
@@ -20,6 +20,7 @@ ScanHandler = Callable[[mdns.Service, mdns.Response], Optional[ScanHandlerReturn
 ScanMethod = Callable[[], Mapping[str, ScanHandler]]
 
 DEVICE_INFO: str = "_device-info._tcp.local"
+SLEEP_PROXY: str = "_sleep-proxy._udp.local"
 
 # These ports have been "arbitrarily" chosen (see issue #580) because a device normally
 # listen on them (more or less). They are used as best-effort when for unicast scanning
@@ -54,10 +55,15 @@ class BaseScanner(ABC):
     def __init__(self) -> None:
         """Initialize a new BaseScanner."""
         self._services: Dict[str, ScanHandler] = {
-            DEVICE_INFO: lambda service, response: None
+            DEVICE_INFO: self._empty_handler,
+            SLEEP_PROXY: self._empty_handler,
         }
         self._found_devices: Dict[IPv4Address, FoundDevice] = {}
         self._properties: Dict[IPv4Address, Dict[str, Mapping[str, str]]] = {}
+
+    @staticmethod
+    def _empty_handler(service: mdns.Service, response: mdns.Response) -> None:
+        pass
 
     def add_service(self, service_type: str, handler: ScanHandler):
         """Add service type to discover."""

--- a/pyatv/support/scan.py
+++ b/pyatv/support/scan.py
@@ -206,7 +206,7 @@ class MulticastMdnsScanner(BaseScanner):
             timeout=timeout,
             end_condition=self._end_if_identifier_found if self.identifier else None,
         )
-        for _, response in responses.items():
+        for response in responses:
             self.handle_response(response)
 
     def _end_if_identifier_found(self, response: mdns.Response):

--- a/tests/fake_udns.py
+++ b/tests/fake_udns.py
@@ -282,7 +282,7 @@ def stub_multicast(udns_server, loop):
         hosts = set(
             chain(*[service.addresses for service in udns_server.services.values()])
         )
-        devices = {}
+        devices = []
         sleep_proxy = udns_server.sleep_proxy
         udns_server.sleep_proxy = False
         for host in hosts:
@@ -290,8 +290,8 @@ def stub_multicast(udns_server, loop):
             response = await mdns.unicast(
                 loop, "127.0.0.1", services, port=udns_server.port
             )
-            devices[IPv4Address(host)] = mdns.Response(
-                response.services, sleep_proxy, response.model
+            devices.append(
+                mdns.Response(response.services, sleep_proxy, response.model)
             )
         return devices
 

--- a/tests/support/test_mdns.py
+++ b/tests/support/test_mdns.py
@@ -246,3 +246,20 @@ def test_parse_properties_converts_keys_to_lower_case():
     assert len(parsed) == 1
     assert parsed[0].properties["foo"] == "bar"
     assert parsed[0].properties["Bar"] == "FOO"
+
+
+def test_parse_ignore_duplicate_records():
+    service_params = ("_abc._tcp.local", "service", [], 0, {})
+    message = dns_utils.add_service(dns.DnsMessage(), *service_params)
+
+    parser = mdns.ServiceParser()
+    parser.add_message(message)
+    parser.add_message(message)
+
+    # One service should be present in the table
+    assert len(parser.table) == 1
+
+    # A single record should be there since duplicates is ignored
+    records = parser.table["service._abc._tcp.local"]
+    assert mdns.QueryType.SRV in records
+    assert len(records[mdns.QueryType.SRV]) == 1

--- a/tests/support/test_mdns.py
+++ b/tests/support/test_mdns.py
@@ -30,7 +30,7 @@ TEST_SERVICES = dict(
 def get_response_for_service(
     service: str,
 ) -> Tuple[dns.DnsMessage, Optional[fake_udns.FakeDnsService]]:
-    req = mdns.create_request([service])
+    req = mdns.create_service_queries([service], mdns.QueryType.PTR)[0]
     resp = fake_udns.create_response(req, TEST_SERVICES)
     return dns.DnsMessage().unpack(resp.pack()), TEST_SERVICES.get(service)
 
@@ -43,14 +43,14 @@ def parse_services(message: mdns.DnsMessage) -> List[mdns.Service]:
 
 def test_non_existing_service():
     resp, _ = get_response_for_service("_missing")
-    assert len(resp.questions) == 1
+    assert len(resp.questions) == 2
     assert len(resp.answers) == 0
     assert len(resp.resources) == 0
 
 
 def test_service_has_expected_responses():
     resp, _ = get_response_for_service(MEDIAREMOTE_SERVICE)
-    assert len(resp.questions) == 1
+    assert len(resp.questions) == 2
     assert len(resp.answers) == 1
     assert len(resp.resources) == 3
 

--- a/tests/support/test_mdns_functional.py
+++ b/tests/support/test_mdns_functional.py
@@ -83,7 +83,7 @@ async def multicast_fastexit(event_loop, monkeypatch, udns_server):
 
     # Checks if either response or request count has been fulfilled
     def _check_cond(protocol: mdns.MulticastDnsSdClientProtocol) -> bool:
-        if len(protocol.responses) == conditions["responses"]:
+        if len(protocol.query_responses) == conditions["responses"]:
             return False
         if conditions["requests"] == 0:
             return True
@@ -201,7 +201,7 @@ async def test_multicast_has_valid_service(event_loop, udns_server, multicast_fa
     )
     assert len(resp) == 1
 
-    first = resp[IPv4Address("127.0.0.1")].services[0]
+    first = resp[0].services[0]
     assert first.type == MEDIAREMOTE_SERVICE
     assert first.name == SERVICE_NAME
     assert first.port == 1234
@@ -226,7 +226,7 @@ async def test_multicast_end_condition_met(
         end_condition=_end_cond,
     )
     assert len(resp) == 1
-    actor.assert_called_once_with(resp[IPv4Address("127.0.0.1")])
+    actor.assert_called_once_with(resp[0])
 
 
 async def test_multicast_sleeping_device(event_loop, udns_server, multicast_fastexit):
@@ -260,7 +260,7 @@ async def test_multicast_deep_sleep(event_loop, udns_server, multicast_fastexit)
         event_loop, [MEDIAREMOTE_SERVICE], "127.0.0.1", udns_server.port
     )
 
-    assert not resp[IPv4Address("127.0.0.1")].deep_sleep
+    assert not resp[0].deep_sleep
 
     udns_server.sleep_proxy = True
     multicast_fastexit(responses=1, requests=0)
@@ -269,7 +269,7 @@ async def test_multicast_deep_sleep(event_loop, udns_server, multicast_fastexit)
         event_loop, [MEDIAREMOTE_SERVICE], "127.0.0.1", udns_server.port
     )
 
-    assert resp[IPv4Address("127.0.0.1")].deep_sleep
+    assert resp[0].deep_sleep
 
 
 async def test_multicast_device_model(event_loop, udns_server, multicast_fastexit):
@@ -279,7 +279,7 @@ async def test_multicast_device_model(event_loop, udns_server, multicast_fastexi
         event_loop, [MEDIAREMOTE_SERVICE], "127.0.0.1", udns_server.port
     )
 
-    assert not resp[IPv4Address("127.0.0.1")].model
+    assert not resp[0].model
 
     udns_server.services = {
         MEDIAREMOTE_SERVICE: fake_udns.FakeDnsService(
@@ -296,4 +296,4 @@ async def test_multicast_device_model(event_loop, udns_server, multicast_fastexi
         event_loop, [MEDIAREMOTE_SERVICE], "127.0.0.1", udns_server.port
     )
 
-    assert resp[IPv4Address("127.0.0.1")].model == "dummy"
+    assert resp[0].model == "dummy"

--- a/tests/support/test_scan.py
+++ b/tests/support/test_scan.py
@@ -10,8 +10,6 @@ from pyatv.support.scan import BaseScanner, get_unique_identifiers
 TEST_SERVICE1 = Service("_service1._tcp.local", "service1", None, 0, {"a": "b"})
 TEST_SERVICE2 = Service("_service2._tcp.local", "service2", None, 0, {"c": "d"})
 
-# class TestScanner(BaseScanner):
-
 
 @pytest.fixture
 def response():


### PR DESCRIPTION
This PR aims to fix #1234 by splitting requests over several messages (instead of just one). So far only unicast scanning has been (partially implemented).#1218 

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1235"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

