### PR TITLE
Keyboard focus events and documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -78,6 +78,8 @@ page_links:
       title: Apps
     - link: /development/audio/
       title: Audio
+    - link: /development/keyboard/
+      title: Keyboard
     - link: /development/logging/
       title: Logging
     - link: /development/examples/

--- a/docs/api/pyatv/const.html
+++ b/docs/api/pyatv/const.html
@@ -92,6 +92,7 @@ link_group: api
 <li><code><a title="pyatv.const.FeatureName.SwitchAccount" href="#pyatv.const.FeatureName.SwitchAccount">SwitchAccount</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.TextAppend" href="#pyatv.const.FeatureName.TextAppend">TextAppend</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.TextClear" href="#pyatv.const.FeatureName.TextClear">TextClear</a></code></li>
+<li><code><a title="pyatv.const.FeatureName.TextFocusState" href="#pyatv.const.FeatureName.TextFocusState">TextFocusState</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.TextGet" href="#pyatv.const.FeatureName.TextGet">TextGet</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.TextSet" href="#pyatv.const.FeatureName.TextSet">TextSet</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.Title" href="#pyatv.const.FeatureName.Title">Title</a></code></li>
@@ -121,6 +122,14 @@ link_group: api
 <li><code><a title="pyatv.const.InputAction.DoubleTap" href="#pyatv.const.InputAction.DoubleTap">DoubleTap</a></code></li>
 <li><code><a title="pyatv.const.InputAction.Hold" href="#pyatv.const.InputAction.Hold">Hold</a></code></li>
 <li><code><a title="pyatv.const.InputAction.SingleTap" href="#pyatv.const.InputAction.SingleTap">SingleTap</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="pyatv.const.KeyboardFocusState" href="#pyatv.const.KeyboardFocusState">KeyboardFocusState</a></code></h4>
+<ul class="">
+<li><code><a title="pyatv.const.KeyboardFocusState.Focused" href="#pyatv.const.KeyboardFocusState.Focused">Focused</a></code></li>
+<li><code><a title="pyatv.const.KeyboardFocusState.Unfocused" href="#pyatv.const.KeyboardFocusState.Unfocused">Unfocused</a></code></li>
+<li><code><a title="pyatv.const.KeyboardFocusState.Unknown" href="#pyatv.const.KeyboardFocusState.Unknown">Unknown</a></code></li>
 </ul>
 </li>
 <li>
@@ -195,7 +204,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Constants used in the public API.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L1-L398" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L1-L414" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -214,7 +223,7 @@ link_group: api
 <section class="desc"><p>Hardware device model.</p>
 <p>Gen2-Gen4K are Apple TV model names and will be renamed to AppleTVGenX in the
 future.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L133-L174" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L146-L187" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -316,7 +325,7 @@ future.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>All supported features.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L229-L398" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L242-L414" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -499,6 +508,10 @@ future.</p></section>
 <dd>
 <section class="desc"><p>Clear virtual keyboard text.</p></section>
 </dd>
+<dt id="pyatv.const.FeatureName.TextFocusState"><code class="name">var <span class="ident">TextFocusState</span></code></dt>
+<dd>
+<section class="desc"><p>Current virtual keyboard focus state.</p></section>
+</dd>
 <dt id="pyatv.const.FeatureName.TextGet"><code class="name">var <span class="ident">TextGet</span></code></dt>
 <dd>
 <section class="desc"><p>Get current virtual keyboard text.</p></section>
@@ -555,7 +568,7 @@ future.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>State of a particular feature.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L209-L225" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L222-L238" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -587,7 +600,7 @@ future.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Type of input when pressing a button.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L177-L187" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L190-L200" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -605,6 +618,33 @@ future.</p></section>
 <dt id="pyatv.const.InputAction.SingleTap"><code class="name">var <span class="ident">SingleTap</span></code></dt>
 <dd>
 <section class="desc"><p>Press and release quickly.</p></section>
