### PR TITLE
Improve pairing requirements in RAOP and Companion

### DIFF
--- a/pyatv/protocols/airplay/__init__.py
+++ b/pyatv/protocols/airplay/__init__.py
@@ -162,12 +162,16 @@ async def service_info(
     """Update service with additional information."""
     service.requires_password = is_password_required(service)
 
-    # Some devices require no pairing at all, so exclude them
-    if devinfo.model in [
+    if service.properties.get("acl", "0") == "1":
+        # Access control might say that pairing is not possible, e.g. only devices
+        # belonging to the same home (not supported by pyatv)
+        service.pairing = PairingRequirement.Disabled
+    elif devinfo.model in [
         DeviceModel.AirPortExpressGen2,
         DeviceModel.HomePod,
         DeviceModel.HomePodMini,
     ]:
+        # Some devices require no pairing at all, so exclude them
         service.pairing = PairingRequirement.NotNeeded
     else:
         service.pairing = get_pairing_requirement(service)

--- a/stream.py
+++ b/stream.py
@@ -1,0 +1,64 @@
+"""Example of streaming a file and printing status updates.
+
+python stream.py 10.0.0.4 file.mp3
+"""
+
+import asyncio
+import sys
+
+import pyatv
+import logging
+from pyatv.interface import Playing, PushListener
+
+LOOP = asyncio.get_event_loop()
+
+
+class PushUpdatePrinter(PushListener):
+    """Print push updates to console."""
+
+    def playstatus_update(self, updater, playstatus: Playing) -> None:
+        """Inform about changes to what is currently playing."""
+        print(30 * "-" + "\n", playstatus)
+
+    def playstatus_error(self, updater, exception: Exception) -> None:
+        """Inform about an error when updating play status."""
+        print("Error:", exception)
+
+
+async def stream_with_push_updates(
+    address: str, filename: str, loop: asyncio.AbstractEventLoop
+):
+    """Find a device and print what is playing."""
+    print("* Discovering device on network...")
+    atvs = await pyatv.scan(loop, hosts=[address], timeout=5)
+
+    if not atvs:
+        print("* Device found", file=sys.stderr)
+        return
+
+    conf = atvs[0]
+
+    print("* Connecting to", conf.address)
+    atv = await pyatv.connect(conf, loop)
+
+    listener = PushUpdatePrinter()
+    atv.push_updater.listener = listener
+    atv.push_updater.start()
+
+    try:
+        print("* Starting to stream", filename)
+        a = asyncio.ensure_future(atv.stream.stream_file(filename))
+        await asyncio.sleep(3)
+        print("stopping")
+        await atv.remote_control.stop()
+        print("waiting")
+        await a
+    except Exception as ex:
+        print("error:", ex)
+    finally:
+        atv.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    LOOP.run_until_complete(stream_with_push_updates(sys.argv[1], sys.argv[2], LOOP))

--- a/tests/protocols/airplay/test_airplay.py
+++ b/tests/protocols/airplay/test_airplay.py
@@ -87,6 +87,8 @@ async def test_service_info_password(airplay_props, mrp_props, requires_password
             {},
             PairingRequirement.Mandatory,
         ),
+        ({"acl": "1"}, {}, PairingRequirement.Disabled),
+        ({"acl": "1", "sf": "0x200"}, {}, PairingRequirement.Disabled),
         # Special cases for devices only requiring transient pairing, e.g.
         # HomePod and AirPort Express
         # AirPort Express gen 1 does not support AirPlay 2 => assume checks above

--- a/tests/protocols/raop/test_raop.py
+++ b/tests/protocols/raop/test_raop.py
@@ -136,14 +136,27 @@ async def test_service_info_password(raop_props, mrp_props, requires_password):
     ],
 )
 async def test_service_info_pairing(raop_props, devinfo, pairing_req):
-    raop_props = MutableService("id", Protocol.AirPlay, 0, raop_props)
+    raop_service = MutableService("id", Protocol.RAOP, 0, raop_props)
 
-    assert raop_props.pairing == PairingRequirement.Unsupported
+    assert raop_service.pairing == PairingRequirement.Unsupported
 
     await service_info(
-        raop_props,
+        raop_service,
         DeviceInfo(devinfo),
-        {Protocol.RAOP: raop_props},
+        {Protocol.RAOP: raop_service},
     )
 
-    assert raop_props.pairing == pairing_req
+    assert raop_service.pairing == pairing_req
+
+
+async def test_service_info_pairing_acl():
+    raop_service = MutableService("id", Protocol.RAOP, 0, {})
+    airplay_props = MutableService("id", Protocol.AirPlay, 0, {"acl": "1"})
+
+    await service_info(
+        raop_service,
+        DeviceInfo({}),
+        {Protocol.RAOP: raop_service, Protocol.AirPlay: airplay_props},
+    )
+
+    assert raop_service.pairing == PairingRequirement.Disabled


### PR DESCRIPTION
See #1330 for details. HomePods will now always be marked as `Unsupported` as pyatv does not support pairing with them anyways.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1331"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

