### PR TITLE
Release 0.13.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,26 @@
 # CHANGES
 
+## 0.13.4 Krusty (2023-08-06)
+
+@bdraco cleaned up in aisle four and made scanning more
+robust in shaky networks, thanks!
+
+**Changes:**
+
+*Other:*
+
+```
+17d130a Fallback to sending unicast PTR queries when multicast is broken or packets are being dropped (#2122)
+b64bdf9 gha: Remove log workflow (#2120)
+```
+
+**All changes:**
+
+```
+17d130a Fallback to sending unicast PTR queries when multicast is broken or packets are being dropped (#2122)
+b64bdf9 gha: Remove log workflow (#2120)
+```
+
 ## 0.13.3 Joe (2023-08-03)
 
 Time for a somewhat minor fix release:

--- a/docs/api/pyatv.html
+++ b/docs/api/pyatv.html
@@ -35,7 +35,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Main routines for interacting with an Apple TV.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L1-L163" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L1-L164" class="git-link">Browse git</a></div>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -78,7 +78,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Connect to a device based on a configuration.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L90-L139" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L91-L140" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.pair">
 <code class="name flex">
@@ -87,7 +87,7 @@ link_group: api
 </dt>
 <dd>
 <section class="desc"><p>Pair a protocol for an Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L142-L163" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L143-L164" class="git-link">Browse git</a></div>
 </dd>
 <dt id="pyatv.scan">
 <code class="name flex">
@@ -98,7 +98,7 @@ link_group: api
 <section class="desc"><p>Scan for Apple TVs on network and return their configurations.</p>
 <p>When passing in an aiozc instance, a ServiceBrowser must
 be running for all the types in the protocols that being scanned for.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L30-L87" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/__init__.py#L31-L88" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 </section>

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 MAJOR_VERSION = "0"
 MINOR_VERSION = "13"
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
## 0.13.4 Krusty (2023-08-06)

@bdraco cleaned up in aisle four and made scanning more
robust in shaky networks, thanks!

**Changes:**

*Other:*

```
17d130a Fallback to sending unicast PTR queries when multicast is broken or packets are being dropped (#2122)
b64bdf9 gha: Remove log workflow (#2120)
```

**All changes:**

```
17d130a Fallback to sending unicast PTR queries when multicast is broken or packets are being dropped (#2122)
b64bdf9 gha: Remove log workflow (#2120)
```

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2127"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

