### PR TITLE
Fix shairport-sync player support

### DIFF
--- a/docs/documentation/supported_features.md
+++ b/docs/documentation/supported_features.md
@@ -235,7 +235,7 @@ Audio streaming has been verified to work with these devices:
 
 The following 3rd party software receivers have also been verified to work:
 
-* [shairport-sync](https://github.com/mikebrady/shairport-sync) (v3.3.8)
+* [shairport-sync](https://github.com/mikebrady/shairport-sync) (v4.2)
 
 If you have verified another device or receiver, please update the list by pressing
 *Edit this page* below and opening a pull request.

--- a/pyatv/support/rtsp.py
+++ b/pyatv/support/rtsp.py
@@ -98,9 +98,7 @@ class RtspSession:
 
     async def info(self) -> Dict[str, object]:
         """Return device information."""
-        device_info = await self.exchange(
-            "GET", "/info", allow_error=True, protocol=HTTP_PROTOCOL
-        )
+        device_info = await self.exchange("GET", "/info", allow_error=True)
 
         # If not supported, just return an empty dict
         if device_info.code != 200:


### PR DESCRIPTION
Fixes #1822. Since pyatv 0.10.0 the client cannot stream to a shairport-sync device, see the issue for more details.

I don't really know anything about AirPlay so this change may have an impact on other devices, but it would be good if this can be looked at as it also fixes https://github.com/home-assistant/core/issues/76843.