### PR TITLE
Switch to using ChaCha20Poly1305Reusable for encryption

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,6 +1,7 @@
 aiohttp==3.1.0
 bitarray==2.1.2
-cryptography==2.6
+cryptography==37.0.2
+chacha20poly1305-reuseable==0.0.3
 ifaddr==0.1.7
 mediafile==0.8.1
 miniaudio==1.45

--- a/pyatv/support/chacha20.py
+++ b/pyatv/support/chacha20.py
@@ -1,5 +1,5 @@
-"""Transparent encryption layer using Chacha20_Pooly1305."""
-from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+"""Transparent encryption layer using Chacha20_Poly1305."""
+from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable as ChaCha20Poly1305
 
 NONCE_LENGTH = 12
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp==3.8.1
 bitarray==2.5.1
 cryptography==37.0.2
+chacha20poly1305-reuseable==0.0.3
 ifaddr==0.1.7
 mediafile==0.9.0
 miniaudio==1.46


### PR DESCRIPTION
I built this for HomeKit but I realized its used here heavily as well
when profiling since I was seeing the ctx get created over and over
even after the HomeKit changes.  It also seems to fix the Home app
stalling out on iOS 16 betas when using them with Home Assistant's
HomeKit integration.

The ChaCha20Poly1305 that comes with cryptography recreates the
ctx every time encrypt is called. Since we call encrypt in
a loop, we can avoid this overhead by using ChaCha20Poly1305Reusable
instead as we are doing everything in the same thread.

Since `pyatv` is sending back and forth encrypted bytes frequently
with the `heartbeater` this reduces the memory churn and cpu
load if you have a few apple tvs or homepods
