### PR TITLE
raop: Improve metadata handling

### DIFF
--- a/docs/api/pyatv/exceptions.html
+++ b/docs/api/pyatv/exceptions.html
@@ -72,6 +72,9 @@ link_group: api
 <h4><code><a title="pyatv.exceptions.NotSupportedError" href="#pyatv.exceptions.NotSupportedError">NotSupportedError</a></code></h4>
 </li>
 <li>
+<h4><code><a title="pyatv.exceptions.OperationTimeoutError" href="#pyatv.exceptions.OperationTimeoutError">OperationTimeoutError</a></code></h4>
+</li>
+<li>
 <h4><code><a title="pyatv.exceptions.PairingError" href="#pyatv.exceptions.PairingError">PairingError</a></code></h4>
 </li>
 <li>
@@ -99,7 +102,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Local exceptions used by library.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/exceptions.py#L1-L119" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/exceptions.py#L1-L123" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -343,6 +346,19 @@ the connection was closed for some other reason.</p></section>
 <ul class="hlist">
 <li>builtins.NotImplementedError</li>
 <li>builtins.RuntimeError</li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="pyatv.exceptions.OperationTimeoutError"><code class="flex name class">
+<span>class <span class="ident">OperationTimeoutError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Raised when a timeout happens.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/exceptions.py#L122-L123" class="git-link">Browse git</a></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
 <li>builtins.Exception</li>
 <li>builtins.BaseException</li>
 </ul>

--- a/docs/api/pyatv/interface.html
+++ b/docs/api/pyatv/interface.html
@@ -2013,7 +2013,7 @@ actually changes.</p>
 </dd>
 <dt id="pyatv.interface.Stream.stream_file">
 <code class="name flex">
-<span>async def <span class="ident">stream_file</span></span>(<span>self, file: Union[str, _io.BufferedReader, asyncio.streams.StreamReader], /, metadata: Optional[<a title="pyatv.interface.MediaMetadata" href="#pyatv.interface.MediaMetadata">MediaMetadata</a>] = None, **kwargs) -> None</span>
+<span>async def <span class="ident">stream_file</span></span>(<span>self, file: Union[str, io.BufferedIOBase, asyncio.streams.StreamReader], /, metadata: Optional[<a title="pyatv.interface.MediaMetadata" href="#pyatv.interface.MediaMetadata">MediaMetadata</a>] = None, **kwargs) -> None</span>
 </code>
 </dt>
 <dd>

