### PR TITLE
Fallback to sending unicast PTR queries when multicast is broken or packets are being dropped

### DIFF
--- a/pyatv/__init__.py
+++ b/pyatv/__init__.py
@@ -19,7 +19,8 @@ from pyatv.core.scan import (
     BaseScanner,
     MulticastMdnsScanner,
     UnicastMdnsScanner,
-    ZeroconfScanner,
+    ZeroconfMulticastScanner,
+    ZeroconfUnicastScanner,
 )
 from pyatv.protocols import PROTOCOLS
 from pyatv.support import http
@@ -54,11 +55,11 @@ async def scan(
     scanner: BaseScanner
     if aiozc:
         if hosts:
-            scanner = ZeroconfScanner(
+            scanner = ZeroconfUnicastScanner(
                 aiozc, hosts=[IPv4Address(host) for host in hosts]
             )
         else:
-            scanner = ZeroconfScanner(aiozc)
+            scanner = ZeroconfMulticastScanner(aiozc)
     else:
         if hosts:
             scanner = UnicastMdnsScanner([IPv4Address(host) for host in hosts], loop)

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -563,7 +563,6 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
                 if infos_by_type := infos_by_address_type.get(address):
                     infos_by_type[info.type] = info
                     self._set_or_get_address_to_device_name(address, info)
-                    break
 
         # Device info is special because it does not have an address
         device_name_to_address = self.device_name_to_address

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -516,7 +516,11 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
     def _discard_completed_needed_types(
         self, infos: List[AsyncServiceInfo], loaded_from_cache: bool
     ) -> List[AsyncServiceInfo]:
-        """Discard needed type that we have info for."""
+        """Discard needed type that we have info for.
+        
+        Returns a list of incomplete infos that we still need to
+        send queries for.
+        """
         zeroconf = self.zeroconf
         incomplete_infos: List[AsyncServiceInfo] = []
         needed_types_by_address = self.needed_types_by_address

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -526,7 +526,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         ] = {host: {f"{type_}.": None for type_ in self._services} for host in hosts}
 
     def _send_ptr_queries(
-        self, address: IPv4Address, needed_types: Set[str]
+        self, address: IPv4Address, needed_types: List[str]
     ) -> None:
         """Send PTR queries."""
         out = DNSOutgoing(_FLAGS_QR_QUERY)

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -568,6 +568,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
                 continue
             if info.type == DEVICE_INFO_TYPE:
                 device_infos.append(info)
+                # Device info is special because it does not have an address
                 continue
             for address in info.ip_addresses_by_version(IPVersion.V4Only):
                 if infos_by_type := infos_by_address_type.get(address):
@@ -595,7 +596,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
     def _process_matching_service_infos(
         self,
     ) -> Tuple[Dict[IPv4Address, List[AsyncServiceInfo]], Dict[str, str]]:
-        """Return all matching service infos."""
+        """Return all matching service infos for the requested hosts."""
         return self._process_service_info_responses(
             [
                 info

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -22,7 +22,7 @@ from typing import (
     cast,
 )
 
-from zeroconf import DNSOutgoing, DNSPointer, IPVersion, const, current_time_millis
+from zeroconf import DNSOutgoing, DNSPointer, IPVersion, current_time_millis
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 from zeroconf.const import _CLASS_IN, _FLAGS_QR_QUERY, _TYPE_PTR
 

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -515,7 +515,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
     def __init__(
         self,
         aiozc: AsyncZeroconf,
-        hosts: Optional[List[IPv4Address]] = None,
+        hosts: List[IPv4Address],
     ) -> None:
         """Initialize a new scanner."""
         super().__init__(aiozc, hosts)

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -548,7 +548,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         self.zeroconf.async_send(out, str(address))
 
     def _process_service_infos(
-        self, infos: List[AsyncServiceInfo], loaded_from_cache: bool
+        self, infos: List[AsyncServiceInfo]
     ) -> None:
         """Process service infos and update self.infos_by_address_type."""
         device_infos: List[AsyncServiceInfo] = []

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -557,7 +557,9 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
             )
 
         # Check to see if we have all the info we need after
-        # sending queries for incomplete infos
+        # sending queries for incomplete infos. There is no point
+        # in sending queries for any types discard_completed_needed_types
+        # returns here because we just sent queries for them.
         self._discard_completed_needed_types(incomplete_infos, False)
 
         # If all services are filled we are done

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -545,7 +545,6 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
             question = DNSQuestion(type_, _TYPE_PTR, _CLASS_IN)
             question.unicast = True
             out.add_question(question)
-        _LOGGER.error("Sending unicast PTR query: %s", out)
         self.zeroconf.async_send(out, str(address))
 
     def _process_service_infos(

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -484,7 +484,10 @@ class ZeroconfMulticastScanner(ZeroconfScanner):
 class ZeroconfUnicastScanner(ZeroconfScanner):
     """Service discovery using zeroconf.
 
-    A ServiceBrowser must be running for all the types we are browsing.
+    A ServiceBrowser should be running for all the types we are browsing,
+    but we will fallback to sending unicast PTR queries for missing types
+    in the event the network is dropping multicast responses for some
+    reason.
     """
 
     def __init__(

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -514,7 +514,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         self.hosts: Set[IPv4Address] = set(hosts) if hosts else set()
         # Once info_by_address_type is filled in, we are done.
         self.infos_by_address_type: Dict[
-            IPv4Address, dict[str, Optional[AsyncServiceInfo]]
+            IPv4Address, Dict[str, Optional[AsyncServiceInfo]]
         ] = {host: {f"{type_}.": None for type_ in self._services} for host in hosts}
 
     def _send_ptr_queries(self, address: IPv4Address, needed_types: List[str]) -> None:
@@ -577,8 +577,8 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
     ) -> bool:
         """Load from cache or send queries."""
         zeroconf = self.zeroconf
-        infos_to_send: list[AsyncServiceInfo] = []
-        infos_with_cache: list[AsyncServiceInfo] = []
+        infos_to_send: List[AsyncServiceInfo] = []
+        infos_with_cache: List[AsyncServiceInfo] = []
         for info in infos:
             if info.load_from_cache(zeroconf):
                 infos_with_cache.append(info)

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -513,10 +513,10 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
             question.unicast = True
         self.zeroconf.async_send(out, str(address))
 
-    def _discard_completed_infos_from_needed_types(
+    def _discard_completed_needed_types(
         self, infos: List[AsyncServiceInfo], loaded_from_cache: bool
     ) -> List[AsyncServiceInfo]:
-        """Discard completed infos from needed types."""
+        """Discard needed type that we have info for."""
         zeroconf = self.zeroconf
         incomplete_infos: List[AsyncServiceInfo] = []
         needed_types_by_address = self.needed_types_by_address
@@ -533,9 +533,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         self, infos: List[AsyncServiceInfo], zc_timeout: float
     ) -> bool:
         """Load from cache or send queries."""
-        incomplete_infos = self._discard_completed_infos_from_needed_types(
-            infos, loaded_from_cache=True
-        )
+        incomplete_infos = self._discard_completed_needed_types(infos, True)
         needed_types_by_address = self.needed_types_by_address
 
         # If all services are cached, we are done
@@ -556,9 +554,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
 
         # Check to see if we have all the info we need after
         # sending queries for incomplete infos
-        self._discard_completed_infos_from_needed_types(
-            incomplete_infos, loaded_from_cache=False
-        )
+        self._discard_completed_needed_types(incomplete_infos, False)
 
         # If all services are filled we are done
         return all(not needed for needed in needed_types_by_address.values())

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -22,13 +22,7 @@ from typing import (
     cast,
 )
 
-from zeroconf import (
-    DNSOutgoing,
-    DNSPointer,
-    DNSQuestion,
-    IPVersion,
-    current_time_millis,
-)
+from zeroconf import DNSOutgoing, DNSPointer, DNSQuestion, IPVersion
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 from zeroconf.const import _CLASS_IN, _FLAGS_QR_QUERY, _TYPE_PTR
 
@@ -547,9 +541,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
             out.add_question(question)
         self.zeroconf.async_send(out, str(address))
 
-    def _process_service_infos(
-        self, infos: List[AsyncServiceInfo]
-    ) -> None:
+    def _process_service_infos(self, infos: List[AsyncServiceInfo]) -> None:
         """Process service infos and update self.infos_by_address_type."""
         device_infos: List[AsyncServiceInfo] = []
         infos_by_address_type = self.infos_by_address_type

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -544,13 +544,15 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
 
         # If we have incomplete infos, send queries for them
         if incomplete_infos:
-            requests: List[Awaitable[bool]] = []
             zeroconf = self.zeroconf
-            for host in self.hosts:
-                host_str = str(host)
-                for info in infos:
-                    requests.append(info.async_request(zeroconf, zc_timeout, host_str))
-            await asyncio.gather(*requests)
+            host_strs = [str(host) for host in self.hosts]
+            await asyncio.gather(
+                *(
+                    info.async_request(zeroconf, zc_timeout, host_str)
+                    for host_str in host_strs
+                    for info in infos
+                )
+            )
 
         # Check to see if we have all the info we need after
         # sending queries for incomplete infos

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -502,7 +502,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         self.needed_types_by_address = {host: set(zc_types) for host in hosts}
 
     async def _send_ptr_queries(
-        self, now: float, address: IPv4Address, needed_types: set[str]
+        self, now: float, address: IPv4Address, needed_types: Set[str]
     ) -> Generator[AsyncServiceInfo, None, None]:
         """Send PTR queries."""
         out = DNSOutgoing(_FLAGS_QR_QUERY)

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -559,7 +559,8 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         # Check to see if we have all the info we need after
         # sending queries for incomplete infos. There is no point
         # in sending queries for any types discard_completed_needed_types
-        # returns here because we just sent queries for them.
+        # returns here because we just sent queries for them and they
+        # were not answered.
         self._discard_completed_needed_types(incomplete_infos, False)
 
         # If all services are filled we are done

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -558,7 +558,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
 
         # Check to see if we have all the info we need after
         # sending queries for incomplete infos. There is no point
-        # in sending queries for any types discard_completed_needed_types
+        # in sending queries for any infos discard_completed_needed_types
         # returns here because we just sent queries for them and they
         # were not answered.
         self._discard_completed_needed_types(incomplete_infos, False)

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -644,9 +644,8 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         if await self._load_from_cache_or_send_queries(infos, zc_timeout):
             return self._process_matching_service_infos()
 
-        # Multicast is likely broken or the network is dropping
-        # multicast responses. We will try to send unicast PTR queries
-        # for the missing types.
+        # Multicast is likely broken, the device is offline, or the network is dropping
+        # multicast responses. We will try to send unicast PTR queries for the missing types.
         return await self._lookup_services_and_models_with_ptr_fallback(zc_timeout)
 
     async def _lookup_services_and_models_with_ptr_fallback(

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -644,11 +644,6 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
 
         # Multicast is likely broken, the device is offline, or the network is dropping
         # multicast responses. We will try to send unicast PTR queries for the missing types.
-        return await self._lookup_services_and_models_with_ptr_fallback(zc_timeout)
-
-    async def _lookup_services_and_models_with_ptr_fallback(
-        self, zc_timeout: float
-    ) -> Tuple[Dict[IPv4Address, List[AsyncServiceInfo]], Dict[str, str]]:
         # Send PTR queries for missing types. This is fallback
         # in the event the network is dropping multicast responses
         infos_by_address_type = self.infos_by_address_type

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -492,10 +492,11 @@ class ZeroconfMulticastScanner(ZeroconfScanner):
         """Lookup services and aggregate them by address."""
         infos = self._build_service_info_queries()
         now = current_time_millis()
+        zeroconf = self.zeroconf
         requests: List[Awaitable[bool]] = [
-            info.async_request(self.zeroconf, zc_timeout)
+            info.async_request(zeroconf, zc_timeout)
             for info in infos
-            if not info.load_from_cache(self.zeroconf, now)
+            if not info.load_from_cache(zeroconf, now)
         ]
         if requests:
             await asyncio.gather(*requests)

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -527,7 +527,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
 
     def _send_ptr_queries(
         self, address: IPv4Address, needed_types: Set[str]
-    ) -> Generator[AsyncServiceInfo, None, None]:
+    ) -> None:
         """Send PTR queries."""
         out = DNSOutgoing(_FLAGS_QR_QUERY)
         # Note that the multicast flag here is True even though we are sending

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -501,7 +501,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         zc_types = (f"{type_}." for type_ in (SLEEP_PROXY, *self._services))
         self.needed_types_by_address = {host: set(zc_types) for host in hosts}
 
-    async def _send_ptr_queries(
+    def _send_ptr_queries(
         self, now: float, address: IPv4Address, needed_types: Set[str]
     ) -> Generator[AsyncServiceInfo, None, None]:
         """Send PTR queries."""

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -525,9 +525,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
             IPv4Address, dict[str, Optional[AsyncServiceInfo]]
         ] = {host: {f"{type_}.": None for type_ in self._services} for host in hosts}
 
-    def _send_ptr_queries(
-        self, address: IPv4Address, needed_types: List[str]
-    ) -> None:
+    def _send_ptr_queries(self, address: IPv4Address, needed_types: List[str]) -> None:
         """Send PTR queries."""
         out = DNSOutgoing(_FLAGS_QR_QUERY)
         # Note that the multicast flag here is True even though we are sending

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -625,10 +625,9 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         if await self._load_from_cache_or_send_queries(infos, zc_timeout):
             return self._process_matching_service_infos()
 
-        # Multicast is likely broken, the device is offline, or the network is dropping
-        # multicast responses. We will try to send unicast PTR queries for the missing types.
-        # Send PTR queries for missing types. This is fallback
-        # in the event the network is dropping multicast responses
+        # Multicast is likely broken, the device is offline,
+        # or the network is dropping multicast responses.
+        # We will try to send unicast PTR queries for the missing types.
         infos_by_address_type = self.infos_by_address_type
         for host in self.hosts:
             # We do not send queries for sleep proxy because
@@ -640,7 +639,8 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
                 if info is None and type_ != SLEEP_PROXY_TYPE
             ]:
                 _LOGGER.debug(
-                    "%s: Multicast is broken or device offline, trying unicast PTR queries for %s",
+                    "%s: Multicast is broken or device offline, "
+                    "trying unicast PTR queries for %s",
                     host,
                     needed_types,
                 )

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -526,12 +526,9 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         hosts: Optional[List[IPv4Address]] = None,
     ) -> None:
         """Initialize a new scanner."""
-        _LOGGER.error("ZeroconfUnicastScanner hosts: %s", hosts)
         super().__init__(aiozc, hosts)
         hosts = self.hosts
-        #
         # Once info_by_address_type is filled in, we are done.
-        #
         self.infos_by_address_type: Dict[
             IPv4Address, dict[str, Optional[AsyncServiceInfo]]
         ] = {host: {f"{type_}.": None for type_ in self._services} for host in hosts}

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -536,11 +536,10 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         incomplete_infos = self._discard_completed_infos_from_needed_types(
             infos, loaded_from_cache=True
         )
+        needed_types_by_address = self.needed_types_by_address
 
         # If all services are cached, we are done
-        if all(
-            not needed_types for needed_types in self.needed_types_by_address.values()
-        ):
+        if all(not needed for needed in needed_types_by_address.values()):
             return True
 
         # If we have incomplete infos, send queries for them
@@ -560,9 +559,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         )
 
         # If all services are filled we are done
