### PR TITLE
Fix intermittent companion proxy connection issues

### DIFF
--- a/docs/documentation/atvproxy.md
+++ b/docs/documentation/atvproxy.md
@@ -93,13 +93,7 @@ work and behave as expected and all traffic should be logged to console.
 
 # Companion Proxy
 
-There is also support for the Companion protocol. Occasionally iOS devices will
-fail to complete the connection ("Connecting" visible in the remote app despite
-seeing initialization traffic in the proxy), possibly due to some kind of IP
-address & port or identifier caching. In such situations rebooting the iOS
-device, restarting the proxy, restarting the Apple TV Remote app (in newer iOS
-versions), or a combination of these has been known to bring it back to a
-working state.
+There is also support for the Companion protocol.
 
 ## Device Credentials
 


### PR DESCRIPTION
Companion protocol appears to bee sensitive to the byte-size of opack encoded integers. Previously proxy connection could sometimes fail if the size of the response "_x" field did not match the size of the request "_x" field.

This PR preserves  integer sizes when decoding/re-encoding with opack