### PR TITLE
Release 0.9.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,33 @@
 # CHANGES
 
+## 0.9.5 Oscar (2021-10-15)
+
+The releases are pouring down right now! Two more bug fixes to smoothen the experience:
+
+* Fix relay bug which could result in methods being reported as unsupported
+* Add some missing DMAP tags (removes warnings)
+
+**Changes:**
+
+*Protocol: DMAP:*
+
+```
+436ba7b dmap: Add missing tags aelb and casa
+```
+
+*Other:*
+
+```
+5170edd core: Fix relayer fallback bug
+```
+
+**All changes:**
+
+```
+436ba7b dmap: Add missing tags aelb and casa
+5170edd core: Fix relayer fallback bug
+```
+
 ## 0.9.4 Nightmare (2021-10-15)
 
 This release just contains two minor bug fixes:

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 MAJOR_VERSION = "0"
 MINOR_VERSION = "9"
-PATCH_VERSION = "4"
+PATCH_VERSION = "5"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
## 0.9.5 Oscar (2021-10-15)

The releases are pouring down right now! Two more bug fixes to smoothen the experience:

* Fix relay bug which could result in methods being reported as unsupported
* Add some missing DMAP tags (removes warnings)

**Changes:**

*Protocol: DMAP:*

```
436ba7b dmap: Add missing tags aelb and casa
```

*Other:*

```
5170edd core: Fix relayer fallback bug
```

**All changes:**

```
436ba7b dmap: Add missing tags aelb and casa
5170edd core: Fix relayer fallback bug
```

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1404"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

