### PR TITLE
Add support for URL param to LaunchApp

### DIFF
--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -426,7 +426,7 @@ all its features.</p>
 </dd>
 <dt id="pyatv.interface.Apps.launch_app">
 <code class="name flex">
-<span>async def <span class="ident">launch_app</span></span>(<span>self, bundle_id: str) -> None</span>
+<span>async def <span class="ident">launch_app</span></span>(<span>self, bundle_id: Optional[str], url: Optional[str]) -> None</span>
 </code>
 </dt>
 <dd>
@@ -434,7 +434,7 @@ all its features.</p>
 <span>Feature: <a title="pyatv.const.FeatureName.LaunchApp" href="const#pyatv.const.FeatureName.LaunchApp">FeatureName.LaunchApp</a>,</span>
 <span>Supported by: <a title="pyatv.const.Protocol.Companion" href="const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
 </div>
-<section class="desc"><p>Launch an app based on bundle ID.</p></section>
+<section class="desc"><p>Launch an app based on bundle ID or URL.</p></section>
 <div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L679-L682" class="git-link">Browse git</a></div>
 </dd>
 </dl>

--- a/docs/development/apps.md
+++ b/docs/development/apps.md
@@ -32,3 +32,9 @@ To launch an app, use its bundle identifier when calling {% include api i="inter
  ```python
 await apps.launch_app("com.netflix.Netflix")
  ```
+
+To launch an app with a URL, pass the URL when calling {% include api i="interface.Apps.launch_app" %}
+
+ ```python
+await apps.launch_app(url="com.apple.tv://tv.apple.com/show/marvels-spidey-and-his-amazing-friends/umc.cmc.3ambs8tqwzphbn0u8e9g76x7m?profile=kids&action=play")
+ ```

--- a/pyatv/core/facade.py
+++ b/pyatv/core/facade.py
@@ -405,9 +405,11 @@ class FacadeApps(Relayer, interface.Apps):
         return await self.relay("app_list")()
 
     @shield.guard
-    async def launch_app(self, bundle_id: str) -> None:
-        """Launch an app based on bundle ID."""
-        await self.relay("launch_app")(bundle_id)
+    async def launch_app(
+        self, bundle_id: Optional[str] = None, url: Optional[str] = None
+    ) -> None:
+        """Launch an app based on bundle ID or URL."""
+        await self.relay("launch_app")(bundle_id, url)
 
 
 class FacadeAudio(Relayer, interface.Audio):

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -677,8 +677,10 @@ class Apps:
         raise exceptions.NotSupportedError()
 
     @feature(39, "LaunchApp", "Launch an app.")
-    async def launch_app(self, bundle_id: str) -> None:
-        """Launch an app based on bundle ID."""
+    async def launch_app(
+        self, bundle_id: Optional[str] = None, url: Optional[str] = None
+    ) -> None:
+        """Launch an app based on bundle ID or URL."""
         raise exceptions.NotSupportedError()
 
 

--- a/pyatv/protocols/companion/__init__.py
+++ b/pyatv/protocols/companion/__init__.py
@@ -172,9 +172,11 @@ class CompanionApps(Apps):
         content = cast(dict, app_list["_c"])
         return [App(name, bundle_id) for bundle_id, name in content.items()]
 
-    async def launch_app(self, bundle_id: str) -> None:
-        """Launch an app based on bundle ID."""
-        await self.api.launch_app(bundle_id)
+    async def launch_app(
+        self, bundle_id: Optional[str] = None, url: Optional[str] = None
+    ) -> None:
+        """Launch an app based on bundle ID or URL."""
+        await self.api.launch_app(bundle_id, url)
 
 
 class CompanionPower(Power):

--- a/pyatv/protocols/companion/api.py
+++ b/pyatv/protocols/companion/api.py
@@ -221,9 +221,17 @@ class CompanionAPI(
         """Subscribe to updates to an event."""
         await self._send_event("_interest", {"_deregEvents": [event]})
 
-    async def launch_app(self, bundle_identifier: str) -> None:
+    async def launch_app(
+        self, bundle_identifier: Optional[str] = None, url: Optional[str] = None
+    ) -> None:
         """Launch an app on the remote device."""
-        await self._send_command("_launchApp", {"_bundleID": bundle_identifier})
+        await self._send_command(
+            "_launchApp",
+            {
+                "_bundleID": bundle_identifier if bundle_identifier else None,
+                "_urlS": url if url else None,
+            },
+        )
 
     async def app_list(self) -> Mapping[str, Any]:
         """Return list of launchable apps on remote device."""

--- a/tests/fake_device/companion.py
+++ b/tests/fake_device/companion.py
@@ -55,6 +55,7 @@ class FakeCompanionState:
     def __init__(self):
         """State of a fake Companion device."""
         self.active_app: Optional[str] = None
+        self.open_url: Optional[str] = None
         self.installed_apps: Dict[str, str] = {}
         self.has_paired: bool = False
         self.powered_on: bool = True
@@ -220,7 +221,12 @@ class FakeCompanionService(CompanionServerAuth, asyncio.Protocol):
         )
 
     def handle__launchapp(self, message):
-        self.state.active_app = message["_c"]["_bundleID"]
+        bundle_id = message["_c"]["_bundleID"]
+        url = message["_c"]["_urlS"]
+        if bundle_id:
+            self.state.active_app = bundle_id
+        elif url:
+            self.state.open_url = url
         self.send_response(message, {})
 
     def handle_fetchlaunchableapplicationsevent(self, message):

--- a/tests/protocols/companion/test_companion_functional.py
+++ b/tests/protocols/companion/test_companion_functional.py
@@ -21,8 +21,10 @@ _LOGGER = logging.getLogger(__name__)
 
 TEST_APP: str = "com.test.Test"
 TEST_APP_NAME: str = "Test"
+TEST_APP_URL: str = "com.test.Test://test/url?param0=value0"
 TEST_APP2: str = "com.test.Test2"
 TEST_APP_NAME2: str = "Test2"
+TEST_APP_URL2: str = "com.test.Test2://test/url?param0=value0"
 
 MEDIA_CONTROL_FEATURES = [
     FeatureName.Play,
@@ -58,6 +60,23 @@ async def test_subscribe_unsubscribe_media_control(companion_client, companion_s
 async def test_launch_app(companion_client, companion_state):
     await companion_client.apps.launch_app(TEST_APP)
     await until(lambda: companion_state.active_app == TEST_APP)
+
+
+async def test_launch_app_with_url(companion_client, companion_state):
+    await companion_client.apps.launch_app(url=TEST_APP_URL)
+    await until(lambda: companion_state.open_url == TEST_APP_URL)
+
+
+async def test_launch_app_with_bundle_id_and_url(companion_client, companion_state):
+    await companion_client.apps.launch_app(TEST_APP, TEST_APP_URL2)
+    await until(lambda: companion_state.active_app == TEST_APP)
+    assert not companion_state.open_url
+
+
+async def test_launch_app_no_params(companion_client, companion_state):
+    await companion_client.apps.launch_app()
+    assert not companion_state.active_app
+    assert not companion_state.open_url
 
 
 async def test_app_list(companion_client, companion_usecase):


### PR DESCRIPTION
This change adds support for passing the optional, undocumented `_urlS`
parameter to `_launchApp`. Passing this parameter enables deep linking
into at least some apps installed on the AppleTV. I discovered this
while searching for a way to launch content directly from a deep link
into the AppleTV+ app.

The first clue that this param exists was that passing a valid URL in
 place of a bundleID returns the error message "No valid bundleID or
URL to LaunchApp". Searching for strings in the rootfs of the tvos 15.6
image for AppleTV5,3 (build 19M65) suggested that the `rapportd` daemon
is responsible for handling companion protocol requests and returning
this error message.

A hidden `_urlS` string key is present in the `rapportd` daemon located near
`_bundleID`:

```
$ strings rapportd | grep -C 5 bundleID
_launchApp
v32@?0@"NSDictionary"8@"NSDictionary"16@?<v@?@"NSDictionary"@"NSDictionary"@"NSError">24
_sessionStart
_sessionStop
v40@?0@"RPConnection"8@"NSDictionary"16@"NSDictionary"24@?<v@?@"NSDictionary"@"NSDictionary"@"NSError">32
_bundleID
RPLaunchApp
_urlS
RPOpenURL
-[RPCompanionLinkDaemon _miscHandleLaunchAppRequest:responseHandler:]_block_invoke
```

Disassembly of the object code reveals the following logic in the
`-[RPCompanionLinkDaemon _miscHandleLaunchAppRequest:responseHandler:]` method:

```
(pseudocode)
if (_bundleID):
    launch_app(_bundleID)
elif (_urlS):
    open_url(_urlS)
else:
    error("No valid bundleID or URL to LaunchApp")
```

If a bundleID is passed to `_launchApp`, it takes precendce. The implementation
provided here does not attempt to enforce this logic on the client. Instead,
params are passed directly through to the server so that there is only one
source of truth for the behavior. The current server behavior is represented
in the updated companion protocol tests.