### PR TITLE
core: Use connect order based on protocol

### DIFF
--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -35,7 +35,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Main routines for interacting with an Apple TV.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L1-L125" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L1-L124" class="git-link">Browse git</a></div>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -78,7 +78,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Connect to a device based on a configuration.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L67-L101" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L67-L100" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.pair">
 <code class="name flex">
@@ -87,7 +87,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Pair a protocol for an Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L104-L125" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L103-L124" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.scan">
 <code class="name flex">

--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -81,12 +81,11 @@ async def connect(
     atv = FacadeAppleTV(config, session_manager)
 
     try:
-        for service in config.services:
-            proto_methods = PROTOCOLS.get(service.protocol)
-            if not proto_methods:
-                raise RuntimeError(
-                    f"missing implementation for protocol {service.protocol}"
-                )
+        # for service in config.services:
+        for proto, proto_methods in PROTOCOLS.items():
+            service = config.get_service(proto)
+            if service is None:
+                continue
 
             for setup_data in proto_methods.setup(
                 loop, config, service, atv, session_manager


### PR DESCRIPTION
Instead of connecting to protocols based on the order they were
discovered, use a pre-defined order (protocol name). It seems some Apple
TVs upgraded to tvOS 15 gets a lingering MRP service not possible to
connect to. If the MRP service is discovered prior to AirPlay,
connecting to such a device will fail. Maintaining this particular order
will serve as a work-around for that.

Relates to #1322

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1328"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