--- a/pyatv/core/facade.py
+++ b/pyatv/core/facade.py
@@ -391,7 +391,7 @@ class FacadeStream(Relayer, interface.Stream):  # pylint: disable=too-few-public
     @shield.guard
     async def stream_file(
         self,
-        file: Union[str, io.BufferedReader, asyncio.streams.StreamReader],
+        file: Union[str, io.BufferedIOBase, asyncio.streams.StreamReader],
         /,
         metadata: Optional[interface.MediaMetadata] = None,
         **kwargs

--- a/pyatv/exceptions.py
+++ b/pyatv/exceptions.py
@@ -117,3 +117,7 @@ class BlockedStateError(Exception):
 
 class InvalidResponseError(Exception):
     """Thrown when a remote sends an invalid response."""
+
+
+class OperationTimeoutError(Exception):
+    """Raised when a timeout happens."""

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -841,7 +841,7 @@ class Stream:  # pylint: disable=too-few-public-methods
     @feature(44, "StreamFile", "Stream local file to device.")
     async def stream_file(
         self,
-        file: Union[str, io.BufferedReader, asyncio.streams.StreamReader],
+        file: Union[str, io.BufferedIOBase, asyncio.streams.StreamReader],
         /,
         metadata: Optional[MediaMetadata] = None,
         **kwargs

--- a/pyatv/support/buffer.py
+++ b/pyatv/support/buffer.py
@@ -15,7 +15,7 @@ class SemiSeekableBuffer:
 
     A semi-seekable buffer in this context is a buffer that allows seeking, but with
     restrictions. The buffer shall be thought of more like a stream, where data is read
-    in a stream like fashion but added similarily to like a buffer. The buffer has a
+    in a stream like fashion but added similarly to like a buffer. The buffer has a
     fixed size internally, but an absolute "position" is maintained based on all data
     read from the buffer.
 
@@ -54,6 +54,7 @@ class SemiSeekableBuffer:
         buffer_size: int = BUFFER_SIZE,
         /,
         seekable_headroom: int = HEADROOM_SIZE,
+        protected_headroom: bool = False
     ) -> None:
         """Initialize a new SemiSeekableBuffer instance."""
         # Headroom cannot be smaller than actual buffer
@@ -65,7 +66,7 @@ class SemiSeekableBuffer:
         self._headroom: int = seekable_headroom
         self._position: int = 0
         self._has_headroom_data: bool = True
-        self._protected: bool = False
+        self._protected: bool = protected_headroom
 
     def empty(self) -> bool:
         """Return True if buffer is empty, otherwise False."""
@@ -144,6 +145,10 @@ class SemiSeekableBuffer:
         This method only works as long as there is headroom available. Returns True if
         seek was successful, otherwise False.
         """
+        # This is a special case where we allow seeking to the current position
+        if position == self.position:
+            return True
+
         # Absolute position (i.e. total amount of data read from buffer) has passed
         # headroom space, so we have no headroom data and thus seeking not possible.
         if not self._has_headroom_data:

--- a/pyatv/support/buffer.py
+++ b/pyatv/support/buffer.py
@@ -1,0 +1,174 @@
+"""Classes and functions for data buffering."""
+from typing import Union
+
+from pyatv.exceptions import InvalidStateError
+
+# Default values for buffer
+BUFFER_SIZE = 8192
+HEADROOM_SIZE = 1024
+
+
+# This class could potentially be heavily optimized using memoryview (or bitarray). But
+# kept simple for now.
+class SemiSeekableBuffer:
+    """Implementation of a "semi-seekable" buffer.
+
+    A semi-seekable buffer in this context is a buffer that allows seeking, but with
+    restrictions. The buffer shall be thought of more like a stream, where data is read
+    in a stream like fashion but added similarily to like a buffer. The buffer has a
+    fixed size internally, but an absolute "position" is maintained based on all data
+    read from the buffer.
+
+    To allow seeking, a "headroom" (with adjustable size) is kept in the beginning of
+    the buffer. Data in the headroom is kept (internally) until the last byte of the
+    headroom is read, after which is discarded from the internal buffer (and new data
+    can be added again, in case buffer was full). As long as headroom is available,
+    seeking is possible. But once it has been discarded, it is not. In analogy to a
+    stream, this basically means the first X bytes of the stream is buffered and
+    seekable until all X bytes have been read completely.
+
+    The purpose of this kind of buffer is to support data streams (e.g. audio files)
+    containing non-linear header data. Some file formats require "looking ahead" in the
+    data stream to figure out the structure, thus seeking is needed to reset to
+    beginning of the file. This is not a foolproof solution, but this allows for far
+    better support in these cases.
+
+    A special feature called "protected headroom" is also implemented. When enabled,
+    the buffer acts as usual but the entire buffer is treated like headroom and no
+    data is ever removed. This is particularly useful when reading metadata with one
+    library (e.g. Mediafile) while decoding actual data with another library (e.g.
+    miniaudio). In a non-seekable stream, the first library would consume data required
+    by the second library. So you would get either metadata or audio data - but not
+    both. By protecting the headroom, Mediafile can read data (and seek) as much as it
+    wants, but it will always be possible to seek to the beginning again and remove
+    the protection before passing buffer to miniaudio, thus allowing both metadata and
+    audio data to be extracted properly.
+
+    Protected headroom can only be enabled/disabled when position is 0, i.e. it
+    cannot be enabled if data has been read nor can it be disabled before seeking to
+    the beginning again.
+    """
+
+    def __init__(
+        self,
+        buffer_size: int = BUFFER_SIZE,
+        /,
+        seekable_headroom: int = HEADROOM_SIZE,
+    ) -> None:
+        """Initialize a new SemiSeekableBuffer instance."""
+        # Headroom cannot be smaller than actual buffer
+        if seekable_headroom > buffer_size:
+            raise ValueError("too large seekable headroom")
+
+        self._buffer: bytes = b""
+        self._buffer_size: int = buffer_size
+        self._headroom: int = seekable_headroom
+        self._position: int = 0
+        self._has_headroom_data: bool = True
+        self._protected: bool = False
+
+    def empty(self) -> bool:
+        """Return True if buffer is empty, otherwise False."""
+        return self.size == 0
+
+    @property
+    def size(self) -> int:
+        """Return number of bytes in buffer."""
+        return len(self._buffer) - (self._position if self._has_headroom_data else 0)
+
+    @property
+    def position(self) -> int:
+        """Return absolute position of bytes read from buffer.
+
+        This property reflects number of bytes returned by the get method in total. It
+        is however reset in case of seeking to reflect seeking position (when
+        possible).
+        """
+        return self._position
+
+    @property
+    def protected_headroom(self) -> bool:
+        """Return if headroom is protected."""
+        return self._protected
+
+    @protected_headroom.setter
+    def protected_headroom(self, protected: bool) -> None:
+        """Set if headroom is protected or not."""
+        if protected == self._protected:
+            return
+
+        if self.position != 0:
+            raise InvalidStateError("not a starting position")
+
+        self._protected = protected
+
+    def add(self, data: bytes) -> int:
+        """Add data to buffer.
+
+        Returns number of bytes added to buffer.
+        """
+        room_in_buffer = min(len(data), self._buffer_size - len(self._buffer))
+        self._buffer += data[0:room_in_buffer]
+        return room_in_buffer
+
+    def get(self, number_of_bytes: int) -> bytes:
+        """Retrieve data from buffer.
+
+        Will return b"" if buffer is empty.
+        """
+        # Use position as offset in case we have (potentially read but kept) headroom
+        if self._has_headroom_data:
+            data = self._buffer[self._position : self._position + number_of_bytes]
+        else:
+            data = self._buffer[0:number_of_bytes]
+
+        self._position += len(data)
+
+        # Treat entire buffer as headroom in case it's protected and do not remove
+        # any data
+        if not self.protected_headroom:
+            if self._has_headroom_data:
+                # If we read past the headroom, we shall discard it (and additional
+                # data we read)
+                if self._position >= self._headroom:
+                    self._has_headroom_data = False
+                    self._buffer = self._buffer[self._position :]
+            else:
+                self._buffer = self._buffer[len(data) :]
+
+        return data
+
+    def seek(self, position: int) -> bool:
+        """Seek to absolute position in buffer.
+
+        This method only works as long as there is headroom available. Returns True if
+        seek was successful, otherwise False.
+        """
+        # Absolute position (i.e. total amount of data read from buffer) has passed
+        # headroom space, so we have no headroom data and thus seeking not possible.
+        if not self._has_headroom_data:
+            return False
+
+        # Can only seek within headroom
+        if position >= self._headroom:
+            return False
+
+        # There must be data in buffer for seeking to work
+        headroom_data_in_buffer = min(self._headroom, len(self._buffer))
+        if position > (headroom_data_in_buffer - 1):
+            return False
+
+        self._position = position
+        return True  # We have headroom data and position is within it
+
+    def fits(self, data: Union[int, bytes]) -> bool:
+        """Check if data (or amount of data) fits in the buffer.
+
+        This method is purely for convenience.
+        """
+        in_size = len(data) if isinstance(data, bytes) else data
+        return (len(self._buffer) + in_size) <= self._buffer_size
+
+    def __len__(self) -> int:
+        """Return number of bytes in buffer."""
+        return self.size

--- a/pyatv/support/metadata.py
+++ b/pyatv/support/metadata.py
@@ -10,18 +10,18 @@ from pyatv.interface import MediaMetadata
 EMPTY_METADATA = MediaMetadata(None, None, None, None)
 
 
-def _open_file(file: io.BufferedReader) -> MediaFile:
+def _open_file(file: io.BufferedIOBase) -> MediaFile:
     start_position = file.tell()
     in_file = MediaFile(file)
     file.seek(start_position)
     return in_file
 
 
-async def get_metadata(file: Union[str, io.BufferedReader]) -> MediaMetadata:
+async def get_metadata(file: Union[str, io.BufferedIOBase]) -> MediaMetadata:
     """Extract metadata from a file and return it."""
     loop = asyncio.get_event_loop()
 
-    if isinstance(file, io.BufferedReader):
+    if isinstance(file, io.BufferedIOBase):
         in_file = await loop.run_in_executor(None, _open_file, file)
     else:
         in_file = await loop.run_in_executor(None, MediaFile, file)

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -9,6 +9,7 @@ pytest-asyncio==0.21.0
 pytest-cov==4.1.0
 pytest-timeout==2.1.0
 pytest-aiohttp==1.0.4
+pytest-httpserver==1.0.8
 pytest-xdist==3.3.1
 pydocstyle==6.3.0
 mypy==1.3.0

--- a/tests/fake_device/raop.py
+++ b/tests/fake_device/raop.py
@@ -388,6 +388,7 @@ class FakeRaopService(HttpSimpleRouter):
         _LOGGER.debug("Received SETUP: %s", request)
         _, options = parse_transport(request.headers["Transport"])
         self.state.control_port = int(options["control_port"])
+        self.state.metadata = SimpleNamespace(title=None, artist=None, album=None)
         self._audio_receiver.reset()
         headers = {
             "Transport": (

--- a/tests/protocols/raop/test_raop_functional.py
+++ b/tests/protocols/raop/test_raop_functional.py
@@ -583,3 +583,17 @@ async def test_stop_playback(raop_client, raop_state, button):
     await raop_client.stream.stream_file(data_path("audio_3_packets.wav"))
 
     assert len(raop_state.raw_audio) >= ONE_FRAME_IN_BYTES
+
+
+@pytest.mark.parametrize(
+    "files, raop_properties", [(["only_metadata.wav"], {"et": "0", "md": "0"})]
+)
+async def test_stream_metadata_from_http(
+    raop_client, raop_state, data_webserver, files
+):
+    file_url = data_webserver + files[0]
+    await raop_client.stream.stream_file(file_url)
+
+    assert raop_state.metadata.artist == "postlund"
+    assert raop_state.metadata.album == "raop"
+    assert raop_state.metadata.title == "pyatv"

--- a/tests/support/test_buffer.py
+++ b/tests/support/test_buffer.py
@@ -1,0 +1,241 @@
+import pytest
+
+from pyatv.exceptions import InvalidStateError
+from pyatv.support import buffer as buf
+
+BUFFER_SIZE = 5
+HEADROOM = 2
+
+
+@pytest.fixture(name="buffer")
+def buffer_fixture() -> buf:
+    yield buf.SemiSeekableBuffer(BUFFER_SIZE, seekable_headroom=0)
+
+
+@pytest.fixture(name="headroom_buffer")
+def buffer_headroom_fixture() -> buf:
+    yield buf.SemiSeekableBuffer(BUFFER_SIZE, seekable_headroom=HEADROOM)
+
+
+@pytest.fixture(name="protected")
+def protected_fixture() -> buf:
+    buffer = buf.SemiSeekableBuffer(BUFFER_SIZE, seekable_headroom=HEADROOM)
+    buffer.protected_headroom = True
+    yield buffer
+
+
+def test_get_empty_buffer(buffer):
+    assert buffer.get(1) == b""
+
+
+def test_add_and_get(buffer):
+    buffer.add(b"abc")
+    assert buffer.get(1) == b"a"
+    assert buffer.get(2) == b"bc"
+    assert buffer.get(1) == b""
+
+
+def test_add_until_full(buffer):
+    assert buffer.add((BUFFER_SIZE - 1) * b"a") == BUFFER_SIZE - 1
+    assert buffer.add(b"aa") == 1
+    assert buffer.add(b"a") == 0
+
+
+def test_buffer_size(buffer):
+    assert buffer.size == 0
+
+    buffer.add(b"a")
+    assert buffer.size == 1
+    assert len(buffer) == 1
+
+    buffer.add(b"abc")
+    assert buffer.size == 4
+    assert len(buffer) == 4
+
+    buffer.add(b"a" * (BUFFER_SIZE - 4))
+    assert buffer.size == BUFFER_SIZE
+    assert len(buffer) == BUFFER_SIZE
+
+    buffer.add(b"a")
+    assert buffer.size == BUFFER_SIZE
+    assert len(buffer) == BUFFER_SIZE
+
+
+def test_buffer_emptyness(buffer):
+    assert buffer.empty()
+
+    buffer.add(b"a")
+    assert not buffer.empty()
+
+    buffer.get(1)
+    assert buffer.empty()
+
+
+def test_position_no_seeking(buffer):
+    assert buffer.position == 0
+
+    buffer.add(b"aaa")
+    assert buffer.position == 0
+
+    buffer.get(1)
+    assert buffer.position == 1
+
+    buffer.get(2)
+    assert buffer.position == 3
+
+    buffer.get(3)  # Buffer is empty at this point
+    assert buffer.position == 3
+
+
+def test_invalid_seekable_headroom():
+    with pytest.raises(ValueError):
+        buf.SemiSeekableBuffer(1, seekable_headroom=2)
+
+
+def test_seek_outside_of_buffer(headroom_buffer):
+    # Buffer is empty so should not be seekable
+    assert not headroom_buffer.seek(1)
+
+
+def test_simple_seek_within_headroom(headroom_buffer):
+    headroom_buffer.add(b"aaaa")
+    assert headroom_buffer.seek(1)
+    assert not headroom_buffer.seek(2)
+    assert headroom_buffer.seek(0)
+
+
+def test_seek_outside_of_headroom_not_possible(headroom_buffer):
+    headroom_buffer.add(BUFFER_SIZE * b"a")
+    assert headroom_buffer.seek(HEADROOM - 1)
+    assert not headroom_buffer.seek(HEADROOM)
+
+
+def test_get_partial_data_allows_seeking(headroom_buffer):
+    headroom_buffer.add(b"abcde")
+
+    assert headroom_buffer.get(1) == b"a"
+    assert headroom_buffer.size == 4
+    assert headroom_buffer.position == 1
+
+    headroom_buffer.seek(0)
+    assert headroom_buffer.size == 5
+    assert headroom_buffer.position == 0
+    assert headroom_buffer.get(1) == b"a"
+    assert headroom_buffer.size == 4
+    assert headroom_buffer.position == 1
+
+
+def test_get_all_headroom_disallows_seeking(headroom_buffer):
+    headroom_buffer.add(b"abcde")
+
+    assert headroom_buffer.get(2) == b"ab"
+    assert not headroom_buffer.seek(0)
+    assert headroom_buffer.size == 3
+    assert headroom_buffer.position == 2
+
+
+def test_can_add_after_headroom_is_removed(headroom_buffer):
+    headroom_buffer.add(b"abcde")
+
+    headroom_buffer.get(3)
+    assert headroom_buffer.size == 2
+    assert headroom_buffer.position == 3
+
+    headroom_buffer.add(b"abcde")
+    assert headroom_buffer.size == 5
+    assert headroom_buffer.position == 3
+
+    assert headroom_buffer.get(5) == b"deabc"
+    assert headroom_buffer.size == 0
+    assert headroom_buffer.position == 8
+
+    headroom_buffer.add(b"abcde")
+    assert headroom_buffer.size == 5
+    assert headroom_buffer.position == 8
+
+    assert headroom_buffer.get(5) == b"abcde"
+    assert headroom_buffer.size == 0
+    assert headroom_buffer.position == 13
+
+
+def test_enable_disable_protected_after_get_fails(protected):
+    # Get something so we are not a position==0
+    protected.add(b"abc")
+    protected.get(1)
+
+    # This is fine
+    protected.protected_headroom = True
+
+    with pytest.raises(InvalidStateError):
+        # This is not
+        protected.protected_headroom = False
+
+
+def test_protected_does_not_remove_data(protected):
+    # Also test that adding too much data not possible
+    protected.add(b"abcdef")
+    assert protected.size == 5
+    assert protected.position == 0
+
+    assert protected.get(2) == b"ab"
+    assert protected.size == 3
+    assert protected.position == 2
+
+    assert protected.get(4) == b"cde"
+    assert protected.size == 0
+    assert protected.position == 5
+
+    assert protected.add(b"ggg") == 0
+    assert protected.size == 0
+    assert protected.position == 5
+
+    assert protected.seek(0)
+    assert protected.size == 5
+    assert protected.position == 0
+
+    assert protected.get(5) == b"abcde"
+    assert protected.size == 0
+    assert protected.position == 5
+
+
+def test_disable_protected_headroom_after_using_it(protected):
+    protected.add(b"abcdef")
+
+    assert protected.get(2) == b"ab"
+    assert protected.size == 3
+    assert protected.position == 2
+
+    # Seek to beginning to make it possible to disable protected headroom
+    assert protected.seek(0)
+    protected.protected_headroom = False
+
+    assert protected.get(6) == b"abcde"
+    assert protected.size == 0
+    assert protected.position == 5
+
+    # Now we can add data again (since not protected)
+    assert protected.add(b"hij") == 3
+    assert protected.size == 3
+    assert protected.position == 5
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (b"a", True),
+        (b"aa", True),
+        (b"aaa", False),
+        (1, True),
+        (2, True),
+        (3, False),
+    ],
+)
+def test_fits_in_buffer(buffer, data, expected):
+    buffer.add(b"abc")
+    assert buffer.fits(data) == expected
+
+
+def test_fits_with_headroom_present(buffer):
+    buffer.add(BUFFER_SIZE * b"a")
+    buffer.get(1)
+    assert not buffer.fits(2)

--- a/tests/support/test_buffer.py
+++ b/tests/support/test_buffer.py
@@ -219,6 +219,18 @@ def test_disable_protected_headroom_after_using_it(protected):
     assert protected.position == 5
 
 
+def test_protected_headroom_constructor():
+    buffer = buf.SemiSeekableBuffer(
+        BUFFER_SIZE, seekable_headroom=HEADROOM, protected_headroom=True
+    )
+    buffer.add(b"abcde")
+
+    assert buffer.get(HEADROOM) == b"ab"
+    assert buffer.position == 2
+    assert buffer.seek(0)
+    assert buffer.position == 0
+
+
 @pytest.mark.parametrize(
     "data, expected",
     [
@@ -239,3 +251,12 @@ def test_fits_with_headroom_present(buffer):
     buffer.add(BUFFER_SIZE * b"a")
     buffer.get(1)
     assert not buffer.fits(2)
+
+
+def test_seek_current_position_ok(buffer):
+    assert buffer.seek(0)
+
+    buffer.add(b"a" * BUFFER_SIZE)
+    buffer.get(HEADROOM)
+    assert not buffer.seek(1)
+    assert buffer.seek(2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -130,6 +130,11 @@ def faketime(module_name, *times):
     return FakeDatetime(list(times))
 
 
+def data_root() -> str:
+    """Return absolute path to data directory used by tests."""
+    return str(Path(__file__).parent.joinpath("data"))
+
+
 def data_path(filename: str) -> str:
     """Return absolute path to a test file in the data directory."""
     abs_path = str(Path(__file__).parent.joinpath("data", filename))


### PR DESCRIPTION
This PR introduces a "Semi-seekable buffer" used when streaming audio in RAOP. I use `mediafile` for extracting metadata and `miniaudio` for playback which introduces a couple of issues, the main one being related to seeking. Most media files require some seeking in the stream to perform decoding, i.e. figuring out file format and potential metadata (e.g. ID3). Under some circumstances `mediafile` is able to extract metadata from a non-seekable stream, but the playback will fail afterwards since position is no longer 0 so important headers are missing (and since stream is not seekable, it's not possible to go back to the beginning).

The rationale behind `SemiSeekableBuffer` is that most media formats keep metadata in beginning of the file, so this buffer will keep the beginning of a file/stream available and allow for seeking within it. The seekable space is called "protected headroom" and as long as this space is not consumed, i.e. enough calls to `get` has been made to have read the total size of this space, it will remain in memory and be seekable. Once it has been consumed, it will be removed and the buffer will act just like a normal buffer (and seeking will not be possible anymore with this buffer).

The protected headroom can also be protected(/read-only) to ensure it is never removed. This makes sure that `mediafile` (in this case) can do whatever with the buffer, i.e. try to extract metadata in any way it wants, but keeping all buffered data intact for streaming later on. The buffer will basically be filled, `mediafile` tries to extract metadata, protected headroom is "unprotected" before streaming and the headroom will be removed during the streaming phase (and more data can be read from the source stream and added to the buffer after that).

It is not a foolproof solution as some media formats sill seem to require seeking in the entire file, but it works a lot better. During my tests, it seems like WAV has most problems while MP3 and FLAC works fine.

The same problem actually exists in `miniaudio` as well, as that library also require seeking in some cases which didn't work before. That should not be a problem now and more files should be support, one being TTS with picoTTS in Home Assistant (which was the main driver for this PR btw).