### PR TITLE
raop: Let pause button stop playback

### DIFF
--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -1465,7 +1465,7 @@ always be the same for the same content, but it is not guaranteed.</p></section>
 <dd>
 <div class="api_feature">
 <span>Feature: <a title="pyatv.const.FeatureName.Pause" href="const#pyatv.const.FeatureName.Pause">FeatureName.Pause</a>,</span>
-<span>Supported by: <a title="pyatv.const.Protocol.Companion" href="const#pyatv.const.Protocol.Companion">Protocol.Companion</a>, <a title="pyatv.const.Protocol.DMAP" href="const#pyatv.const.Protocol.DMAP">Protocol.DMAP</a>, <a title="pyatv.const.Protocol.MRP" href="const#pyatv.const.Protocol.MRP">Protocol.MRP</a></span>
+<span>Supported by: <a title="pyatv.const.Protocol.Companion" href="const#pyatv.const.Protocol.Companion">Protocol.Companion</a>, <a title="pyatv.const.Protocol.DMAP" href="const#pyatv.const.Protocol.DMAP">Protocol.DMAP</a>, <a title="pyatv.const.Protocol.MRP" href="const#pyatv.const.Protocol.MRP">Protocol.MRP</a>, <a title="pyatv.const.Protocol.RAOP" href="const#pyatv.const.Protocol.RAOP">Protocol.RAOP</a></span>
 </div>
 <section class="desc"><p>Press key play.</p></section>
 <div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L293-L296" class="git-link">Browse git</a></div>

--- a/pyatv/protocols/raop/__init__.py
+++ b/pyatv/protocols/raop/__init__.py
@@ -216,7 +216,7 @@ class RaopFeatures(Features):
         ]:
             return FeatureInfo(FeatureState.Available)
 
-        if feature_name == FeatureName.Stop:
+        if feature_name in [FeatureName.Stop, FeatureName.Pause]:
             is_streaming = self.playback_manager.raop is not None
             return FeatureInfo(
                 FeatureState.Available if is_streaming else FeatureState.Unavailable
@@ -377,6 +377,13 @@ class RaopRemoteControl(RemoteControl):
         self.audio = audio
         self.playback_manager = playback_manager
 
+    # At the moment, pause will stop playback until it is properly implemented. This
+    # gives a better experience in Home Assistant.
+    async def pause(self) -> None:
+        """Press key pause."""
+        if self.playback_manager.raop:
+            self.playback_manager.raop.stop()
+
     async def stop(self) -> None:
         """Press key stop."""
         if self.playback_manager.raop:
@@ -533,6 +540,7 @@ def setup(  # pylint: disable=too-many-locals
                 FeatureName.VolumeUp,
                 FeatureName.VolumeDown,
                 FeatureName.Stop,
+                FeatureName.Pause,
             ]
         ),
     )

--- a/tests/protocols/raop/test_raop_functional.py
+++ b/tests/protocols/raop/test_raop_functional.py
@@ -41,7 +41,7 @@ VOLUME_FIELDS = [
     FeatureName.VolumeUp,
     FeatureName.VolumeDown,
 ]
-REMOTE_CONTROL_FIELDS = [FeatureName.Stop]
+REMOTE_CONTROL_FIELDS = [FeatureName.Stop, FeatureName.Pause]
 
 
 @pytest.fixture(name="playing_listener")
@@ -547,13 +547,16 @@ async def test_stream_from_buffer(raop_client, raop_state):
     # assert await audio_matches(raop_state.raw_audio, frames=FRAMES_PER_PACKET)
 
 
-@pytest.mark.parametrize("raop_properties", [({"et": "0"})])
-async def test_stop_playback(raop_client, raop_state):
+@pytest.mark.parametrize(
+    "raop_properties,button",
+    [({"et": "0"}, "stop"), ({"et": "0"}, "pause")],  # We treat pause as stop for now
+)
+async def test_stop_playback(raop_client, raop_state, button):
     async def _fake_sleep(time: float = None, loop=None):
         async def dummy():
             pass
 
-        await raop_client.remote_control.stop()
+        await getattr(raop_client.remote_control, button)()
         await asyncio.ensure_future(dummy())
 
     # The idea here is to simulate calling "stop" after the first frame has been sent,


### PR DESCRIPTION
Until pause is implemented properly, let it stop the playback. This is
a hack that aligns with Home Assistant as in most cases only the pause
button will be shown in the frontend which won't do anything. This way
it's possible to stop playback easily.

Relates to #1451