### PR TITLE
raop: Send audio as raw PCM

### DIFF
--- a/pyatv/protocols/raop/alac.py
+++ b/pyatv/protocols/raop/alac.py
@@ -10,6 +10,8 @@ Some assumptions here:
 * Samples are 16 bit/2 bytes
 * Number of samples in a frame is derived from frame size
 * End tag (111) is present at the end of a frame
+
+NB: This module is currently not used as raw samples are sent instead of ALAC.
 """
 from bitarray import bitarray
 

--- a/pyatv/protocols/raop/protocols/airplayv2.py
+++ b/pyatv/protocols/raop/protocols/airplayv2.py
@@ -45,7 +45,17 @@ class AirPlayV2(StreamProtocol):
                 "sessionUUID": str(uuid4()).upper(),
                 "timingPort": timing_client_port,
                 "timingProtocol": "NTP",
-                "sourceVersion": "409.16",
+                "isMultiSelectAirPlay": True,
+                "groupContainsGroupLeader": False,
+                "macAddress": "AA:BB:CC:DD:EE:FF",
+                "model": "iPhone14,3",
+                "name": "pyatv",
+                "osBuildVersion": "20F66",
+                "osName": "iPhone OS",
+                "osVersion": "16.5",
+                "senderSupportsRelay": False,
+                "sourceVersion": "690.7.1",
+                "statsCollectionEnabled": False,
             }
         )
         resp = decode_bplist_from_body(setup_resp)
@@ -94,10 +104,10 @@ class AirPlayV2(StreamProtocol):
             body={
                 "streams": [
                     {
-                        "audioFormat": 0x40000,
+                        "audioFormat": 0x800,
                         "audioMode": "default",
                         "controlPort": control_client_port,
-                        "ct": 2,  # Channels?
+                        "ct": 1,  # Raw PCM
                         "isMedia": True,
                         "latencyMax": 88200,
                         "latencyMin": 11025,

--- a/pyatv/protocols/raop/stream_client.py
+++ b/pyatv/protocols/raop/stream_client.py
@@ -7,13 +7,13 @@ AirPlay v1 and/or v2. This is mainly for code re-use purposes.
 from abc import ABC, abstractmethod
 import asyncio
 import logging
-from time import perf_counter
+from time import monotonic, perf_counter
 from typing import Any, Dict, Mapping, NamedTuple, Optional, Tuple, cast
 import weakref
 
 from pyatv import exceptions
 from pyatv.protocols.airplay.utils import pct_to_dbfs
-from pyatv.protocols.raop import alac, timing
+from pyatv.protocols.raop import timing
 from pyatv.protocols.raop.audio_source import AudioSource
 from pyatv.protocols.raop.fifo import PacketFifo
 from pyatv.protocols.raop.packets import (
@@ -502,7 +502,7 @@ class StreamClient:
     ):
         stats = Statistics(self.context.sample_rate)
 
-        initial_time = perf_counter()
+        initial_time = monotonic()
         self._is_playing = True
         prev_slow_seqno = None
         number_slow_seqno = 0
@@ -551,7 +551,7 @@ class StreamClient:
             # are (from when we initially stared to stream). The diff is the time we
             # need to sleep until next lap.
             abs_time_stream = stats.total_frames / self.context.sample_rate
-            rel_to_start = perf_counter() - initial_time
+            rel_to_start = monotonic() - initial_time
             diff = abs_time_stream - rel_to_start
             if diff > 0:
                 number_slow_seqno = 0
@@ -610,7 +610,7 @@ class StreamClient:
             self.rtsp.session_id,
         )
 
-        audio = alac.encode(frames)
+        audio = frames
 
         if transport.is_closing():
             _LOGGER.warning("Connection closed while streaming audio")

--- a/pyatv/support/buffer.py
+++ b/pyatv/support/buffer.py
@@ -78,6 +78,11 @@ class SemiSeekableBuffer:
         return len(self._buffer) - (self._position if self._has_headroom_data else 0)
 
     @property
+    def remaining(self) -> int:
+        """Return remaining bytes in buffer."""
+        return self._buffer_size - self.size
+
+    @property
     def position(self) -> int:
         """Return absolute position of bytes read from buffer.
 

--- a/pyatv/support/rtsp.py
+++ b/pyatv/support/rtsp.py
@@ -29,7 +29,7 @@ ANNOUNCE_PAYLOAD = (
     + "c=IN IP4 {remote_ip}\r\n"
     + "t=0 0\r\n"
     + "m=audio 0 RTP/AVP 96\r\n"
-    + "a=rtpmap:96 AppleLossless\r\n"
+    + "a=rtpmap:96 L16/44100/2\r\n"
     + f"a=fmtp:96 {FRAMES_PER_PACKET} 0 "
     + "{bits_per_channel} 40 10 14 {channels} 255 0 0 {sample_rate}\r\n"
 )

--- a/tests/fake_device/raop.py
+++ b/tests/fake_device/raop.py
@@ -12,7 +12,6 @@ from typing import Dict, Optional, cast
 
 from pyatv.protocols.dmap import parser
 from pyatv.protocols.dmap.tag_definitions import lookup_tag
-from pyatv.protocols.raop import alac
 from pyatv.protocols.raop.packets import RetransmitReqeust, RtpHeader, SyncPacket
 from pyatv.protocols.raop.protocols.airplayv1 import parse_transport
 from pyatv.support.http import (
@@ -235,10 +234,10 @@ class AudioReceiver(asyncio.Protocol):
                         data, (self.state.remote_address, self.state.control_port)
                     )
             else:
-                self.state.add_audio_packet(header.seqno, alac.decode(data[12:]))
+                self.state.add_audio_packet(header.seqno, data[12:])
         elif packet_type == 0x56:  # Retransmission
             original_packet = data[4:]  # Remove retransmission header
-            self.state.add_audio_packet(header.seqno, alac.decode(original_packet[12:]))
+            self.state.add_audio_packet(header.seqno, original_packet[12:])
         else:
             _LOGGER.debug("Unhandled packet type: %d", packet_type)
 

--- a/tests/support/test_buffer.py
+++ b/tests/support/test_buffer.py
@@ -71,6 +71,16 @@ def test_buffer_emptyness(buffer):
     assert buffer.empty()
 
 
+def test_buffer_remaining(buffer):
+    assert buffer.remaining == BUFFER_SIZE
+
+    buffer.add(b"a")
+    assert buffer.remaining == BUFFER_SIZE - 1
+
+    buffer.add(b"a" * BUFFER_SIZE)
+    assert buffer.remaining == 0
+
+
 def test_position_no_seeking(buffer):
     assert buffer.position == 0
 


### PR DESCRIPTION
Audio is now sent as raw PCM samples instead of being encapsulated into ALAC frames. This gives a big performance boost since data is no longer unaligned. Also made some other optimizations, so it should be less stressful on low end systems.

Relates to #2057 

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2059"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