+</dd>
+</dl>
+</dd>
+<dt id="pyatv.const.KeyboardFocusState"><code class="flex name class">
+<span>class <span class="ident">KeyboardFocusState</span></span>
+<span>(</span><span>value, names=None, *, module=None, qualname=None, type=None, start=1)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>All supported keyboard focus states.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L113-L123" class="git-link">Browse git</a></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>enum.Enum</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="pyatv.const.KeyboardFocusState.Focused"><code class="name">var <span class="ident">Focused</span></code></dt>
+<dd>
+<section class="desc"><p>Keyboard is focused.</p></section>
+</dd>
+<dt id="pyatv.const.KeyboardFocusState.Unfocused"><code class="name">var <span class="ident">Unfocused</span></code></dt>
+<dd>
+<section class="desc"><p>Keyboard is not focused.</p></section>
+</dd>
+<dt id="pyatv.const.KeyboardFocusState.Unknown"><code class="name">var <span class="ident">Unknown</span></code></dt>
+<dd>
+<section class="desc"><p>Keyboard focus state is not determinable.</p></section>
 </dd>
 </dl>
 </dd>
@@ -647,7 +687,7 @@ not report a valid media type.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Operating system on device.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L113-L130" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L126-L143" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -681,7 +721,7 @@ is Apple TV Software (pre-tvOS).</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Pairing requirement for a service.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L190-L206" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L203-L219" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>

--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -149,8 +149,15 @@ link_group: api
 <ul class="">
 <li><code><a title="pyatv.interface.Keyboard.text_append" href="#pyatv.interface.Keyboard.text_append">text_append</a></code></li>
 <li><code><a title="pyatv.interface.Keyboard.text_clear" href="#pyatv.interface.Keyboard.text_clear">text_clear</a></code></li>
+<li><code><a title="pyatv.interface.Keyboard.text_focus_state" href="#pyatv.interface.Keyboard.text_focus_state">text_focus_state</a></code></li>
 <li><code><a title="pyatv.interface.Keyboard.text_get" href="#pyatv.interface.Keyboard.text_get">text_get</a></code></li>
 <li><code><a title="pyatv.interface.Keyboard.text_set" href="#pyatv.interface.Keyboard.text_set">text_set</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="pyatv.interface.KeyboardListener" href="#pyatv.interface.KeyboardListener">KeyboardListener</a></code></h4>
+<ul class="">
+<li><code><a title="pyatv.interface.KeyboardListener.focusstate_update" href="#pyatv.interface.KeyboardListener.focusstate_update">focusstate_update</a></code></li>
 </ul>
 </li>
 <li>
