### PR TITLE
ability to ask AppleTV to open a user-provided URL

### DIFF
--- a/pyatv/core/facade.py
+++ b/pyatv/core/facade.py
@@ -409,6 +409,11 @@ class FacadeApps(Relayer, interface.Apps):
         """Launch an app based on bundle ID."""
         await self.relay("launch_app")(bundle_id)
 
+    @shield.guard
+    async def open_url(self, url: str) -> None:
+        """Open a URL."""
+        await self.relay("open_url")(url)
+
 
 class FacadeAudio(Relayer, interface.Audio):
     """Facade implementation for audio functionality."""

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -681,6 +681,10 @@ class Apps:
         """Launch an app based on bundle ID."""
         raise exceptions.NotSupportedError()
 
+    @feature(50, "OpenURL", "Open a URL.")
+    async def open_url(self, url: str) -> None:
+        """Open a URL."""
+        raise exceptions.NotSupportedError()
 
 class Metadata:
     """Base class for retrieving metadata from an Apple TV."""

--- a/pyatv/protocols/companion/__init__.py
+++ b/pyatv/protocols/companion/__init__.py
@@ -176,6 +176,9 @@ class CompanionApps(Apps):
         """Launch an app based on bundle ID."""
         await self.api.launch_app(bundle_id)
 
+    async def open_url(self, url: str) -> None:
+        """Open a URL."""
+        await self.api.open_url(url)
 
 class CompanionPower(Power):
     """Implementation of power management API."""

--- a/pyatv/protocols/companion/api.py
+++ b/pyatv/protocols/companion/api.py
@@ -225,6 +225,10 @@ class CompanionAPI(
         """Launch an app on the remote device."""
         await self._send_command("_launchApp", {"_bundleID": bundle_identifier})
 
+    async def open_url(self, url: str) -> None:
+        """Ask the remote device to open an URL."""
+        await self._send_command("_launchApp", {"_urlS": url})
+
     async def app_list(self) -> Mapping[str, Any]:
         """Return list of launchable apps on remote device."""
         return await self._send_command("FetchLaunchableApplicationsEvent", {})

--- a/tests/protocols/companion/test_companion_functional.py
+++ b/tests/protocols/companion/test_companion_functional.py
@@ -59,6 +59,10 @@ async def test_launch_app(companion_client, companion_state):
     await companion_client.apps.launch_app(TEST_APP)
     await until(lambda: companion_state.active_app == TEST_APP)
 
+async def test_open_url(companion_client, companion_state):
+    await companion_client.apps.open_url(TEST_APP)
+    await until(lambda: companion_state.active_app == TEST_APP)
+
 
 async def test_app_list(companion_client, companion_usecase):
     companion_usecase.set_installed_apps(


### PR DESCRIPTION
This adds a `open_url=the://url/goes/here` command to pyatv.

I did some hacking to figure this one out.  I can't say there's any documentation around this.  It uses the "_launchApp" command, but specifies a "_urlS" instead of the bundle_id.

I can only assume AppleTV takes the url and asks each installed app, one-by-one, to open it.  If one of them agrees to open it, it will.  If none of them want it, it'll fail with:

```
pyatv.exceptions.ProtocolError: Command failed: Open URL failed
```

Some apps seem to have their own custom URL schemes, while others seem to respond to just general https://.  I'm not even going to attempt to document what I've learned about all that.

If there's anything else you might need from me for this PR, just ask.  I would like to see it merged so I don't have to maintain/install from my own fork.