-        return not all(
-            not needed_types for needed_types in self.needed_types_by_address.values()
-        )
+        return all(not needed for needed in needed_types_by_address.values())
 
     async def _lookup_services_and_models(
         self, zc_timeout: float

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -22,9 +22,9 @@ from typing import (
     cast,
 )
 
-from zeroconf import DNSPointer, IPVersion, DNSOutgoing, const, current_time_millis
+from zeroconf import DNSOutgoing, DNSPointer, IPVersion, const, current_time_millis
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
-from zeroconf.const import _CLASS_IN, _TYPE_PTR, _FLAGS_QR_QUERY
+from zeroconf.const import _CLASS_IN, _FLAGS_QR_QUERY, _TYPE_PTR
 
 from pyatv import conf
 from pyatv.const import DeviceModel, Protocol
@@ -517,7 +517,7 @@ class ZeroconfUnicastScanner(ZeroconfScanner):
         self, infos: List[AsyncServiceInfo], loaded_from_cache: bool
     ) -> List[AsyncServiceInfo]:
         """Discard needed type that we have info for.
-        
+
         Returns a list of incomplete infos that we still need to
         send queries for.
         """

--- a/pyatv/core/scan.py
+++ b/pyatv/core/scan.py
@@ -356,11 +356,9 @@ class ZeroconfScanner(BaseScanner):
 
     def _set_or_get_address_to_device_name(
         self, address: IPv4Address, info: AsyncServiceInfo
-    ) -> str | None:
+    ) -> Optional[str]:
         """Get and cache address to device name mapping."""
         address_to_device_name = self.address_to_device_name