@@ -298,7 +305,7 @@ link_group: api
 <p>Public interface exposed by library.</p>
 <p>This module contains all the interfaces that represents a generic Apple TV device and
 all its features.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1-L1352" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1-L1373" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -351,7 +358,7 @@ all its features.</p>
 <section class="desc"><p>Base class representing an Apple TV.</p>
 <p>Listener interface: <code>pyatv.interfaces.DeviceListener</code></p>
 <p>Initialize a new StateProducer instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1277-L1352" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1298-L1373" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -367,62 +374,62 @@ all its features.</p>
 <dt id="pyatv.interface.AppleTV.apps"><code class="name">var <span class="ident">apps</span> -> <a title="pyatv.interface.Apps" href="#pyatv.interface.Apps">Apps</a></code></dt>
 <dd>
 <section class="desc"><p>Return apps interface.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1334-L1337" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1355-L1358" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.audio"><code class="name">var <span class="ident">audio</span> -> <a title="pyatv.interface.Audio" href="#pyatv.interface.Audio">Audio</a></code></dt>
 <dd>
 <section class="desc"><p>Return audio interface.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1344-L1347" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1365-L1368" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.device_info"><code class="name">var <span class="ident">device_info</span> -> <a title="pyatv.interface.DeviceInfo" href="#pyatv.interface.DeviceInfo">DeviceInfo</a></code></dt>
 <dd>
 <section class="desc"><p>Return API for device information.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1294-L1297" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1315-L1318" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.features"><code class="name">var <span class="ident">features</span> -> <a title="pyatv.interface.Features" href="#pyatv.interface.Features">Features</a></code></dt>
 <dd>
 <section class="desc"><p>Return features interface.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1329-L1332" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1350-L1353" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.keyboard"><code class="name">var <span class="ident">keyboard</span> -> <a title="pyatv.interface.Keyboard" href="#pyatv.interface.Keyboard">Keyboard</a></code></dt>
 <dd>
 <section class="desc"><p>Return keyboard interface.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1349-L1352" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1370-L1373" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.metadata"><code class="name">var <span class="ident">metadata</span> -> <a title="pyatv.interface.Metadata" href="#pyatv.interface.Metadata">Metadata</a></code></dt>
 <dd>
 <section class="desc"><p>Return API for retrieving metadata from the Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1309-L1312" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1330-L1333" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.power"><code class="name">var <span class="ident">power</span> -> <a title="pyatv.interface.Power" href="#pyatv.interface.Power">Power</a></code></dt>
 <dd>
 <section class="desc"><p>Return API for power management.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1324-L1327" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1345-L1348" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.push_updater"><code class="name">var <span class="ident">push_updater</span> -> <a title="pyatv.interface.PushUpdater" href="#pyatv.interface.PushUpdater">PushUpdater</a></code></dt>
 <dd>
 <section class="desc"><p>Return API for handling push update from the Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1314-L1317" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1335-L1338" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.remote_control"><code class="name">var <span class="ident">remote_control</span> -> <a title="pyatv.interface.RemoteControl" href="#pyatv.interface.RemoteControl">RemoteControl</a></code></dt>
 <dd>
 <section class="desc"><p>Return API for controlling the Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1304-L1307" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1325-L1328" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.service"><code class="name">var <span class="ident">service</span> -> <a title="pyatv.interface.BaseService" href="#pyatv.interface.BaseService">BaseService</a></code></dt>
 <dd>
 <section class="desc"><p>Return service used to connect to the Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1299-L1302" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1320-L1323" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.stream"><code class="name">var <span class="ident">stream</span> -> <a title="pyatv.interface.Stream" href="#pyatv.interface.Stream">Stream</a></code></dt>
 <dd>
 <section class="desc"><p>Return API for streaming media.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1319-L1322" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1340-L1343" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.user_accounts"><code class="name">var <span class="ident">user_accounts</span> -> <a title="pyatv.interface.UserAccounts" href="#pyatv.interface.UserAccounts">UserAccounts</a></code></dt>
 <dd>
 <section class="desc"><p>Return user accounts interface.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1339-L1342" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1360-L1363" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 <h3>Methods</h3>
@@ -434,7 +441,7 @@ all its features.</p>
 </dt>
 <dd>
 <section class="desc"><p>Close connection and release allocated resources.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1290-L1292" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1311-L1313" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.AppleTV.connect">
 <code class="name flex">
@@ -444,7 +451,7 @@ all its features.</p>
 <dd>
 <section class="desc"><p>Initiate connection to device.</p>
 <p>No need to call it yourself, it's done automatically.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1283-L1288" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1304-L1309" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 </dd>
