### PR TITLE
Release 0.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,8 +137,8 @@ jobs:
               if name is not None:
                 notes += line
 
-          print(f"name={name} >> " + os.environ["GITHUB_OUTPUT"])
-          print(f"version={version} >> " + os.environ["GITHUB_OUTPUT"])
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.writelines([f"name={name}", f"version={version}"])
 
           with open("notes.md", "w", encoding="utf-8") as handle:
             handle.write(notes)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,135 @@
 # CHANGES
 
+## 0.13.0 Grandpa (2023-06-15)
+
+This release contains some big new stuff, really nice. In summary we have:
+
+* Basic support for audio streaming using AirPlay 2
+* Proper power state support in Companion
+* Support for activating screensaver
+* Improved buffering of audio when streaming
+* Added support for changing output devices in tvOS (@michalmo)
+* atvproxy now supports MRP-over-AirPlay (@michalmo)
+* Bug: Absolute/relative volume management is greatly improved (@michalmo)
+* Bug: Position calculation improved in MRP
+
+One of the big new things in this release is support for streaming audio via
+AirPlay 2. Streaming via AirPlay 1 has been possible for quite some time now
+and that is "good enough" (based on what pyatv supports) with Apple devices,
+but not most 3rd party receivers as lots of them only support AirPlay 2. From
+now on however, pyatv can be used to stream audio to previously unsupported
+receivers, like Sonos for instance. It is still not possible to use controls
+like pause and skip next, but metadata should work fine. More features will
+be added over time. Main driver for this feature is using any AirPlay 2
+receiver for Text-To-Speech (TTS) in Home Assistant.
+
+Another feature lots of people have been asking for is an API to change output
+device(s) on their Apple TV. This allows for changing audio device to for
+instance a HomePod instead of the built-in TV speakers. @michalmo took a
+crack at and implemented that (fixing AirPlay support in atvproxy whilst doing
+so). Active devices can be listed or removed and new devices added, nice!
+
+Yet another feature/bug fix is buffering support for non-seekable streams when
+streaming audio via RAOP. When streaming from an Internet source for instance,
+pyatv would "consume" data in a linear fashion (get X bytes, stream that, throw
+it away, get next X bytes, etc.). For some formats this works fine, but a few
+requires seeking, i.e. looking into the future of the stream and then going
+back to the start again. This is not possible if the buffer is not seekable,
+which is the case for an Internet source. I have now added general buffering
+support for the beginning of a anything being streamed, improving streaming
+support a lot. It also allows for extracting metadata from more formats, even
+Internet sources, so that's a big improvements as well. It's not bulletproof,
+so milage may vary. Again, main driver for this is Home Assistant. Some
+TTS integrations, like picoTTS, would not work because the generated file
+required seeking (due to file format being wav I think). This release should
+fix that.
+
+One more thing... proper standby detection via Companion! Recently (not exactly
+sure which version) Apple added "SystemStatus" support over Companion. The
+system status reflects whether a device is in standby or awake mode (or even
+has the screensaver active). Changes are pushed as an event, so pyatv will
+get notified as soon as the state changes. I hope this will help a lot of
+people having problem with device state, like we see a lot of in Home
+Assistant.
+
+**Changes:**
+
+*Protocol: MRP:*
+
+```
+850547e mrp: Fix position if playbackRate is 0.0
+```
+
+*Protocol: AirPlay:*
+
+```
+8badbf7 Support volume control for an Apple TV connected to HomePod(s) instead of TV speakers
+254694c Control AirPlay output devices (#2044)
+```
+
+*Protocol: Companion:*
+
+```
+74b3fc4 companion: Implement SystemStatus support
+62f6654 companion: Add screensaver support
+```
+
+*Protocol: RAOP:*
+
+```
+6d46726 raop: Basic AirPlay 2 streaming
+bb20742 raop: Migrate remaining buffers to SemiSeekableBuffer
+4807f0f raop: Migrate PatchedIceCastClient to SemiSeekableBuffer
+```
+
+*Script: atvremote:*
+
+```
+139bc4b atvremote: Allow custom service properties
+```
+
+**All changes:**
+
+```
+74b3fc4 companion: Implement SystemStatus support
+850547e mrp: Fix position if playbackRate is 0.0
+10e207f raop: Handle setting volume later
+ab8ee57 raop: Add feedback to AirPlay 2 streaming
+6d46726 raop: Basic AirPlay 2 streaming
+139bc4b atvremote: Allow custom service properties
+12d9b5a airplay: Change RemoteControl to AP2Session
+290a1e0 rtsp: Make handling of bplists more general
+8badbf7 Support volume control for an Apple TV connected to HomePod(s) instead of TV speakers
+b99b4f8 Volume control improvements
+8815d02 build(deps): Bump codespell from 2.2.4 to 2.2.5 in /requirements
+979e61e build(deps): Bump protobuf from 4.23.2 to 4.23.3 in /requirements (#2051)
+a3e3d51 add FeatureName.TextFocusState to supported features for Companion (#2047)
+254694c Control AirPlay output devices (#2044)
+bb20742 raop: Migrate remaining buffers to SemiSeekableBuffer
+4807f0f raop: Migrate PatchedIceCastClient to SemiSeekableBuffer
+44a4c7a support: Add a SemiSeekableBuffer
+ca8c928 build(deps): Bump zeroconf from 0.64.1 to 0.66.0 in /requirements
+eeba576 build(deps): Bump bitarray from 2.7.4 to 2.7.5 in /requirements
+72f2f92 build(deps): Bump pytest from 7.3.1 to 7.3.2 in /requirements
+62f6654 companion: Add screensaver support
+e66aa2e if: Update doc string for pause
+4a66c5d tests: Fix some streaming instability in RAOP
+fbf02c3 cq: Disable deprecated warnings in pyatv tests
+ff89c26 update documentation
+d500480 unify identifiers and credentials
+83be27e add tests for HAP and transient auth
+0b75957 update tests to use airplay.server_auth
+a311b8b support segmented requests in BasicHttpServer
+054b9e5 rewrite identifiers to improve connection
+7a307c2 add protobuf ConfigureConnectionMessage
+fa006ff add field to UpdateOutputDeviceMessage
+6ca50c1 regenerate protobuf code
+d192759 log decoded channel messages
+5ebc663 replace CaseInsensitiveDict in pyatv.support.http with version from requests that preserves input case, which is better for proxying
+443f7d1 add public methods to pyatv.http to format requests and reponses
+ee9523b initial airplay proxy working with pyatv client
+```
+
 ## 0.12.1 Frankie (2023-06-08)
 
 Time for a new release. Here it goes:

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -4,8 +4,8 @@
 from enum import Enum
 
 MAJOR_VERSION = "0"
