### PR TITLE
Volume control improvements

### DIFF
--- a/pyatv/scripts/atvproxy.py
+++ b/pyatv/scripts/atvproxy.py
@@ -811,6 +811,12 @@ class AirPlayDataStreamChannelAppleTVProxy(
                 inner.airPlayGroupID = shift_hex_identifier(inner.airPlayGroupID)
             return message
 
+        if message.type == protobuf.SET_VOLUME_MESSAGE:
+            inner = cast(protobuf.SetVolumeMessage, message.inner())
+            if inner.outputDeviceUID == SERVER_IDENTIFIER:
+                inner.outputDeviceUID = self.target_identifier
+                return message
+
         if message.type == protobuf.CONFIGURE_CONNECTION_MESSAGE:
             # iOS doesn't like the rewritten airplay group id and sends this
             # message, but sending it on causes issues with the connection.

--- a/tests/fake_device/mrp.py
+++ b/tests/fake_device/mrp.py
@@ -275,13 +275,24 @@ class FakeMrpState:
             client.displayName = display_name
         self._send(msg)
 
-    def volume_control(self, available):
+    def volume_control(self, available, support_absolute=True, support_relative=True):
+        if support_absolute and support_relative:
+            capabilities = protobuf.VolumeCapabilities.Both
+        elif support_absolute:
+            capabilities = protobuf.VolumeCapabilities.Absolute
+        elif support_relative:
+            capabilities = protobuf.VolumeCapabilities.Relative
+        else:
+            capabilities = None
+
         msg = messages.create(protobuf.VOLUME_CONTROL_AVAILABILITY_MESSAGE)
         msg.inner().volumeControlAvailable = available
+        msg.inner().volumeCapabilities = capabilities
         self._send(msg)
 
         msg = messages.create(protobuf.VOLUME_CONTROL_CAPABILITIES_DID_CHANGE_MESSAGE)
         msg.inner().capabilities.volumeControlAvailable = available
+        msg.inner().capabilities.volumeCapabilities = capabilities
         msg.inner().outputDeviceUID = DEVICE_UID
         self._send(msg)
 
@@ -626,9 +637,15 @@ class FakeMrpUseCases:
         """Initialize a new FakeMrpUseCases."""
         self.state = state
 
-    def change_volume_control(self, available):
+    def change_volume_control(
+        self, available, support_absolute=True, support_relative=True
+    ):
         """Change volume control availability."""
-        self.state.volume_control(available)
+        self.state.volume_control(
+            available,
+            support_absolute=support_absolute,
+            support_relative=support_relative,
+        )
 
         # Device always sends current volume if controls are available
         if available:

--- a/tests/protocols/mrp/test_mrp_functional.py
+++ b/tests/protocols/mrp/test_mrp_functional.py
@@ -558,6 +558,34 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
             FeatureName.ContentIdentifier,
         )
 
+    async def test_absolute_volume_features(self):
+        features = [
+            FeatureName.Volume,
+            FeatureName.SetVolume,
+        ]
+        self.assertFeatures(FeatureState.Unavailable, *features)
+
+        self.usecase.change_volume_control(
+            available=True, support_absolute=False, support_relative=True
+        )
+        self.usecase.example_video(title="dummy2")
+        await self.playing(title="dummy2")
+        self.assertFeatures(FeatureState.Unavailable, *features)
+
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=False
+        )
+        self.usecase.example_video(title="dummy3")
+        await self.playing(title="dummy3")
+        self.assertFeatures(FeatureState.Available, *features)
+
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=True
+        )
+        self.usecase.example_video(title="dummy4")
+        await self.playing(title="dummy4")
+        self.assertFeatures(FeatureState.Available, *features)
+
     async def test_volume_change(self):
         self.usecase.change_volume_control(available=True)
 
@@ -577,9 +605,7 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         self.usecase.set_volume(0.3, DEVICE_UID)
         await until(lambda: math.isclose(self.atv.audio.volume, 30.0))
 
-    async def test_audio_volume_up_increases_volume(self):
-        self.usecase.change_volume_control(available=True)
-
+    async def _test_audio_volume_up_increases_volume(self):
         await until(
             lambda: self.atv.features.in_state(
                 FeatureState.Available, FeatureName.SetVolume
@@ -594,7 +620,19 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         await self.atv.audio.volume_up()
         assert self.atv.audio.volume == round(20.0 + 2 * VOLUME_STEP * 100.0)
 
-    async def test_audio_volume_down_decreases_volume(self):
+    async def test_audio_volume_up_increases_volume_relative(self):
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=True
+        )
+        await self._test_audio_volume_up_increases_volume()
+
+    async def test_audio_volume_up_increases_volume_absolute(self):
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=False
+        )
+        await self._test_audio_volume_up_increases_volume()
+
+    async def _test_audio_volume_down_decreases_volume(self):
         self.usecase.change_volume_control(available=True)
 
         await until(
@@ -611,9 +649,19 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         await self.atv.audio.volume_down()
         assert self.atv.audio.volume == round(20 - 2 * VOLUME_STEP * 100.0)
 
-    async def test_audio_volume_up_above_max(self):
-        self.usecase.change_volume_control(available=True)
+    async def test_audio_volume_down_decreases_volume_relative(self):
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=True
+        )
+        await self._test_audio_volume_down_decreases_volume()
 
+    async def test_audio_volume_down_decreases_volume_absolute(self):
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=False
+        )
+        await self._test_audio_volume_down_decreases_volume()
+
+    async def _test_audio_volume_up_above_max(self):
         await until(
             lambda: self.atv.features.in_state(
                 FeatureState.Available, FeatureName.SetVolume
@@ -625,9 +673,19 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
         # Should not yield a timeout
         await self.atv.audio.volume_up()
 
-    async def test_audio_volume_down_below_zero(self):
-        self.usecase.change_volume_control(available=True)
+    async def test_audio_volume_up_above_max_relative(self):
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=True
+        )
+        await self._test_audio_volume_up_above_max()
 
+    async def test_audio_volume_up_above_max_absolute(self):
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=False
+        )
+        await self._test_audio_volume_up_above_max()
+
+    async def _test_audio_volume_down_below_zero(self):
         await until(
             lambda: self.atv.features.in_state(
                 FeatureState.Available, FeatureName.SetVolume
@@ -638,6 +696,18 @@ class MRPFunctionalTest(common_functional_tests.CommonFunctionalTests):
 
         # Should not yield a timeout
         await self.atv.audio.volume_down()
+
+    async def test_audio_volume_down_below_zero_relative(self):
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=True
+        )
+        await self._test_audio_volume_down_below_zero()
+
+    async def test_audio_volume_down_below_zero_absolute(self):
+        self.usecase.change_volume_control(
+            available=True, support_absolute=True, support_relative=False
+        )
+        await self._test_audio_volume_down_below_zero()
 
     async def test_output_devices(self):
         assert self.atv.audio.output_devices == [


### PR DESCRIPTION
This PR changes MRP volume control to be aware of the device `volumeCapabilities` (`Absolute` or `Relative`).

Should fix https://github.com/home-assistant/core/issues/76117 for HomePods which only support `Absolute` and do not respond to HIP volume up/down commands.

For Apple TV it should set the Volume and SetVolume features as Unavailable when the device reports `Relative`, so it should be easier to explain behaviour in tickets such as #1838.
Home Assistant will still say it supports the volume features in this case (https://github.com/home-assistant/core/blob/dev/homeassistant/components/apple_tv/media_player.py#L125-L128) and show the volume slider, but now pyatv will not throw a TimeoutError.