@@ -646,7 +653,7 @@ possible and supported).</p></section>
 several services depending on the protocols it supports, e.g. DMAP or
 AirPlay.</p>
 <p>Initialize a new BaseConfig instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1141-L1274" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1162-L1295" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -660,47 +667,47 @@ AirPlay.</p>
 <dt id="pyatv.interface.BaseConfig.address"><code class="name">var <span class="ident">address</span> -> ipaddress.IPv4Address</code></dt>
 <dd>
 <section class="desc"><p>IP address of device.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1153-L1156" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1174-L1177" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.all_identifiers"><code class="name">var <span class="ident">all_identifiers</span> -> List[str]</code></dt>
 <dd>
 <section class="desc"><p>Return all unique identifiers for this device.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1221-L1224" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1242-L1245" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.deep_sleep"><code class="name">var <span class="ident">deep_sleep</span> -> bool</code></dt>
 <dd>
 <section class="desc"><p>If device is in deep sleep.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1163-L1166" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1184-L1187" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.device_info"><code class="name">var <span class="ident">device_info</span> -> <a title="pyatv.interface.DeviceInfo" href="#pyatv.interface.DeviceInfo">DeviceInfo</a></code></dt>
 <dd>
 <section class="desc"><p>Return general device information.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1173-L1176" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1194-L1197" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.identifier"><code class="name">var <span class="ident">identifier</span> -> Optional[str]</code></dt>
 <dd>
 <section class="desc"><p>Return the main identifier associated with this device.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1206-L1219" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1227-L1240" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.name"><code class="name">var <span class="ident">name</span> -> str</code></dt>
 <dd>
 <section class="desc"><p>Name of device.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1158-L1161" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1179-L1182" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.properties"><code class="name">var <span class="ident">properties</span> -> Mapping[str, Mapping[str, str]]</code></dt>
 <dd>
 <section class="desc"><p>Return Zeroconf properties.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1193-L1196" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1214-L1217" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.ready"><code class="name">var <span class="ident">ready</span> -> bool</code></dt>
 <dd>
 <section class="desc"><p>Return if configuration is ready, (at least one service with identifier).</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1198-L1204" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1219-L1225" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.services"><code class="name">var <span class="ident">services</span> -> List[<a title="pyatv.interface.BaseService" href="#pyatv.interface.BaseService">BaseService</a>]</code></dt>
 <dd>
 <section class="desc"><p>Return all supported services.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1168-L1171" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1189-L1192" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 <h3>Methods</h3>
@@ -713,7 +720,7 @@ AirPlay.</p>
 <dd>
 <section class="desc"><p>Add a new service.</p>
 <p>If the service already exists, it will be merged.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1178-L1183" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1199-L1204" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.get_service">
 <code class="name flex">
@@ -724,7 +731,7 @@ AirPlay.</p>
 <section class="desc"><p>Look up a service based on protocol.</p>
 <p>If a service with the specified protocol is not available, None is
 returned.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1185-L1191" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1206-L1212" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.main_service">
 <code class="name flex">
@@ -733,7 +740,7 @@ returned.</p></section>
 </dt>
 <dd>
 <section class="desc"><p>Return suggested service used to establish connection.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1226-L1239" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1247-L1260" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.BaseConfig.set_credentials">
 <code class="name flex">
@@ -742,7 +749,7 @@ returned.</p></section>
 </dt>
 <dd>
 <section class="desc"><p>Set credentials for a protocol if it exists.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1241-L1247" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1262-L1268" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 </dd>
@@ -977,15 +984,37 @@ in one of the listed states.</p></section>
 </dd>
 <dt id="pyatv.interface.Keyboard"><code class="flex name class">
 <span>class <span class="ident">Keyboard</span></span>
+<span>(</span><span>max_calls: int = 0)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Base class for keyboard handling.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1117-L1138" class="git-link">Browse git</a></div>
+<section class="desc"><p>Base class for keyboard handling.</p>
+<p>Listener
+interface: <code>pyatv.interfaces.KeyboardListener</code></p>
+<p>Initialize a new StateProducer instance.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1128-L1159" class="git-link">Browse git</a></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>abc.ABC</li>
+<li>pyatv.support.state_producer.StateProducer</li>
+<li>typing.Generic</li>
+</ul>
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li>pyatv.core.facade.FacadeKeyboard</li>
 <li>pyatv.protocols.companion.CompanionKeyboard</li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="pyatv.interface.Keyboard.text_focus_state"><code class="name">var <span class="ident">text_focus_state</span> -> <a title="pyatv.const.KeyboardFocusState" href="const#pyatv.const.KeyboardFocusState">KeyboardFocusState</a></code></dt>
