### PR TITLE
Release 0.10.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # CHANGES
 
+## 0.10.2 Bonnet (2022-06-28)
+
+This release just lowers the required version of cryptography
+to 36.0.2 or higher.
+
+**Changes:**
+
+*Other:*
+
+```
+ecada17 deps: Require cryptography >= 36.0.2 (#1780)
+```
+
+**All changes:**
+
+```
+ecada17 deps: Require cryptography >= 36.0.2 (#1780)
+```
+
 ## 0.10.1 Yenndo (2022-06-28)
 
 This is a minor bug fix release, taking care of some nasty stuff:

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 MAJOR_VERSION = "0"
 MINOR_VERSION = "10"
-PATCH_VERSION = "1"
+PATCH_VERSION = "2"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
## 0.10.2 Bonnet (2022-06-28)

This release just lowers the required version of cryptography
to 36.0.2 or higher.

**Changes:**

*Other:*

```
ecada17 deps: Require cryptography >= 36.0.2 (#1780)
```

**All changes:**

```
ecada17 deps: Require cryptography >= 36.0.2 (#1780)
```


<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/1781"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

