### PR TITLE
airplay: Handle Access Control Type

### DIFF
--- a/pyatv/protocols/airplay/utils.py
+++ b/pyatv/protocols/airplay/utils.py
@@ -141,10 +141,18 @@ def get_pairing_requirement(service: BaseService) -> PairingRequirement:
     - Bit 0x200 is set in sf (AirPlay v1)/flags (AirPlay v2)
     - But 0x8 set in sf/flags
 
+    There's an "act" (Access Control Type) field present in some cases. Values are yet
+    unknown, but "2" seems to correspond to "Current User".
+
     Other cases are optimistically treated as NotNeeded.
     """
     if _get_flags(service.properties) & (LEGACY_PAIRING_BIT | PIN_REQUIRED):
         return PairingRequirement.Mandatory
+
+    # "Current User" not supported by pyatv
+    if service.properties.get("act", "0") == "2":
+        return PairingRequirement.Unsupported
+
     return PairingRequirement.NotNeeded
 
 

--- a/pyatv/protocols/raop/__init__.py
+++ b/pyatv/protocols/raop/__init__.py
@@ -499,6 +499,10 @@ async def service_info(
         # Access control might say that pairing is not possible, e.g. only devices
         # belonging to the same home (not supported by pyatv)
         service.pairing = PairingRequirement.Disabled
+    elif airplay_service and airplay_service.properties.get("act", "0") == "2":
+        # Similarly to ACL, we can have an access control type we do not support,
+        # e.g. "2" which corresponds to "Current User". So we need to filter that.
+        service.pairing = PairingRequirement.Unsupported
     else:
         # Same behavior as for AirPlay expected, so re-using that here
         update_service_details(service)

--- a/tests/protocols/airplay/test_utils.py
+++ b/tests/protocols/airplay/test_utils.py
@@ -87,6 +87,9 @@ def test_is_password_required(properties, requires_password):
         ({"sf": "0x8"}, PairingRequirement.Mandatory),
         ({"flags": "0x8"}, PairingRequirement.Mandatory),
         ({"flags": "0x0"}, PairingRequirement.NotNeeded),
+        # Corresponds to only allow "Current User", which is not
+        # supported by pyatv right now
+        ({"act": "2"}, PairingRequirement.Unsupported),
     ],
 )
 async def test_get_pairing_requirement(props, expected_req):

--- a/tests/protocols/raop/test_raop.py
+++ b/tests/protocols/raop/test_raop.py
@@ -153,9 +153,16 @@ async def test_service_info_pairing(raop_props, devinfo, pairing_req):
 
 
 @pytest.mark.asyncio
-async def test_service_info_pairing_acl():
+@pytest.mark.parametrize(
+    "props, pairing_req",
+    [
+        ({"acl": "1"}, PairingRequirement.Disabled),
+        ({"act": "2"}, PairingRequirement.Unsupported),
+    ],
+)
+async def test_service_info_pairing_acl(props, pairing_req):
     raop_service = MutableService("id", Protocol.RAOP, 0, {})
-    airplay_props = MutableService("id", Protocol.AirPlay, 0, {"acl": "1"})
+    airplay_props = MutableService("id", Protocol.AirPlay, 0, props)
 
     await service_info(
         raop_service,
@@ -163,4 +170,4 @@ async def test_service_info_pairing_acl():
         {Protocol.RAOP: raop_service, Protocol.AirPlay: airplay_props},
     )
 
-    assert raop_service.pairing == PairingRequirement.Disabled
+    assert raop_service.pairing == pairing_req


### PR DESCRIPTION
The Access Control Type (ACT) tells us more regarding if pairing if required or not. It is however not known what the different values are, but "2" corresponds to access setting "Current User", which is not supported by pyatv. So filter that and return Unsupported as pairing requirement.

Relates to #2105