### PR TITLE
env: Rebuild miniaudio in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
         python -m pip install --upgrade setuptools pip pyyaml
     - name: Test with chickn
       if: steps.run_result.outputs.run_result != 'success'
-      run: python ./scripts/chickn.py -t ${{ matrix.python-version }} ${{ matrix.chickn-args }}
+      run: python ./scripts/chickn.py -t miniaudio -t ${{ matrix.python-version }} ${{ matrix.chickn-args }}
       shell: bash
     - name: Upload coverage to Codecov
       if: steps.run_result.outputs.run_result != 'success'

--- a/chickn.yaml
+++ b/chickn.yaml
@@ -19,15 +19,26 @@ dependencies:
 
 pipeline:
   pre:
-   - name: clean
-     run: coverage erase
-   - name: fixup
-     tags: [all, fixup]
-     run:
-       - black .
-       - isort {code_dirs}
-       - ./scripts/api.py generate
-       - ./scripts/protobuf.py generate
+    - name: clean
+      run: coverage erase
+    - name: fixup
+      tags: [all, fixup]
+      run:
+        - black .
+        - isort {code_dirs}
+        - ./scripts/api.py generate
+        - ./scripts/protobuf.py generate
+  rebuild_miniaudio:
+    # A lot of builds on GitHub Actions result in "Illegal Instruction"
+    # when calling functions in miniaudio. Seemingly random and not
+    # always. Likely has to do with some instruction set mismatch, but
+    # not sure. Rebuilding miniaudio seems to improve the situation,
+    # so this optional step is used by the tests workflow to do that.
+    - name: miniaudio
+      tags: [all, miniaudio]
+      run:
+        - "pip uninstall -y miniaudio"
+        - "pip install --no-binary :all: miniaudio"
   validate:
     - name: pylint
       run: pylint -j 0 {pydirs}


### PR DESCRIPTION
Always rebuild miniaudio when running with GitHub Actions as that seems
to improve stability.

Relates to #1437

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1444"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

