### PR TITLE
raop: Fallback to pk as unique id

### DIFF
--- a/chickn.yaml
+++ b/chickn.yaml
@@ -63,7 +63,6 @@ pipeline:
       run: mypy --python-executable "{python_executable}" --ignore-missing-imports --follow-imports=skip pyatv
     - name: pytest
       run: pytest -n auto --log-level=debug -q -d --timeout=30 --durations=10 --cov --cov-report=term-missing --cov-report=xml tests
-      retries: 1
   post:
     - name: report
       run:

--- a/pyatv/helpers.py
+++ b/pyatv/helpers.py
@@ -50,7 +50,7 @@ async def auto_connect(
     await _handle(loop)
 
 
-def get_unique_id(
+def get_unique_id(  # pylint: disable=too-many-return-statements
     service_type: str, service_name: str, properties: Mapping[str, str]
 ) -> Optional[str]:
     """Return unique identifier from a Zeroconf service.
@@ -70,7 +70,15 @@ def get_unique_id(
     if service_type == AIRPLAY_SERVICE:
         return properties.get("deviceid")
     if service_type == RAOP_SERVICE:
-        return service_name.split("@", maxsplit=1)[0]
+        split = service_name.split("@", maxsplit=1)
+
+        # Normally a RAOP devices announces with "id@name" as zeroconf name. But some
+        # devices seems to break from this behavior and just use "name", thus leaving
+        # out the id. Some of these devices however have the public key ("pk")
+        # available as an attribute so that can be used as an identifier in that case.
+        if len(split) == 2:
+            return split[0]
+        return properties.get("pk")
     return None
 
 

--- a/pyatv/protocols/raop/__init__.py
+++ b/pyatv/protocols/raop/__init__.py
@@ -426,11 +426,17 @@ class RaopRemoteControl(RemoteControl):
         await self.audio.set_volume(max(self.audio.volume - 5.0, 0.0))
 
 
+def raop_name_from_service_name(service_name: str) -> str:
+    """Convert an raop service name to a name."""
+    split = service_name.split("@", maxsplit=1)
+    return split[1] if len(split) == 2 else split[0]
+
+
 def raop_service_handler(
     mdns_service: mdns.Service, response: mdns.Response
 ) -> Optional[ScanHandlerReturn]:
     """Parse and return a new RAOP service."""
-    _, name = mdns_service.name.split("@", maxsplit=1)
+    name = raop_name_from_service_name(mdns_service.name)
     service = MutableService(
         get_unique_id(mdns_service.type, mdns_service.name, mdns_service.properties),
         Protocol.RAOP,
@@ -438,11 +444,6 @@ def raop_service_handler(
         mdns_service.properties,
     )
     return name, service
-
-
-def raop_name_from_service_name(service_name: str) -> str:
-    """Convert an raop service name to a name."""
-    return service_name.split("@", maxsplit=1)[1]
 
 
 def scan() -> Mapping[str, ScanHandlerDeviceInfoName]:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -83,6 +83,7 @@ async def test_auto_connect_with_device(mock_scan, mock_connect):
         ("_airplay._tcp.local", "name", {"deviceid": "test"}, "test"),
         ("_raop._tcp.local", "abcd@name", {}, "abcd"),
         ("_raop._tcp.local", "abcd@name", {}, "abcd"),
+        ("_raop._tcp.local", "name", {"pk": "abcd"}, "abcd"),
         ("_hscp._tcp.local", "name", {"Machine ID": "abcd"}, "abcd"),
     ],
 )


### PR DESCRIPTION
If device id is not present in the Zeroconf name, use public key of
device as unique identifier (if present).

Relates to #1747

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1777"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

