### PR TITLE
Redirecting to correct page

### DIFF
--- a/docs/documentation/getting_started.md
+++ b/docs/documentation/getting_started.md
@@ -147,7 +147,7 @@ You can find this example under `examples/scan_and_connect.py`
 
 # What's next?
 
-It is recommended that you read the [Documentation](../documentation/) section to get
-a better grasp of how pyatv works. Then continue with [Development](../development)
+It is recommended that you read the [Documentation](../../documentation/) section to get
+a better grasp of how pyatv works. Then continue with [Development](../../development)
 once you are ready to write some code. Next is however a tutorial
 you can follow if you want to try out creating a simple application!


### PR DESCRIPTION
Hey, in the current getting started page , the current redirect to documentation and development is giving a 404 error as the redirect link was incorrect.