-MINOR_VERSION = "12"
-PATCH_VERSION = "1"
+MINOR_VERSION = "13"
+PATCH_VERSION = "0"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
## 0.13.0 Grandpa (2023-06-15)

This release contains some big new stuff, really nice. In summary we have:

* Basic support for audio streaming using AirPlay 2
* Proper power state support in Companion
* Support for activating screensaver
* Improved buffering of audio when streaming
* Added support for changing output devices in tvOS (@michalmo)
* atvproxy now supports MRP-over-AirPlay (@michalmo)
* Bug: Absolute/relative volume management is greatly improved (@michalmo)
* Bug: Position calculation improved in MRP

One of the big new things in this release is support for streaming audio via
AirPlay 2. Streaming via AirPlay 1 has been possible for quite some time now
and that is "good enough" (based on what pyatv supports) with Apple devices,
but not most 3rd party receivers as lots of them only support AirPlay 2. From
now on however, pyatv can be used to stream audio to previously unsupported
receivers, like Sonos for instance. It is still not possible to use controls
like pause and skip next, but metadata should work fine. More features will
be added over time. Main driver for this feature is using any AirPlay 2
receiver for Text-To-Speech (TTS) in Home Assistant.

Another feature lots of people have been asking for is an API to change output
device(s) on their Apple TV. This allows for changing audio device to for
instance a HomePod instead of the built-in TV speakers. @michalmo took a
crack at and implemented that (fixing AirPlay support in atvproxy whilst doing
so). Active devices can be listed or removed and new devices added, nice!

