### PR TITLE
gha: Fix python version in logs workflow

### DIFF
--- a/.github/workflows/log.yaml
+++ b/.github/workflows/log.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install python packages
       run: |
         pip install --upgrade pip


### PR DESCRIPTION
Must quote 3.10, otherwise it becomes 3.1.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2028"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

