### PR TITLE
airplay: Fix pairing requirement bug

### DIFF
--- a/pyatv/protocols/airplay/__init__.py
+++ b/pyatv/protocols/airplay/__init__.py
@@ -174,13 +174,6 @@ async def service_info(
         # Access control might say that pairing is not possible, e.g. only devices
         # belonging to the same home (not supported by pyatv)
         service.pairing = PairingRequirement.Disabled
-    elif devinfo.model in [
-        DeviceModel.AirPortExpressGen2,
-        DeviceModel.HomePod,
-        DeviceModel.HomePodMini,
-    ]:
-        # Some devices require no pairing at all, so exclude them
-        service.pairing = PairingRequirement.NotNeeded
     else:
         service.pairing = get_pairing_requirement(service)
 

--- a/tests/protocols/airplay/test_airplay.py
+++ b/tests/protocols/airplay/test_airplay.py
@@ -88,33 +88,12 @@ async def test_service_info_password(airplay_props, mrp_props, requires_password
 @pytest.mark.parametrize(
     "airplay_props,devinfo,pairing_req",
     [
+        ({"sf": "0x0"}, {}, PairingRequirement.NotNeeded),
+        ({"sf": "0x8"}, {}, PairingRequirement.Mandatory),
         ({"sf": "0x200"}, {}, PairingRequirement.Mandatory),
         ({"flags": "0x200"}, {}, PairingRequirement.Mandatory),
-        (
-            {"features": hex(AirPlayFlags.SupportsLegacyPairing)},
-            {},
-            PairingRequirement.Mandatory,
-        ),
         ({"acl": "1"}, {}, PairingRequirement.Disabled),
         ({"acl": "1", "sf": "0x200"}, {}, PairingRequirement.Disabled),
-        # Special cases for devices only requiring transient pairing, e.g.
-        # HomePod and AirPort Express
-        # AirPort Express gen 1 does not support AirPlay 2 => assume checks above
-        (
-            {"flags": "0x200"},
-            {DeviceInfo.MODEL: DeviceModel.AirPortExpressGen2},
-            PairingRequirement.NotNeeded,
-        ),
-        (
-            {"flags": "0x200"},
-            {DeviceInfo.MODEL: DeviceModel.HomePod},
-            PairingRequirement.NotNeeded,
-        ),
-        (
-            {"flags": "0x200"},
-            {DeviceInfo.MODEL: DeviceModel.HomePodMini},
-            PairingRequirement.NotNeeded,
-        ),
     ],
 )
 async def test_service_info_pairing(airplay_props, devinfo, pairing_req):

--- a/tests/protocols/airplay/test_utils.py
+++ b/tests/protocols/airplay/test_utils.py
@@ -78,18 +78,12 @@ def test_is_password_required(properties, requires_password):
         ({"sf": "0x1"}, PairingRequirement.NotNeeded),
         ({"sf": "0x200"}, PairingRequirement.Mandatory),
         ({"ft": "0x1"}, PairingRequirement.NotNeeded),
-        ({"ft": "0x200"}, PairingRequirement.Mandatory),
         ({"flags": "0x1"}, PairingRequirement.NotNeeded),
         ({"flags": "0x200"}, PairingRequirement.Mandatory),
         ({"features": "0x1"}, PairingRequirement.NotNeeded),
-        (
-            {"features": hex(AirPlayFlags.SupportsLegacyPairing)},
-            PairingRequirement.Mandatory,
-        ),
-        (
-            {"features": "0x00000000,0x10000"},
-            PairingRequirement.Mandatory,
-        ),
+        ({"sf": "0x8"}, PairingRequirement.Mandatory),
+        ({"flags": "0x8"}, PairingRequirement.Mandatory),
+        ({"flags": "0x0"}, PairingRequirement.NotNeeded),
     ],
 )
 async def test_get_pairing_requirement(props, expected_req):

--- a/tests/protocols/raop/test_raop.py
+++ b/tests/protocols/raop/test_raop.py
@@ -113,31 +113,10 @@ async def test_service_info_password(raop_props, mrp_props, requires_password):
 @pytest.mark.parametrize(
     "raop_props,devinfo,pairing_req",
     [
+        ({"sf": "0x0"}, {}, PairingRequirement.NotNeeded),
+        ({"sf": "0x8"}, {}, PairingRequirement.Mandatory),
         ({"sf": "0x200"}, {}, PairingRequirement.Mandatory),
         ({"flags": "0x200"}, {}, PairingRequirement.Mandatory),
-        (
-            {"features": hex(AirPlayFlags.SupportsLegacyPairing)},
-            {},
-            PairingRequirement.Mandatory,
-        ),
-        # Special cases for devices only requiring transient pairing, e.g.
-        # HomePod and AirPort Express
-        # AirPort Express gen 1 does not support AirPlay 2 => assume checks above
-        (
-            {"flags": "0x200"},
-            {DeviceInfo.MODEL: DeviceModel.AirPortExpressGen2},
-            PairingRequirement.NotNeeded,
-        ),
-        (
-            {"flags": "0x200"},
-            {DeviceInfo.MODEL: DeviceModel.HomePod},
-            PairingRequirement.NotNeeded,
-        ),
-        (
-            {"flags": "0x200"},
-            {DeviceInfo.MODEL: DeviceModel.HomePodMini},
-            PairingRequirement.NotNeeded,
-        ),
     ],
 )
 async def test_service_info_pairing(raop_props, devinfo, pairing_req):


### PR DESCRIPTION
Look at status flags instead of feature flags as they tell what is
required and not only what is supported.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1544"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

