### PR TITLE
gha: Don't build for armv7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           context: .
           github-token: ${{ secrets.GITHUB_TOKEN }}
           builder: ${{ steps.buildx.outputs.name }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Building docker images for ARMv7 seems broken, so disable for now.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1557"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

