### PR TITLE
env: Install correct miniaudio on GHA

### DIFF
--- a/chickn.yaml
+++ b/chickn.yaml
@@ -8,8 +8,9 @@ variables:
     - pyatv
     - scripts
     - examples
-  cs_exclude_words: cann,cant,asai,,cafs
+  cs_exclude_words: cann,cant,asai,cafs
   requirements_file: requirements/requirements.txt
+  miniaudio_package: $(grep miniaudio= requirements/requirements.txt)
 
 dependencies:
   files:
@@ -38,7 +39,7 @@ pipeline:
       tags: [all, miniaudio]
       run:
         - "pip uninstall -y miniaudio"
-        - "pip install --no-binary :all: miniaudio"
+        - "pip install --no-binary :all: {miniaudio_package}"
   validate:
     - name: pylint
       run: pylint -j 0 {pydirs}


### PR DESCRIPTION
GitHub actions always rebuilds miniaudio because of reasons. It however always uses the latest released version, not the pinned version. Since current version (1.58) is broken (does not build), it breaks workflows for pyatv on GitHub actions. This change makes sure we always use the pinned version.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2012"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

