### PR TITLE
gha: Fix building docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,17 +28,17 @@ jobs:
           EOF
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -52,10 +52,10 @@ jobs:
 
           python -m pip install --upgrade setuptools pip wheel
           python setup.py sdist bdist_wheel
-          echo "::set-output name=version::$(python scripts/version.py get)"
+          echo "version=$(python scripts/version.py get)" >> $GITHUB_OUTPUT
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           labels: |
@@ -76,7 +76,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
             VERSION=${{ steps.wheel.outputs.version }}
 
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: packages
           path: |
@@ -104,15 +104,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Download pre-built packages
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v23
         with:
           name: packages
           path: dist
@@ -121,6 +121,7 @@ jobs:
         id: info
         shell: python {0}
         run: |
+          import os
           import re
 
           name = None
@@ -136,8 +137,8 @@ jobs:
               if name is not None:
                 notes += line
 
-          print("::set-output name=name::" + name)
-          print("::set-output name=version::" + version)
+          print(f"name={name} >> " + os.environ["GITHUB_OUTPUT"])
+          print(f"version={version} >> " + os.environ["GITHUB_OUTPUT"])
 
           with open("notes.md", "w", encoding="utf-8") as handle:
             handle.write(notes)
@@ -153,7 +154,7 @@ jobs:
           name: ${{ steps.info.outputs.name }}
 
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip_existing: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ ARG VERSION
 
 WORKDIR .
 COPY dist/pyatv-${VERSION}-py3-none-any.whl .
+COPY requirements/requirements.txt .
 
 RUN apk add gcc musl-dev build-base linux-headers libffi-dev rust cargo openssl-dev git && \
     pip install setuptools-rust && \
+    pip install -r requirements.txt && \
     pip install pyatv-${VERSION}-py3-none-any.whl && \
     apk del gcc musl-dev build-base linux-headers libffi-dev rust cargo openssl-dev git && \
     rm pyatv-${VERSION}-py3-none-any.whl && \
+    rm requirements.txt && \
     rm -rf /root/.cache /root/.cargo


### PR DESCRIPTION
Install dependencies specified in requirements.txt to avoid potentially broken dependencies (like miniaudio currently is).

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2015"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