-        device_name_to_address = self.device_name_to_address
-
         if cached_name := address_to_device_name.get(address):
             return cached_name
 
@@ -369,7 +367,7 @@ class ZeroconfScanner(BaseScanner):
 
         if device_name := self._device_info_name[service_type](name):
             address_to_device_name[address] = device_name
-            device_name_to_address[device_name] = address
+            self.device_name_to_address[device_name] = address
             return device_name
 
         return None

--- a/tests/core/test_scan.py
+++ b/tests/core/test_scan.py
@@ -6,10 +6,10 @@ from unittest.mock import patch
 import pytest
 from zeroconf import (
     DNSAddress,
+    DNSOutgoing,
     DNSPointer,
     DNSService,
     DNSText,
-    DNSOutgoing,
     ServiceListener,
     Zeroconf,
     const,

--- a/tests/core/test_scan.py
+++ b/tests/core/test_scan.py
@@ -380,12 +380,13 @@ async def test_scan_with_zeroconf_unicast_not_found():
         # Called with host argument
         assert call[1][2] == "127.0.0.1"
     calls = mock_async_send.mock_calls
-    assert len(calls) == 2
-    # We should send a PTR query as a fallback
-    second_send = calls[-1][1]
-    target = second_send[1]
+    assert len(calls) >= 1
+    # We should send a PTR query as a fallback to unicast
+    # which has a target of 127.0.0.1
+    last_call = calls[-1][1]
+    target = last_call[1]
     assert target == "127.0.0.1"
-    dns_outgoing: DNSOutgoing = second_send[0]
+    dns_outgoing: DNSOutgoing = last_call[0]
     assert len(dns_outgoing.questions) == 1
     question = dns_outgoing.questions[0]
     assert question.name == "_device-info._tcp.local."

--- a/tests/core/test_scan.py
+++ b/tests/core/test_scan.py
@@ -9,6 +9,7 @@ from zeroconf import (
     DNSPointer,
     DNSService,
     DNSText,
+    DNSOutgoing,
     ServiceListener,
     Zeroconf,
     const,
@@ -28,6 +29,7 @@ ALL_MDNS_SERVICES = [
     "_mediaremotetv._tcp.local.",
     "_companion-link._tcp.local.",
     "_airport._tcp.local.",
+    "_device_info._tcp.local.",
     "_sleep-proxy._udp.local.",
     "_touch-able._tcp.local.",
     "_appletv-v2._tcp.local.",
@@ -369,12 +371,25 @@ async def test_scan_with_zeroconf_multicast_not_found():
 async def test_scan_with_zeroconf_unicast_not_found():
     aiozc, browser = await _create_zc_with_cache(PTR_RECORDS_ONLY)
     loop = asyncio.get_event_loop()
-    with patch("pyatv.core.scan.AsyncServiceInfo.async_request") as mock_async_request:
+    with patch(
+        "pyatv.core.scan.AsyncServiceInfo.async_request"
+    ) as mock_async_request, patch("zeroconf.Zeroconf.async_send") as mock_async_send:
         results = await scan(loop, timeout=0, aiozc=aiozc, hosts=["127.0.0.1"])
     assert mock_async_request.mock_calls
     for call in mock_async_request.mock_calls:
         # Called with host argument
         assert call[1][2] == "127.0.0.1"
+    calls = mock_async_send.mock_calls
+    assert len(calls) == 2
+    # We should send a PTR query as a fallback
+    second_send = calls[-1][1]
+    target = second_send[1]
+    assert target == "127.0.0.1"
+    dns_outgoing: DNSOutgoing = second_send[0]
+    assert len(dns_outgoing.questions) == 1
+    question = dns_outgoing.questions[0]
+    assert question.name == "_device-info._tcp.local."
+    assert question.unicast is True
     assert not results
     await browser.async_cancel()
     await aiozc.async_close()


### PR DESCRIPTION
fixes https://github.com/home-assistant/core/issues/95768

I came up with a pretty good way to test this.  I moved my sonos roam to the edge of wifi range to the point were it had significant packet loss and removed the filters in HA. I'm now able to add the roam when the wifi has significant packet loss. This is effectively the same problem as why Passive Observation Of Failures (POOF) is unviable for setups where the responders are on Wi-Fi

By design we only send one unicast packet to do the fallback query to minimize the network and processing impact.  If the network is flakey Home Assistant is going to retry setup again anyways and the next attempt is likely to be successful. 

This is a bit complex because the unicast scanner takes a list of hosts so we have to send to handle that case even though in practice we only ever send to one. We may need this behavior in the future so I didn't remove it and make it a single host only.