### PR TITLE
Update python dependency and enable Dependabot for Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
   - postlund
   labels:
   - dependencies
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 3
+  reviewers:
+    - postlund
+  assignees:
+    - postlund
+  labels:
+    - dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.7-alpine
+FROM python:3.11.4-alpine
 ARG VERSION
 
 WORKDIR .


### PR DESCRIPTION
I use the pyatv Docker container for building the [pyatv-mqtt-bridge](https://github.com/sebbo2002/pyatv-mqtt-bridge) container. Due to that, I noticed that the Alpine image as well as the Python version used for the pyatv image is comparatively old.

I [updated the Python base image from 3.9.7 to 3.11.4](https://github.com/postlund/pyatv/commit/c3c2dfdbbb6c025acdc42cefced706724c2238c1) and also [enabled Dependabot for the Dockerfile](https://github.com/postlund/pyatv/commit/04d6d985dc847bf2d5db29950e69f99bd6eb1b21), so that the base image is kept up to date. Hope it works, I don't know anything about Python so I didn't even try it.

Thanks 👋🏼