### PR TITLE
raop: Override volume from other protocols

### DIFF
--- a/pyatv/core/__init__.py
+++ b/pyatv/core/__init__.py
@@ -33,6 +33,9 @@ class UpdatedState(Enum):
     Playing = 1
     """Playing state in metadata was updated."""
 
+    Volume = 2
+    """Volume was updated."""
+
 
 # pylint: enable=invalid-name
 
@@ -45,6 +48,7 @@ class StateMessage(NamedTuple):
 
     # Type depending on value of state:
     # - UpdatedState.Playing -> interface.Playing
+    # - UpdatedState.Volume -> float
     value: Any
 
     def __str__(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import pytest
 
 import pyatv
 from pyatv.auth.hap_pairing import parse_credentials
+from pyatv.const import Protocol
+from pyatv.core import CoreStateDispatcher, ProtocolStateDispatcher
 from pyatv.interface import BaseConfig
 from pyatv.support.http import create_session
 from pyatv.support.net import unused_port
@@ -149,3 +151,18 @@ def airplay_creds_fixture():
     with patch("pyatv.protocols.airplay.auth.new_credentials") as new_credentials:
         new_credentials.return_value = parse_credentials(DEVICE_CREDENTIALS)
         yield
+
+
+@pytest.fixture(name="core_dispatcher")
+def core_dispatcher():
+    yield CoreStateDispatcher()
+
+
+@pytest.fixture(name="mrp_state_dispatcher")
+def mrp_state_dispatcher_fixture(core_dispatcher):
+    yield ProtocolStateDispatcher(Protocol.MRP, core_dispatcher)
+
+
+@pytest.fixture(name="dmap_state_dispatcher")
+def dmap_state_dispatcher_fixture(core_dispatcher):
+    yield ProtocolStateDispatcher(Protocol.DMAP, core_dispatcher)

--- a/tests/core/test_facade.py
+++ b/tests/core/test_facade.py
@@ -20,14 +20,7 @@ from pyatv.const import (
     PowerState,
     Protocol,
 )
-from pyatv.core import (
-    AbstractPushUpdater,
-    CoreStateDispatcher,
-    ProtocolStateDispatcher,
-    SetupData,
-    StateMessage,
-    UpdatedState,
-)
+from pyatv.core import AbstractPushUpdater, SetupData, StateMessage, UpdatedState
 from pyatv.core.facade import FacadeAppleTV, SetupData
 from pyatv.interface import (
     AppleTV,
@@ -55,21 +48,6 @@ _LOGGER = logging.getLogger(__name__)
 TEST_URL = "http://test"
 
 pytestmark = pytest.mark.asyncio
-
-
-@pytest.fixture(name="core_dispatcher")
-def core_dispatcher():
-    yield CoreStateDispatcher()
-
-
-@pytest.fixture(name="mrp_state_dispatcher")
-def mrp_state_dispatcher_fixture(core_dispatcher):
-    yield ProtocolStateDispatcher(Protocol.MRP, core_dispatcher)
-
-
-@pytest.fixture(name="dmap_state_dispatcher")
-def dmap_state_dispatcher_fixture(core_dispatcher):
-    yield ProtocolStateDispatcher(Protocol.DMAP, core_dispatcher)
 
 
 @pytest.fixture(name="facade_dummy")

--- a/tests/protocols/mrp/test_mrp_interface.py
+++ b/tests/protocols/mrp/test_mrp_interface.py
@@ -23,8 +23,8 @@ async def volume_controls_changed(protocol, device_uid, controls_available):
 
 
 @pytest.fixture(name="audio")
-def audio_fixture(protocol_mock):
-    yield MrpAudio(protocol_mock)
+def audio_fixture(protocol_mock, mrp_state_dispatcher):
+    yield MrpAudio(protocol_mock, mrp_state_dispatcher)
 
 
 async def test_audio_volume_control_availability(protocol_mock, audio):

--- a/tests/protocols/raop/test_raop_functional.py
+++ b/tests/protocols/raop/test_raop_functional.py
@@ -4,6 +4,7 @@ TODO: Things to improve:
 
 * Add tests for timing server
 * Improve sync tests
+* Volume changed by other protocol (multi-protocol test)
 """
 import asyncio
 import io


### PR DESCRIPTION
raop: Override volume from other protocols
    
The volume state in RAOP was (potentially) only derived by the first connection made to the remote device. Mainly becuase no persistent connection is maintained. This resulted in the volume level getting out of sync very easily. Now RAOP will update volume changes according to what other protocols are dispatching.
    
Relates to #1522

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1542"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

