### PR TITLE
docs: Use absolute address to logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A client library for Apple TV and AirPlay devices
 =================================================
 
-<img src="docs/assets/img/logo.svg?raw=true" width="150">
+<img src="https://raw.githubusercontent.com/postlund/pyatv/master/docs/assets/img/logo.svg?raw=true" width="150">
 
 ![Tests](https://github.com/postlund/pyatv/workflows/Tests/badge.svg)
 [![codecov](https://codecov.io/gh/postlund/pyatv/branch/master/graph/badge.svg)](https://codecov.io/gh/postlund/pyatv)


### PR DESCRIPTION
The logo is broken on external sites, like pypi. So lets use an absolute
address to fix that.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1272"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

