### PR TITLE
Some minor fixes

### DIFF
--- a/pyatv/protocols/dmap/pairing.py
+++ b/pyatv/protocols/dmap/pairing.py
@@ -57,7 +57,7 @@ class DmapPairingHandler(
         """Initialize a new instance."""
         super().__init__(session_manager, service)
         self._loop = loop
-        self._zeroconf = kwargs.get("zeroconf", Zeroconf())
+        self._zeroconf = kwargs.get("zeroconf") or Zeroconf()
         self._name = kwargs.get("name", "pyatv")
         self.app = web.Application()
         self.app.router.add_routes([web.get("/pair", self.handle_request)])

--- a/tests/protocols/companion/test_companion.py
+++ b/tests/protocols/companion/test_companion.py
@@ -54,7 +54,7 @@ def test_device_info(service_type, properties, expected):
         ({}, PairingRequirement.Unsupported),
         ({"rpfl": "0x627B6"}, PairingRequirement.Disabled),
         ({"rpfl": "0x36782"}, PairingRequirement.Mandatory),
-        # ({"rpfl": "0x0"}, PairingRequirement.Unsupported),
+        ({"rpfl": "0x0"}, PairingRequirement.Unsupported),
     ],
 )
 async def test_service_info_pairing(properties, expected):


### PR DESCRIPTION
Enable a test that was commented by accident and don't create unnecessary  instances of `Zeroconf`.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1347"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

