### PR TITLE
core: Switch from audio-metadata to mediafile

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,7 +1,7 @@
 aiohttp==3.1.0,<5
-audio-metadata==0.11.1
 bitarray==2.1.2
 cryptography==2.6
+mediafile==0.8.0
 miniaudio==1.44
 netifaces==0.10.0
 protobuf==3.17.3,<4

--- a/pyatv/raop/audio_source.py
+++ b/pyatv/raop/audio_source.py
@@ -57,11 +57,6 @@ class AudioSource(ABC):
     def duration(self) -> int:
         """Return duration in seconds."""
 
-    @property
-    @abstractmethod
-    def supports_seek(self) -> bool:
-        """Return if source supports seeking."""
-
 
 class ReaderWrapper(miniaudio.StreamableSource):
     """Wraps a reader into a StreamableSource that miniaudio can consume."""
@@ -228,11 +223,6 @@ class BufferedReaderSource(AudioSource):
         """Return duration in seconds."""
         return 0  # We don't know the duration
 
-    @property
-    def supports_seek(self) -> bool:
-        """Return if source supports seeking."""
-        return self.wrapper.reader.seekable()
-
 
 class FileSource(AudioSource):
     """Audio source used to play a local audio file."""
@@ -290,11 +280,6 @@ class FileSource(AudioSource):
     def duration(self) -> int:
         """Return duration in seconds."""
         return round(self.src.duration)
-
-    @property
-    def supports_seek(self) -> bool:
-        """Return if source supports seeking."""
-        return True
 
 
 async def open_source(


### PR DESCRIPTION
This will fix the dependency issues that audio-metadata provides since mediafile only has mutagen as dependency (which has no other dependencies). Current problem is that mediafile doesn't support WAV-files yet (I opened an issue about it https://github.com/beetbox/mediafile/issues/49 and a PR https://github.com/beetbox/mediafile/issues/50), so will have to wait until that is fixed.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1271"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

