### PR TITLE
atvremote: Fix storage passing to pair

### DIFF
--- a/pyatv/scripts/atvremote.py
+++ b/pyatv/scripts/atvremote.py
@@ -189,7 +189,7 @@ class GlobalCommands:
             )
 
         pairing = await pair(
-            conf, self.args.protocol, self.loop, self.storage, **options
+            conf, self.args.protocol, self.loop, storage=self.storage, **options
         )
 
         try:
@@ -333,7 +333,7 @@ Press ENTER to continue
 
         print("Starting to pair", service.protocol)
 
-        pairing = await pair(conf, service.protocol, self.loop, self.storage)
+        pairing = await pair(conf, service.protocol, self.loop, storage=self.storage)
 
         await pairing.begin()
 


### PR DESCRIPTION
Passed storage as incorrect argument to pair. Not sure how mypy did not catch that.

Relates to #2192

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

