### PR TITLE
raop: Use requests instead of urllib in web stream

### DIFF
--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -16,3 +16,4 @@ mypy==0.920
 mypy-protobuf==3.0.0
 typed-ast==1.5.1
 types-protobuf==3.18.2
+types-requests==2.26.2


### PR DESCRIPTION
It seems like urllib is blocked by Cloudflare so better to use a more
capable client, i.e. requests. The code has also been tidied up and
error handling improved.

Relates to #1546

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1553"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

