### PR TITLE
mrp: Fix protocol bug in state dispatcher

### DIFF
--- a/pyatv/core/__init__.py
+++ b/pyatv/core/__init__.py
@@ -71,6 +71,10 @@ class ProtocolStateDispatcher:
         self._protocol = protocol
         self._core_dispatcher = core_dispatcher
 
+    def create_copy(self, protocol: Protocol) -> "ProtocolStateDispatcher":
+        """Create a copy of this instance but with a new protocol."""
+        return ProtocolStateDispatcher(protocol, self._core_dispatcher)
+
     def listen_to(
         self,
         state: UpdatedState,

--- a/pyatv/protocols/airplay/__init__.py
+++ b/pyatv/protocols/airplay/__init__.py
@@ -256,7 +256,7 @@ def setup(  # pylint: disable=too-many-locals
             device_listener,
             session_manager,
             takeover,
-            state_dispatcher,
+            state_dispatcher.create_copy(Protocol.MRP),
             AirPlayMrpConnection(control, device_listener),
             requires_heatbeat=False,  # Already have heartbeat on control channel
         )

--- a/pyatv/protocols/mrp/__init__.py
+++ b/pyatv/protocols/mrp/__init__.py
@@ -555,6 +555,7 @@ class MrpPower(Power):
         self.device_info = None
         self._waiters: Dict[PowerState, asyncio.Event] = {}
 
+        self.protocol.listen_to(protobuf.DEVICE_INFO_MESSAGE, self._update_power_state)
         self.protocol.listen_to(
             protobuf.DEVICE_INFO_UPDATE_MESSAGE, self._update_power_state
         )

--- a/pyatv/protocols/mrp/protocol.py
+++ b/pyatv/protocols/mrp/protocol.py
@@ -137,9 +137,13 @@ class MrpProtocol(MessageDispatcher[int, protobuf.ProtocolMessage]):
 
             # The first message must always be DEVICE_INFORMATION, otherwise the
             # device will not respond with anything
-            msg = messages.device_information("pyatv", self.srp.pairing_id.decode())
+            self.device_info = await self.send_and_receive(
+                messages.device_information("pyatv", self.srp.pairing_id.decode())
+            )
 
-            self.device_info = await self.send_and_receive(msg)
+            # Distribute the device information to all listeners (as the
+            # send_and_receive will stop that propagation).
+            self.dispatch(protobuf.DEVICE_INFO_MESSAGE, self.device_info)
 
             # This is a hack to support re-use of a protocol object in
             # proxy (will be removed/refactored later)

--- a/tests/core/test_facade.py
+++ b/tests/core/test_facade.py
@@ -696,13 +696,13 @@ async def test_power_state_respect_playing_state(mrp_state_dispatcher, power_set
 
     # Trigger something to play (but keep power state off) changes it to On
     await dispatch_device_state(mrp_state_dispatcher, DeviceState.Playing)
-    power_setup.listener.last_update == PowerState.On
-    power_setup.power_state == PowerState.On
+    assert power_setup.listener.last_update == PowerState.On
+    assert power_setup.power_state == PowerState.On
 
     # Trigger back to idle shall give power state Off again
     await dispatch_device_state(mrp_state_dispatcher, DeviceState.Idle)
-    power_setup.listener.last_update == PowerState.Off
-    power_setup.power_state == PowerState.Off
+    assert power_setup.listener.last_update == PowerState.Off
+    assert power_setup.power_state == PowerState.Off
 
 
 async def test_power_state_defaults_to_derived_power_state_from_off(
@@ -712,14 +712,14 @@ async def test_power_state_defaults_to_derived_power_state_from_off(
 
     # Trigger something to play (but keep power state off) changes it to On
     await dispatch_device_state(mrp_state_dispatcher, DeviceState.Playing)
-    power_setup.listener.last_update == PowerState.On
+    assert power_setup.listener.last_update == PowerState.On
 
     # Change derived power state to On
     power_instance.current_state = PowerState.On
 
     # Trigger back to idle shall give power state On as derived state is On
     await dispatch_device_state(mrp_state_dispatcher, DeviceState.Idle)
-    power_setup.power_state == PowerState.On
+    assert power_setup.power_state == PowerState.On
 
 
 async def test_power_state_defaults_to_derived_power_state_from_on(
@@ -729,11 +729,12 @@ async def test_power_state_defaults_to_derived_power_state_from_on(
 
     # Trigger something to play (but keep power state off) changes it to On
     await dispatch_device_state(mrp_state_dispatcher, DeviceState.Playing)
-    power_setup.listener.last_update == PowerState.On
+    assert power_setup.listener.last_update is None
 
     # Trigger back to idle shall give power state On as derived state is On
     await dispatch_device_state(mrp_state_dispatcher, DeviceState.Idle)
-    power_setup.power_state == PowerState.On
+    assert power_setup.power_state == PowerState.On
+    assert power_setup.listener.last_update is None
 
 
 async def test_power_play_state_only_from_main_protocol(


### PR DESCRIPTION
The wrong protocol was used in the ProtocolStateDispatcher passed to
MRP, so play state updates didn't reach the power implementation in
facade. Hopefully this will make the implementation more stable.

Relates to #1500

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1541"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

