### PR TITLE
raop: Increase late warning to five frames

### DIFF
--- a/pyatv/protocols/raop/raop.py
+++ b/pyatv/protocols/raop/raop.py
@@ -43,7 +43,7 @@ PACKET_BACKLOG_SIZE = 1000
 KEEP_ALIVE_INTERVAL = 25  # Seconds
 
 # Number of "too slow to keep up" warnings to suppress before warning about them
-SLOW_WARNING_THRESHOLD = 3
+SLOW_WARNING_THRESHOLD = 5
 
 # Metadata used when no metadata is present
 MISSING_METADATA = AudioMetadata(


### PR DESCRIPTION
Relates to #1771

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1775"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

