### PR TITLE
Fix for OS16.4 Stream file Timeout error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # CHANGES
 
+Fix http timeout error, noted with OS16.4 upgrade
+Fix Pause/Play button mis-labelled
+
 ## 0.10.3 Chica (2022-08-02)
 
 This is another minor release:

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 MAJOR_VERSION = "0"
 MINOR_VERSION = "10"
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -294,7 +294,7 @@ class RemoteControl:
 
     @feature(6, "Pause", "Pause playing media.")
     async def pause(self) -> None:
-        """Press key play."""
+        """Press key pause."""
         raise exceptions.NotSupportedError()
 
     @feature(7, "Stop", "Stop playing media.")

--- a/pyatv/support/http.py
+++ b/pyatv/support/http.py
@@ -386,7 +386,7 @@ class HttpConnection(asyncio.Protocol):
         event = asyncio.Event()
         self._requests.appendleft(event)
         try:
-            async with async_timeout.timeout(4):
+            async with async_timeout.timeout(10):
                 await event.wait()
             response = cast(HttpResponse, self._responses.get())
         except asyncio.TimeoutError as ex:


### PR DESCRIPTION
Seems to have been a number of OS16.4 changes which slows down the handling, leading to timeout of streaming file

Increasing timeout to 10 seconds resolves.

Fix here for mislabelling of play/pause

Closes:
#1941 
#1886