+<dd>
+<div class="api_feature">
+<span>Feature: <a title="pyatv.const.FeatureName.TextFocusState" href="const#pyatv.const.FeatureName.TextFocusState">FeatureName.TextFocusState</a>,</span>
+<span>Supported by: <a title="pyatv.const.Protocol.Companion" href="const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
+</div>
+<section class="desc"><p>Return keyboard focus state.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1135-L1139" class="git-link">Browse git</a></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="pyatv.interface.Keyboard.text_append">
@@ -999,7 +1028,7 @@ in one of the listed states.</p></section>
 <span>Supported by: <a title="pyatv.const.Protocol.Companion" href="const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
 </div>
 <section class="desc"><p>Input text into virtual keyboard.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1130-L1133" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1151-L1154" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.Keyboard.text_clear">
 <code class="name flex">
@@ -1012,7 +1041,7 @@ in one of the listed states.</p></section>
 <span>Supported by: <a title="pyatv.const.Protocol.Companion" href="const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
 </div>
 <section class="desc"><p>Clear virtual keyboard text.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1125-L1128" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1146-L1149" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.Keyboard.text_get">
 <code class="name flex">
@@ -1025,7 +1054,7 @@ in one of the listed states.</p></section>
 <span>Supported by: <a title="pyatv.const.Protocol.Companion" href="const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
 </div>
 <section class="desc"><p>Get current virtual keyboard text.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1120-L1123" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1141-L1144" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.interface.Keyboard.text_set">
 <code class="name flex">
@@ -1038,7 +1067,34 @@ in one of the listed states.</p></section>
 <span>Supported by: <a title="pyatv.const.Protocol.Companion" href="const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
 </div>
 <section class="desc"><p>Replace text in virtual keyboard.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1135-L1138" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1156-L1159" class="git-link">Browse git</a></div>
+</dd>
+</dl>
+</dd>
+<dt id="pyatv.interface.KeyboardListener"><code class="flex name class">
+<span>class <span class="ident">KeyboardListener</span></span>
+</code></dt>
+<dd>
+<section class="desc"><p>Listener interface for keyboard updates.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1117-L1125" class="git-link">Browse git</a></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>abc.ABC</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li>pyatv.scripts.atvscript.KeyboardPrinter</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="pyatv.interface.KeyboardListener.focusstate_update">
+<code class="name flex">
+<span>def <span class="ident">focusstate_update</span></span>(<span>self, old_state: <a title="pyatv.const.KeyboardFocusState" href="const#pyatv.const.KeyboardFocusState">KeyboardFocusState</a>, new_state: <a title="pyatv.const.KeyboardFocusState" href="const#pyatv.const.KeyboardFocusState">KeyboardFocusState</a>)</span>
+</code>
+</dt>
+<dd>
+<section class="desc"><p>Keyboard focus state was updated.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1120-L1125" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 </dd>

