### PR TITLE
raop: Fix stream from buffer bug

### DIFF
--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -35,7 +35,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Main routines for interacting with an Apple TV.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L1-L142" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L1-L145" class="git-link">Browse git</a></div>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -78,7 +78,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Connect to a device based on a configuration.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L71-L118" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L71-L121" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.pair">
 <code class="name flex">
@@ -87,7 +87,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Pair a protocol for an Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L121-L142" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L124-L145" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.scan">
 <code class="name flex">

--- a/pyatv/protocols/raop/__init__.py
+++ b/pyatv/protocols/raop/__init__.py
@@ -351,9 +351,9 @@ class RaopStream(Stream):
             metadata: AudioMetadata = EMPTY_METADATA
             try:
                 # Source must support seeking to read metadata (or point to file)
-                if (
-                    isinstance(file, io.BufferedReader) and file.seekable
-                ) or path.exists(file):
+                if (isinstance(file, io.BufferedReader) and file.seekable()) or (
+                    isinstance(file, str) and path.exists(file)
+                ):
                     metadata = await get_metadata(file)
                 else:
                     _LOGGER.debug(


### PR DESCRIPTION
Did not call the seekable method properly so metadata would be extracted
from buffered streams, which would fail as that is not supported.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1556"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