Yet another feature/bug fix is buffering support for non-seekable streams when
streaming audio via RAOP. When streaming from an Internet source for instance,
pyatv would "consume" data in a linear fashion (get X bytes, stream that, throw
it away, get next X bytes, etc.). For some formats this works fine, but a few
requires seeking, i.e. looking into the future of the stream and then going
back to the start again. This is not possible if the buffer is not seekable,
which is the case for an Internet source. I have now added general buffering
support for the beginning of a anything being streamed, improving streaming
support a lot. It also allows for extracting metadata from more formats, even
Internet sources, so that's a big improvements as well. It's not bulletproof,
so milage may vary. Again, main driver for this is Home Assistant. Some
TTS integrations, like picoTTS, would not work because the generated file
required seeking (due to file format being wav I think). This release should
fix that.

One more thing... proper standby detection via Companion! Recently (not exactly
sure which version) Apple added "SystemStatus" support over Companion. The
system status reflects whether a device is in standby or awake mode (or even
has the screensaver active). Changes are pushed as an event, so pyatv will
get notified as soon as the state changes. I hope this will help a lot of
people having problem with device state, like we see a lot of in Home
Assistant.

**Changes:**

*Protocol: MRP:*

```
850547e mrp: Fix position if playbackRate is 0.0
```

*Protocol: AirPlay:*

```
8badbf7 Support volume control for an Apple TV connected to HomePod(s) instead of TV speakers
254694c Control AirPlay output devices (#2044)
```

*Protocol: Companion:*

```
74b3fc4 companion: Implement SystemStatus support
62f6654 companion: Add screensaver support
```

*Protocol: RAOP:*

```
6d46726 raop: Basic AirPlay 2 streaming
bb20742 raop: Migrate remaining buffers to SemiSeekableBuffer
4807f0f raop: Migrate PatchedIceCastClient to SemiSeekableBuffer
```

*Script: atvremote:*

```
139bc4b atvremote: Allow custom service properties
```

**All changes:**

```
74b3fc4 companion: Implement SystemStatus support
850547e mrp: Fix position if playbackRate is 0.0
10e207f raop: Handle setting volume later
ab8ee57 raop: Add feedback to AirPlay 2 streaming
6d46726 raop: Basic AirPlay 2 streaming
139bc4b atvremote: Allow custom service properties
12d9b5a airplay: Change RemoteControl to AP2Session
290a1e0 rtsp: Make handling of bplists more general
8badbf7 Support volume control for an Apple TV connected to HomePod(s) instead of TV speakers
b99b4f8 Volume control improvements
8815d02 build(deps): Bump codespell from 2.2.4 to 2.2.5 in /requirements
979e61e build(deps): Bump protobuf from 4.23.2 to 4.23.3 in /requirements (#2051)
a3e3d51 add FeatureName.TextFocusState to supported features for Companion (#2047)
254694c Control AirPlay output devices (#2044)
bb20742 raop: Migrate remaining buffers to SemiSeekableBuffer
4807f0f raop: Migrate PatchedIceCastClient to SemiSeekableBuffer
44a4c7a support: Add a SemiSeekableBuffer
ca8c928 build(deps): Bump zeroconf from 0.64.1 to 0.66.0 in /requirements
eeba576 build(deps): Bump bitarray from 2.7.4 to 2.7.5 in /requirements
72f2f92 build(deps): Bump pytest from 7.3.1 to 7.3.2 in /requirements
62f6654 companion: Add screensaver support
e66aa2e if: Update doc string for pause
4a66c5d tests: Fix some streaming instability in RAOP
fbf02c3 cq: Disable deprecated warnings in pyatv tests
ff89c26 update documentation
d500480 unify identifiers and credentials
83be27e add tests for HAP and transient auth
0b75957 update tests to use airplay.server_auth
a311b8b support segmented requests in BasicHttpServer
054b9e5 rewrite identifiers to improve connection
7a307c2 add protobuf ConfigureConnectionMessage
fa006ff add field to UpdateOutputDeviceMessage
6ca50c1 regenerate protobuf code
d192759 log decoded channel messages
5ebc663 replace CaseInsensitiveDict in pyatv.support.http with version from requests that preserves input case, which is better for proxying
443f7d1 add public methods to pyatv.http to format requests and reponses
ee9523b initial airplay proxy working with pyatv client
```

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2055"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

