### PR TITLE
core: Introduce Core in protocols

### DIFF
--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -35,7 +35,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Main routines for interacting with an Apple TV.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L1-L139" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L1-L142" class="git-link">Browse git</a></div>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -78,7 +78,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Connect to a device based on a configuration.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L71-L115" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L71-L118" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.pair">
 <code class="name flex">
@@ -87,7 +87,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Pair a protocol for an Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L118-L139" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L121-L142" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.scan">
 <code class="name flex">

--- a/pyatv/core/__init__.py
+++ b/pyatv/core/__init__.py
@@ -16,7 +16,9 @@ from typing import (
 
 from pyatv.const import FeatureName, PairingRequirement, Protocol
 from pyatv.core.protocol import MessageDispatcher
-from pyatv.interface import BaseService, Playing, PushUpdater
+from pyatv.interface import BaseConfig, BaseService, Playing, PushUpdater
+from pyatv.support.http import ClientSessionManager
+from pyatv.support.state_producer import StateProducer
 
 TakeoverMethod = Callable[
     ...,
@@ -191,3 +193,26 @@ class SetupData(NamedTuple):
     device_info: Callable[[], Dict[str, Any]]
     interfaces: Mapping[Any, Any]
     features: Set[FeatureName]
+
+
+class Core:
+    """Instance for protocols to access core features."""
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        config: BaseConfig,
+        service: BaseService,
+        device_listener: StateProducer,
+        session_manager: ClientSessionManager,
+        takeover: TakeoverMethod,
+        state_dispatcher: ProtocolStateDispatcher,
+    ) -> None:
+        """Initialize a new Core instance."""
+        self.loop = loop
+        self.config = config
+        self.service = service
+        self.device_listener = device_listener
+        self.session_manager = session_manager
+        self.takeover = takeover
+        self.state_dispatcher = state_dispatcher

--- a/pyatv/protocols/__init__.py
+++ b/pyatv/protocols/__init__.py
@@ -1,15 +1,10 @@
 """Module containing all protocol logic."""
-import asyncio
+
 from typing import Any, Awaitable, Callable, Dict, Generator, Mapping, NamedTuple
 
 from pyatv import interface
 from pyatv.const import Protocol
-from pyatv.core import (
-    MutableService,
-    ProtocolStateDispatcher,
-    SetupData,
-    TakeoverMethod,
-)
+from pyatv.core import Core, MutableService, SetupData
 from pyatv.core.scan import ScanMethod
 from pyatv.interface import BaseService, DeviceInfo
 from pyatv.protocols import airplay as airplay_proto
@@ -17,19 +12,9 @@ from pyatv.protocols import companion as companion_proto
 from pyatv.protocols import dmap as dmap_proto
 from pyatv.protocols import mrp as mrp_proto
 from pyatv.protocols import raop as raop_proto
-from pyatv.support.http import ClientSessionManager
-from pyatv.support.state_producer import StateProducer
 
 SetupMethod = Callable[
-    [
-        asyncio.AbstractEventLoop,
-        interface.BaseConfig,
-        interface.BaseService,
-        StateProducer,
-        ClientSessionManager,
-        TakeoverMethod,
-        ProtocolStateDispatcher,
-    ],
+    [Core],
     Generator[SetupData, None, None],
 ]
 PairMethod = Callable[..., interface.PairingHandler]


### PR DESCRIPTION
Initial steps to move shared services to a common Core instance. Each
protocol has its own Core instance which is specific to the protocol.
Note that this is only the first step, many improvements can be made
within the protocol to use this new instance.

Relates to #1141

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1552"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

