### PR TITLE
Release 0.13.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,48 @@
 # CHANGES
 
+## 0.13.1 Homer (2023-06-22)
+
+Small patch release coming up! Second generation HomePod has
+been added as device type. A bug when streaming from a buffer
+(something inheriting BufferedIOBase) has been fixed. The bug
+would render metadata detection unusable and playback to cut
+off early.
+
+Previous releases would send raw PCM samples encapsulated in
+Apple Lossless Audio Codec (ALAC) frames. This is now changed
+to send pure raw audio frames instead (without ALAC). This
+has a big benefit in regards to performance as the ALAC
+header is not byte-aligned, so it required a lot of bit
+shifting and memory copying. This was extremly noticable on
+low-end systems like raspberry pi. Hopefully the performance
+is a lot better now. Issue #2057 contains more details
+regarding this for those interested.
+
+**Changes:**
+
+*Protocol: RAOP:*
+
+```
+51dffc9 raop: Send autio as raw PCM
+3d4c5ff raop: Fix bug when streaming from buffer
+```
+
+*Other:*
+
+```
+02a8cab device: Add second generation HomePod
+```
+
+**All changes:**
+
+```
+dd773cc build(deps): Bump mypy from 1.3.0 to 1.4.0 in /requirements
+fb18e3a build(deps): Bump zeroconf from 0.66.0 to 0.69.0 in /requirements
+02a8cab device: Add second generation HomePod
+51dffc9 raop: Send autio as raw PCM
+3d4c5ff raop: Fix bug when streaming from buffer
+```
+
 ## 0.13.0 Grandpa (2023-06-15)
 
 This release contains some big new stuff, really nice. In summary we have:

--- a/docs/api/pyatv/const.html
+++ b/docs/api/pyatv/const.html
@@ -29,6 +29,7 @@ link_group: api
 <li><code><a title="pyatv.const.DeviceModel.Gen4" href="#pyatv.const.DeviceModel.Gen4">Gen4</a></code></li>
 <li><code><a title="pyatv.const.DeviceModel.Gen4K" href="#pyatv.const.DeviceModel.Gen4K">Gen4K</a></code></li>
 <li><code><a title="pyatv.const.DeviceModel.HomePod" href="#pyatv.const.DeviceModel.HomePod">HomePod</a></code></li>
+<li><code><a title="pyatv.const.DeviceModel.HomePodGen2" href="#pyatv.const.DeviceModel.HomePodGen2">HomePodGen2</a></code></li>
 <li><code><a title="pyatv.const.DeviceModel.HomePodMini" href="#pyatv.const.DeviceModel.HomePodMini">HomePodMini</a></code></li>
 <li><code><a title="pyatv.const.DeviceModel.Music" href="#pyatv.const.DeviceModel.Music">Music</a></code></li>
 <li><code><a title="pyatv.const.DeviceModel.Unknown" href="#pyatv.const.DeviceModel.Unknown">Unknown</a></code></li>
@@ -209,7 +210,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Constants used in the public API.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L1-L429" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L1-L432" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -228,7 +229,7 @@ link_group: api
 <section class="desc"><p>Hardware device model.</p>
 <p>Gen2-Gen4K are Apple TV model names and will be renamed to AppleTVGenX in the
 future.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L146-L187" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L146-L190" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -270,6 +271,10 @@ future.</p></section>
 <dt id="pyatv.const.DeviceModel.HomePod"><code class="name">var <span class="ident">HomePod</span></code></dt>
 <dd>
 <section class="desc"><p>Device model is HomePod (first generation).</p></section>
+</dd>
+<dt id="pyatv.const.DeviceModel.HomePodGen2"><code class="name">var <span class="ident">HomePodGen2</span></code></dt>
+<dd>
+<section class="desc"><p>Device model is HomePod (second generation).</p></section>
 </dd>
 <dt id="pyatv.const.DeviceModel.HomePodMini"><code class="name">var <span class="ident">HomePodMini</span></code></dt>
 <dd>
@@ -330,7 +335,7 @@ future.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>All supported features.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L242-L429" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L245-L432" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -593,7 +598,7 @@ future.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>State of a particular feature.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L222-L238" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L225-L241" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -625,7 +630,7 @@ future.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Type of input when pressing a button.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L190-L200" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L193-L203" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -746,7 +751,7 @@ is Apple TV Software (pre-tvOS).</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Pairing requirement for a service.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L203-L219" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L206-L222" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>

--- a/docs/api/pyatv/convert.html
+++ b/docs/api/pyatv/convert.html
@@ -33,7 +33,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Various types of extraction and conversion functions.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/convert.py#L1-L79" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/convert.py#L1-L80" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -67,7 +67,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Convert device model to string.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/convert.py#L65-L79" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/convert.py#L65-L80" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.convert.protocol_str">
 <code class="name flex">

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 MAJOR_VERSION = "0"
 MINOR_VERSION = "13"
-PATCH_VERSION = "0"
+PATCH_VERSION = "1"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
## 0.13.1 Homer (2023-06-22)

Small patch release coming up! Second generation HomePod has
been added as device type. A bug when streaming from a buffer
(something inheriting BufferedIOBase) has been fixed. The bug
would render metadata detection unusable and playback to cut
off early.

Previous releases would send raw PCM samples encapsulated in
Apple Lossless Audio Codec (ALAC) frames. This is now changed
to send pure raw audio frames instead (without ALAC). This
has a big benefit in regards to performance as the ALAC
header is not byte-aligned, so it required a lot of bit
shifting and memory copying. This was extremly noticable on
low-end systems like raspberry pi. Hopefully the performance
is a lot better now. Issue #2057 contains more details
regarding this for those interested.

**Changes:**

*Protocol: RAOP:*

```
51dffc9 raop: Send autio as raw PCM
3d4c5ff raop: Fix bug when streaming from buffer
```

*Other:*

```
02a8cab device: Add second generation HomePod
```

**All changes:**

```
dd773cc build(deps): Bump mypy from 1.3.0 to 1.4.0 in /requirements
fb18e3a build(deps): Bump zeroconf from 0.66.0 to 0.69.0 in /requirements
02a8cab device: Add second generation HomePod
51dffc9 raop: Send autio as raw PCM
3d4c5ff raop: Fix bug when streaming from buffer
```

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2067"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