--- a/docs/development/keyboard.md
+++ b/docs/development/keyboard.md
@@ -1,0 +1,51 @@
+---
+layout: template
+title: Keyboard
+permalink: /development/keyboard/
+link_group: development
+---
+# Keyboard
+
+It is possible to interact with the Apple TV virtual keyboard via the Keyboard interface.
+To use this interface, the Companion protocol must be available.
+
+## Using the Keyboard API
+
+After connecting to a device, you get the keyboard interface via {% include api i="interface.AppleTV.keyboard" %}:
+
+```python
+atv = await pyatv.connect(config, ...)
+keyboard = atv.keyboard
+```
+
+To check whether the virtual keyboard is focused and active, use {% include api i="interface.Keyboard.text_focus_state" %}:
+
+```python
+print("Keyboard focus state:", keyboard.text_focus_state)
+```
+
+To fetch the current virtual keyboard text content, use {% include api i="interface.Keyboard.text_get" %}:
+
+```python
+print("Keyboard text:", await keyboard.text_get())
+```
+
+To set (replace) the virtual keyboard text, use {% include api i="interface.Keyboard.text_set" %}:
+
+```python
+await keyboard.text_set("text to set")
+```
+
+To append to the virtual keyboard text, use {% include api i="interface.Keyboard.text_append" %}:
+
+```python
+await keyboard.text_append("text to append")
+```
+
+Finally, to clear the virtual keyboard text, use {% include api i="interface.Keyboard.text_clear" %}:
+
+```python
+await keyboard.text_clear()
+```
+
+The keyboard API supports push updates via a listener, as described [here](../listeners#keyboard-updates).

--- a/docs/development/listeners.md
+++ b/docs/development/listeners.md
@@ -116,3 +116,24 @@ atv.audio.listener = listener
 
 Live volume level updates are only sent over the `MRP` protocol. If an Apple TV is connected to
 speakers in a way that doesn't support volume levels, it will not send these updates.
+
+## Keyboard Updates
+
+It is possible to get callbacks whenever the virtual keyboard focus state of a device is changed.
+The API is defined by the
+{% include api i="interface.KeyboardListener" %} interface and works similarly to how push updates works.
+
+Here is a simple example:
+
+```python
+class MyKeyboardListener(interface.KeyboardListener):
+
+    def focusstate_update(self, old_state, new_state):
+        print('Focus state changed from {0:s} to {1:s}'.format(old_state, new_state))
+
+
+listener = MyKeyboardListener()
+atv.keyboard.listener = listener
+```
+
+Keyboard focus state updates are only sent over the `Companion` protocol.

--- a/docs/documentation/atvscript.md
+++ b/docs/documentation/atvscript.md
@@ -203,17 +203,20 @@ $ atvscript -s 10.0.10.81 menu
 {"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "command": "menu"}
 ```
 
-## Push, Power and Audio Updates
+## Push, Power, Audio and Keyboard Updates
 
-Push, power and audio updates are printed to the terminal as they happen:
+Push, power, audio and keyboard updates are printed to the terminal as they happen:
 
 ```shell
 $ atvscript -s 10.0.10.81 push_updates
 {"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "power_state": "off"}
+{"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "focus_state": "unfocused"}
 {"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "hash": "azyFEzFpSNOSGq9ZvcaX4A\u2206DcpumkUoRty+R098MQeIKA", "media_type": "music", "device_state": "paused", "title": "Ordinary World (Live)", "artist": "Duran Duran", "album": "From Mediterranea With Love - EP", "genre": "Rock", "total_time": 395, "position": 1, "shuffle": "off", "repeat": "off", "app": "Musik", "app_id": "com.apple.TVMusic"}
 {"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "power_state": "on"}
 {"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "volume": 20.0}
 {"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "volume": 15.0}
+{"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "focus_state": "focused"}
+{"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "focus_state": "unfocused"}
 {"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "power_state": "off"}
 
 {"result": "success", "datetime": "2020-04-06T18:51:04.758569+02:00", "push_updates": "finished"}

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -110,6 +110,19 @@ class PowerState(Enum):
     """Device is turned on."""
 
 
+class KeyboardFocusState(Enum):
+    """All supported keyboard focus states."""
+
+    Unknown = 0
+    """Keyboard focus state is not determinable."""
+
+    Unfocused = 1
+    """Keyboard is not focused."""
+
+    Focused = 2
+    """Keyboard is focused."""
+
+
 class OperatingSystem(Enum):
     """Operating system on device."""
 
@@ -384,6 +397,9 @@ class FeatureName(Enum):
 
     SetVolume = 46
     """Set volume level."""
+
+    TextFocusState = 57
+    """Current virtual keyboard focus state."""
 
     TextGet = 51
     """Get current virtual keyboard text."""

--- a/pyatv/core/__init__.py
+++ b/pyatv/core/__init__.py
@@ -38,6 +38,9 @@ class UpdatedState(Enum):
     Volume = 2
     """Volume was updated."""
 
+    KeyboardFocus = 3
+    """Keyboard focus was updated."""
+
 
 # pylint: enable=invalid-name
 
@@ -51,6 +54,7 @@ class StateMessage(NamedTuple):
     # Type depending on value of state:
     # - UpdatedState.Playing -> interface.Playing
     # - UpdatedState.Volume -> float
+    # - UpdatedState.KeyboardFocus -> const.KeyboardFocusState
     value: Any
 
     def __str__(self):

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -1122,7 +1122,7 @@ class KeyboardListener(ABC):  # pylint: disable=too-few-public-methods
         self, old_state: const.KeyboardFocusState, new_state: const.KeyboardFocusState
     ):
         """Keyboard focus state was updated."""
-        raise NotImplementedError()
+        raise exceptions.NotSupportedError()
 
 
 class Keyboard(ABC, StateProducer):

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -1114,8 +1114,29 @@ class Audio(ABC, StateProducer):
         raise exceptions.NotSupportedError()
 
 
-class Keyboard:
-    """Base class for keyboard handling."""
+class KeyboardListener(ABC):  # pylint: disable=too-few-public-methods
+    """Listener interface for keyboard updates."""
+
+    @abstractmethod
+    def focusstate_update(
+        self, old_state: const.KeyboardFocusState, new_state: const.KeyboardFocusState
+    ):
+        """Keyboard focus state was updated."""
+        raise NotImplementedError()
+
+
+class Keyboard(ABC, StateProducer):
+    """Base class for keyboard handling.
+
+    Listener
+    interface: `pyatv.interfaces.KeyboardListener`
+    """
+
+    @property
+    @feature(57, "TextFocusState", "Current virtual keyboard focus state.")
+    def text_focus_state(self) -> const.KeyboardFocusState:
+        """Return keyboard focus state."""
+        raise exceptions.NotSupportedError()
 
     @feature(51, "TextGet", "Get current virtual keyboard text.")
     async def text_get(self) -> Optional[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,3 +167,8 @@ def mrp_state_dispatcher_fixture(core_dispatcher):
 @pytest.fixture(name="dmap_state_dispatcher")
 def dmap_state_dispatcher_fixture(core_dispatcher):
     yield ProtocolStateDispatcher(Protocol.DMAP, core_dispatcher)
+
+
+@pytest.fixture(name="companion_state_dispatcher")
+def companion_state_dispatcher_fixture(core_dispatcher):
+    yield ProtocolStateDispatcher(Protocol.Companion, core_dispatcher)

--- a/tests/protocols/companion/test_companion_functional.py
+++ b/tests/protocols/companion/test_companion_functional.py
@@ -10,7 +10,7 @@ import pytest
 import pyatv
 from pyatv import exceptions
 from pyatv.conf import AppleTV, ManualService
-from pyatv.const import Protocol
+from pyatv.const import KeyboardFocusState, Protocol
 from pyatv.interface import App, FeatureName, FeatureState, UserAccount
 
 from tests.fake_device.companion import INITIAL_RTI_TEXT, INITIAL_VOLUME, VOLUME_STEP
@@ -207,6 +207,22 @@ async def test_audio_volume_down(companion_client, companion_state):
     assert companion_state.latest_button == "volume_down"
 
 
+async def test_text_input_text_focus_state(companion_client, companion_usecase):
+    state = companion_client.keyboard.text_focus_state
+    assert state == KeyboardFocusState.Focused
+
+    companion_usecase.set_rti_focus_state(KeyboardFocusState.Unfocused)
+    await until(
+        lambda: companion_client.keyboard.text_focus_state
+        == KeyboardFocusState.Unfocused
+    )
+
+    companion_usecase.set_rti_focus_state(KeyboardFocusState.Focused)
+    await until(
+        lambda: companion_client.keyboard.text_focus_state == KeyboardFocusState.Focused
+    )
+
+
 async def test_text_input_text_get(companion_client, companion_usecase):
     text = await companion_client.keyboard.text_get()
     assert text == INITIAL_RTI_TEXT
@@ -219,21 +235,21 @@ async def test_text_input_text_get(companion_client, companion_usecase):
 async def test_text_input_text_get_when_no_keyboard(
     companion_client, companion_usecase
 ):
-    companion_usecase.set_rti_text(None)
+    companion_usecase.set_rti_focus_state(KeyboardFocusState.Unfocused)
     text = await companion_client.keyboard.text_get()
     assert text is None
 
 
 async def test_text_input_text_clear(companion_client, companion_state):
     await companion_client.keyboard.text_clear()
-    assert companion_state.rti_text == ""
+    await until(lambda: companion_state.rti_text == "")
 
 
 async def test_text_input_text_append(companion_client, companion_state):
     await companion_client.keyboard.text_append("test")
-    assert companion_state.rti_text == INITIAL_RTI_TEXT + "test"
+    await until(lambda: companion_state.rti_text == INITIAL_RTI_TEXT + "test")
 
 
 async def test_text_input_text_set(companion_client, companion_state):
     await companion_client.keyboard.text_set("test")
-    assert companion_state.rti_text == "test"
+    await until(lambda: companion_state.rti_text == "test")

--- a/tests/protocols/companion/test_companion_interface.py
+++ b/tests/protocols/companion/test_companion_interface.py
@@ -1,0 +1,62 @@
+import asyncio
+from typing import Any, Mapping, cast
+from unittest.mock import Mock
+
+import pytest
+
+from pyatv import Core
+from pyatv.const import KeyboardFocusState
+from pyatv.core import MessageDispatcher, ProtocolStateDispatcher, UpdatedState
+from pyatv.protocols.companion import CompanionKeyboard
+
+pytestmark = pytest.mark.asyncio
+
+
+class CompanionApiMock(MessageDispatcher[str, Mapping[str, Any]]):
+    async def inject(self, event_name: str, data: Mapping[str, Any]) -> None:
+        await asyncio.gather(*self.dispatch(event_name, data))
+
+
+class CompanionCoreMock:
+    def __init__(
+        self,
+        state_dispatcher: ProtocolStateDispatcher,
+    ) -> None:
+        self.state_dispatcher = state_dispatcher
+
+
+@pytest.fixture(name="api_mock")
+def api_mock_fixture(event_loop):
+    yield CompanionApiMock()
+
+
+@pytest.fixture(name="keyboard")
+def audio_fixture(api_mock, companion_state_dispatcher):
+    yield CompanionKeyboard(
+        api_mock, cast(Core, CompanionCoreMock(companion_state_dispatcher))
+    )
+
+
+@pytest.mark.parametrize(
+    "event,data,expected_volume",
+    [
+        ("_tiStarted", {"_tiD": b""}, KeyboardFocusState.Focused),
+        ("_tiStopped", {}, KeyboardFocusState.Unfocused),
+    ],
+)
+async def test_keyboard_handle_text_input_dispatches(
+    api_mock,
+    keyboard,
+    companion_state_dispatcher,
+    event,
+    data,
+    expected_volume,
+):
+    callback = Mock()
+    companion_state_dispatcher.listen_to(UpdatedState.KeyboardFocus, callback)
+
+    await api_mock.inject(event, data)
+
+    assert callback.called is True
+    message = callback.call_args.args[0]
+    assert message.value == expected_volume


### PR DESCRIPTION
This PR adds a listener interface for updating the focus state of the virtual keyboard, and documentation for the Keyboard interface as discussed in comments to #1905.

I've opted to not create a listener for text content, or to pass the current text as part of the focus state update since my testing has found this unreliable. The device only sends text updates for changes made through on screen clicks, not made over the API, and only appears to have started doing so in a patch release that occurred after developing the initial PR. Using text_get gets the actual content always by resetting the text input session before each request.