### PR TITLE
storage: Add FileStorage.default_storage

### DIFF
--- a/docs/api/pyatv.storage.file_storage.html
+++ b/docs/api/pyatv.storage.file_storage.html
@@ -21,6 +21,9 @@ This module has additional documentation
 <ul>
 <li>
 <h4><code><a title="pyatv.storage.file_storage.FileStorage" href="#pyatv.storage.file_storage.FileStorage">FileStorage</a></code></h4>
+<ul class="">
+<li><code><a title="pyatv.storage.file_storage.FileStorage.default_storage" href="#pyatv.storage.file_storage.FileStorage.default_storage">default_storage</a></code></li>
+</ul>
 </li>
 </ul>
 </li>
@@ -32,7 +35,7 @@ This module has additional documentation
 </header>
 <section id="section-intro">
 <p>File based storage module.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L1-L54" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L1-L68" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -50,13 +53,30 @@ This module has additional documentation
 <dd>
 <section class="desc"><p>Storage module storing settings in a file.</p>
 <p>Initialize a new FileStorage instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L14-L54" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L15-L68" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="pyatv.storage.AbstractStorage" href="#pyatv.storage.AbstractStorage">AbstractStorage</a></li>
 <li><a title="pyatv.interface.Storage" href="../../interface#pyatv.interface.Storage">Storage</a></li>
 <li>abc.ABC</li>
 </ul>
+<h3>Static methods</h3>
+<dl>
+<dt id="pyatv.storage.file_storage.FileStorage.default_storage">
+<code class="name flex">
+<span>def <span class="ident">default_storage</span></span>(<span>loop: asyncio.events.AbstractEventLoop) -> <a title="pyatv.storage.file_storage.FileStorage" href="#pyatv.storage.file_storage.FileStorage">FileStorage</a></span>
+</code>
+</dt>
+<dd>
+<section class="desc"><p>Return file storage with default path.</p>
+<p>This corresponds to the default file storage path that pyatv uses internally,
+e.g. in atvremote. Use this if you want to hook into that storage in your own
+applications.</p>
+<p>The path used for this file is $HOME/.pyatv.conf (C:\Users\<user>.pyatv.conf
+on Windows).</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L24-L35" class="git-link">Browse git</a></div>
+</dd>
+</dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
 <li><code><b><a title="pyatv.storage.AbstractStorage" href="#pyatv.storage.AbstractStorage">AbstractStorage</a></b></code>:

--- a/docs/development/storage.md
+++ b/docs/development/storage.md
@@ -159,6 +159,20 @@ await storage.save()
 Storages are supposed to keep track of changes and only save changes if something has actually
 changed.
 
+### Default File Storage
+
+When using tools bundled with pyatv, e.g. `atvremote` or `atvscript`,
+{% include api i="storage/file_storage.FileStorage" %} is used with the file `$HOME/.pyatv.conf`.
+You can tap into this storage with your own applications, thus sharing credentials with pyatv.
+There is a convenience method called
+{% include api i="storage/file_storage.FileStorage.default_storage" %} that is recommended to use
+as it is platform agnostic:
+
+```python
+loop = asyncio.get_event_loop()
+storage = FileStorage.default_storage(loop)
+await storage.load()
+```
 ## Changing Settings
 
 As stated in [Storage Guidelines](#storage-guidelines), some settings are only used when connecting

--- a/examples/storage.py
+++ b/examples/storage.py
@@ -1,7 +1,6 @@
 """Simple example using file based storage."""
 
 import asyncio
-import os
 import sys
 
 from pyatv import connect, scan
@@ -13,7 +12,9 @@ LOOP = asyncio.get_event_loop()
 async def connect_with_storage(host):
     """Connect to a device using a storage."""
     loop = asyncio.get_event_loop()
-    storage = FileStorage(os.path.join(os.environ["HOME"], ".pyatv.conf"), loop)
+
+    # Load the same storage that pyatv uses internally (e.g. in atvremote)
+    storage = FileStorage.default_storage(loop)
     await storage.load()
 
     atvs = await scan(loop, timeout=5, hosts=[host], storage=storage)

--- a/pyatv/scripts/__init__.py
+++ b/pyatv/scripts/__init__.py
@@ -5,7 +5,6 @@ import asyncio
 from ipaddress import ip_address
 import json
 import logging
-import os
 
 from pyatv import const
 from pyatv.interface import Storage
@@ -104,11 +103,10 @@ def create_common_parser() -> argparse.ArgumentParser:
         help="storage backend for settings",
     )
 
-    storage_file = os.path.join(os.environ["HOME"], ".pyatv.conf")
     settings_group.add_argument(
         "--storage-filename",
         type=str,
-        default=storage_file,
+        default="default",  # Corresponds to FileStorage.default_storage()
         help="file used by file storage",
     )
 
@@ -118,6 +116,8 @@ def create_common_parser() -> argparse.ArgumentParser:
 def get_storage(args, loop: asyncio.AbstractEventLoop) -> Storage:
     """Get storage module based on user configuration."""
     if args.storage == "file":
+        if args.storage_filename == "default":
+            return FileStorage.default_storage(loop)
         return FileStorage(args.storage_filename, loop)
     return MemoryStorage()
 

--- a/pyatv/storage/file_storage.py
+++ b/pyatv/storage/file_storage.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import logging
 from os import path
+from pathlib import Path
 
 from pyatv.storage import AbstractStorage, StorageModel
 
@@ -19,6 +20,19 @@ class FileStorage(AbstractStorage):
         super().__init__()
         self._filename = filename
         self._loop = loop
+
+    @staticmethod
+    def default_storage(loop: asyncio.AbstractEventLoop) -> "FileStorage":
+        r"""Return file storage with default path.
+
+        This corresponds to the default file storage path that pyatv uses internally,
+        e.g. in atvremote. Use this if you want to hook into that storage in your own
+        applications.
+
+        The path used for this file is $HOME/.pyatv.conf (C:\Users\<user>\.pyatv.conf
+        on Windows).
+        """
+        return FileStorage(Path.home().joinpath(".pyatv.conf").as_posix(), loop)
 
     async def save(self) -> None:
         """Save settings to active storage."""


### PR DESCRIPTION
This is the default storage used internally by pyatv, but is also open for everyone else to use. There were some issues with paths on Windows, so this solves that as the path is platform agnostic.

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2169"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

