### PR TITLE
mrp: Fix pairing requirement when disabled

### DIFF
--- a/pyatv/protocols/mrp/__init__.py
+++ b/pyatv/protocols/mrp/__init__.py
@@ -1053,11 +1053,12 @@ async def service_info(
     Pairing has never been enforced by MRP (maybe by design), but it is
     possible to pair if AllowPairing is YES.
     """
-    service.pairing = (
-        PairingRequirement.Optional
-        if service.properties.get("allowpairing", "no").lower() == "yes"
-        else PairingRequirement.Disabled
-    )
+    if not service.enabled:
+        service.pairing = PairingRequirement.NotNeeded
+    elif service.properties.get("allowpairing", "no").lower() == "yes":
+        service.pairing = PairingRequirement.Optional
+    else:
+        service.pairing = PairingRequirement.Disabled
 
 
 def create_with_connection(  # pylint: disable=too-many-locals

--- a/tests/protocols/mrp/test_mrp.py
+++ b/tests/protocols/mrp/test_mrp.py
@@ -99,3 +99,16 @@ async def test_service_info_pairing(airplay_props, mrp_props, pairing_req):
 
     assert mrp_service.pairing == pairing_req
     assert airplay_service.pairing == PairingRequirement.Unsupported
+
+
+@pytest.mark.asyncio
+async def test_disabled_service_no_pairing():
+    mrp_service = MutableService("mrp", Protocol.MRP, 0, {}, enabled=False)
+    airplay_service = MutableService("id", Protocol.AirPlay, 0, {"allowpairing": "no"})
+
+    await service_info(
+        mrp_service,
+        DeviceInfo({}),
+        {Protocol.MRP: mrp_service, Protocol.AirPlay: airplay_service},
+    )
+    assert mrp_service.pairing == PairingRequirement.NotNeeded


### PR DESCRIPTION
Relates to #1567

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2099"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

