### PR TITLE
Switch out asyncio.wait_for with async_timeout in hot paths

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,4 +1,5 @@
 aiohttp==3.8.1,<5
+async_timeout==4.0.2
 bitarray==2.1.2
 cryptography==36.0.2
 chacha20poly1305-reuseable==0.0.3

--- a/pyatv/protocols/mrp/protocol.py
+++ b/pyatv/protocols/mrp/protocol.py
@@ -7,6 +7,8 @@ import logging
 from typing import Dict, NamedTuple, Optional
 import uuid
 
+import async_timeout
+
 from pyatv import exceptions
 from pyatv.auth.hap_pairing import parse_credentials
 from pyatv.auth.hap_srp import SRPAuthHandler
@@ -268,7 +270,8 @@ class MrpProtocol(MessageDispatcher[int, protobuf.ProtocolMessage]):
 
         try:
             # The connection instance will dispatch the message
-            await asyncio.wait_for(semaphore.acquire(), timeout)
+            async with async_timeout.timeout(timeout):
+                await semaphore.acquire()
 
         except Exception:
             del self._outstanding[identifier]

--- a/pyatv/support/http.py
+++ b/pyatv/support/http.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict, Mapping, NamedTuple, Optional, Tuple, Union, 
 
 from aiohttp import ClientSession, web
 from aiohttp.web import middleware
+import async_timeout
 
 from pyatv import const, exceptions
 from pyatv.support import log_binary
@@ -385,7 +386,8 @@ class HttpConnection(asyncio.Protocol):
         event = asyncio.Event()
         self._requests.appendleft(event)
         try:
-            await asyncio.wait_for(event.wait(), timeout=4)
+            async with async_timeout.timeout(4):
+                await event.wait()
             response = cast(HttpResponse, self._responses.get())
         except asyncio.TimeoutError as ex:
             raise TimeoutError(f"no response to {method} {uri} ({protocol})") from ex

--- a/pyatv/support/rtsp.py
+++ b/pyatv/support/rtsp.py
@@ -10,6 +10,8 @@ import plistlib
 from random import randrange
 from typing import Any, Dict, Mapping, NamedTuple, Optional, Tuple, Union
 
+import async_timeout
+
 from pyatv.protocols.dmap import tags
 from pyatv.support.http import HttpConnection, HttpResponse
 from pyatv.support.metadata import AudioMetadata
@@ -283,7 +285,8 @@ class RtspSession:
 
         # Wait for response to the CSeq we expect
         try:
-            await asyncio.wait_for(self.requests[cseq][0].wait(), 4)
+            async with async_timeout.timeout(4):
+                await self.requests[cseq][0].wait()
             response = self.requests[cseq][1]
         except asyncio.TimeoutError as ex:
             raise TimeoutError(

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.8.1
+async_timeout==4.0.2
 bitarray==2.6.0
 cryptography==37.0.4
 chacha20poly1305-reuseable==0.0.4


### PR DESCRIPTION
I keep forgetting to do this, and I keep using `asyncio.wait_for` in places where
`async_timeout` would be better, but Martin reminded me that we should be
using `async_timeout` where we can in https://github.com/home-assistant/core/pull/75848
so it made me remember here as well.

 `async_timeout` is already a dep of aiohttp which uses `async_timeout`
  since its much faster than `asyncio.wait_for`

https://pypi.org/project/async-timeout/
<img width="1633" alt="Screen Shot 2022-07-28 at 7 29 53 AM" src="https://user-images.githubusercontent.com/663432/181600709-be9acc6a-f285-4428-9dd8-ba90ad593f30.png">

