### PR TITLE
raop: Add protocol_version setting

### DIFF
--- a/docs/api/pyatv.settings.html
+++ b/docs/api/pyatv.settings.html
@@ -28,6 +28,14 @@ This module has additional documentation
 </ul>
 </li>
 <li>
+<h4><code><a title="pyatv.settings.AirPlayVersion" href="#pyatv.settings.AirPlayVersion">AirPlayVersion</a></code></h4>
+<ul class="">
+<li><code><a title="pyatv.settings.AirPlayVersion.Auto" href="#pyatv.settings.AirPlayVersion.Auto">Auto</a></code></li>
+<li><code><a title="pyatv.settings.AirPlayVersion.V1" href="#pyatv.settings.AirPlayVersion.V1">V1</a></code></li>
+<li><code><a title="pyatv.settings.AirPlayVersion.V2" href="#pyatv.settings.AirPlayVersion.V2">V2</a></code></li>
+</ul>
+</li>
+<li>
 <h4><code><a title="pyatv.settings.CompanionSettings" href="#pyatv.settings.CompanionSettings">CompanionSettings</a></code></h4>
 <ul class="">
 <li><code><a title="pyatv.settings.CompanionSettings.credentials" href="#pyatv.settings.CompanionSettings.credentials">credentials</a></code></li>
@@ -72,11 +80,12 @@ This module has additional documentation
 </li>
 <li>
 <h4><code><a title="pyatv.settings.RaopSettings" href="#pyatv.settings.RaopSettings">RaopSettings</a></code></h4>
-<ul class="">
+<ul class="two-column">
 <li><code><a title="pyatv.settings.RaopSettings.control_port" href="#pyatv.settings.RaopSettings.control_port">control_port</a></code></li>
 <li><code><a title="pyatv.settings.RaopSettings.credentials" href="#pyatv.settings.RaopSettings.credentials">credentials</a></code></li>
 <li><code><a title="pyatv.settings.RaopSettings.identifier" href="#pyatv.settings.RaopSettings.identifier">identifier</a></code></li>
 <li><code><a title="pyatv.settings.RaopSettings.password" href="#pyatv.settings.RaopSettings.password">password</a></code></li>
+<li><code><a title="pyatv.settings.RaopSettings.protocol_version" href="#pyatv.settings.RaopSettings.protocol_version">protocol_version</a></code></li>
 <li><code><a title="pyatv.settings.RaopSettings.timing_port" href="#pyatv.settings.RaopSettings.timing_port">timing_port</a></code></li>
 </ul>
 </li>
@@ -97,7 +106,7 @@ This module has additional documentation
 </header>
 <section id="section-intro">
 <p>Settings for configuring pyatv.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L1-L113" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L1-L134" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -119,7 +128,7 @@ This module has additional documentation
 validated to form a valid model.</p>
 <p><code>__init__</code> uses <code>__pydantic_self__</code> instead of the more common <code>self</code> for the first arg to
 allow <code>self</code> as a field name.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L50-L55" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L64-L69" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.main.BaseModel</li>
@@ -140,6 +149,34 @@ allow <code>self</code> as a field name.</p></section>
 </dd>
 </dl>
 </dd>
+<dt id="pyatv.settings.AirPlayVersion"><code class="flex name class">
+<span>class <span class="ident">AirPlayVersion</span></span>
+<span>(</span><span>value, names=None, *, module=None, qualname=None, type=None, start=1)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>AirPlay version to use.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L41-L46" class="git-link">Browse git</a></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.str</li>
+<li>enum.Enum</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="pyatv.settings.AirPlayVersion.Auto"><code class="name">var <span class="ident">Auto</span> = auto</code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
+<dt id="pyatv.settings.AirPlayVersion.V1"><code class="name">var <span class="ident">V1</span> = 1</code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
+<dt id="pyatv.settings.AirPlayVersion.V2"><code class="name">var <span class="ident">V2</span> = 2</code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
+</dl>
+</dd>
 <dt id="pyatv.settings.CompanionSettings"><code class="flex name class">
 <span>class <span class="ident">CompanionSettings</span></span>
 <span>(</span><span>**data: Any)</span>
@@ -151,7 +188,7 @@ allow <code>self</code> as a field name.</p></section>
 validated to form a valid model.</p>
 <p><code>__init__</code> uses <code>__pydantic_self__</code> instead of the more common <code>self</code> for the first arg to
 allow <code>self</code> as a field name.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L58-L62" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L72-L76" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.main.BaseModel</li>
@@ -179,7 +216,7 @@ allow <code>self</code> as a field name.</p></section>
 validated to form a valid model.</p>
 <p><code>__init__</code> uses <code>__pydantic_self__</code> instead of the more common <code>self</code> for the first arg to
 allow <code>self</code> as a field name.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L65-L69" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L79-L83" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.main.BaseModel</li>
@@ -207,7 +244,7 @@ allow <code>self</code> as a field name.</p></section>
 validated to form a valid model.</p>
 <p><code>__init__</code> uses <code>__pydantic_self__</code> instead of the more common <code>self</code> for the first arg to
 allow <code>self</code> as a field name.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L38-L47" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L52-L61" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.main.BaseModel</li>
@@ -255,7 +292,7 @@ allow <code>self</code> as a field name.</p></section>
 validated to form a valid model.</p>
 <p><code>__init__</code> uses <code>__pydantic_self__</code> instead of the more common <code>self</code> for the first arg to
 allow <code>self</code> as a field name.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L72-L76" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L86-L90" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.main.BaseModel</li>
@@ -283,7 +320,7 @@ allow <code>self</code> as a field name.</p></section>
 validated to form a valid model.</p>
 <p><code>__init__</code> uses <code>__pydantic_self__</code> instead of the more common <code>self</code> for the first arg to
 allow <code>self</code> as a field name.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L99-L106" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L120-L127" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.main.BaseModel</li>
@@ -323,7 +360,7 @@ allow <code>self</code> as a field name.</p></section>
 validated to form a valid model.</p>
 <p><code>__init__</code> uses <code>__pydantic_self__</code> instead of the more common <code>self</code> for the first arg to
 allow <code>self</code> as a field name.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L79-L96" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L93-L117" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.main.BaseModel</li>
@@ -347,6 +384,12 @@ allow <code>self</code> as a field name.</p></section>
 <dd>
 <section class="desc"></section>
 </dd>
+<dt id="pyatv.settings.RaopSettings.protocol_version"><code class="name">var <span class="ident">protocol_version</span> -> <a title="pyatv.settings.AirPlayVersion" href="#pyatv.settings.AirPlayVersion">AirPlayVersion</a> = auto</code></dt>
+<dd>
+<section class="desc"><p>Protocol version used.</p>
+<p>In reality this corresponds to the AirPlay version used. Set to 0 for automatic
+mode (recommended), or 1 or 2 for AirPlay 1 or 2 respectively.</p></section>
+</dd>
 <dt id="pyatv.settings.RaopSettings.timing_port"><code class="name">var <span class="ident">timing_port</span> -> int = 0</code></dt>
 <dd>
 <section class="desc"><p>Server side (UDP) port used by timing server.</p>
@@ -365,7 +408,7 @@ allow <code>self</code> as a field name.</p></section>
 validated to form a valid model.</p>
 <p><code>__init__</code> uses <code>__pydantic_self__</code> instead of the more common <code>self</code> for the first arg to
 allow <code>self</code> as a field name.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L109-L113" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L130-L134" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic_settings.main.BaseSettings</li>

--- a/docs/documentation/atvremote.md
+++ b/docs/documentation/atvremote.md
@@ -389,6 +389,35 @@ like this:
 $ atvremote -s 10.0.10.84 unset_setting=protocols.raop.password
 ```
 
+As `atvremote` tries to interpolate the correct data type of input (e.g. it
+will try to interpret "1" as an integer), you might end up with issues if a
+setting expects a number as a string. One example is this:
+
+```raw
+protocols.raop.protocol_version = auto (AirPlayVersion)
+```
+
+`AirPlayVersion` can be either auto, 1 or 2. Trying to change to 1 yields
+an error:
+
+```raw
+$ atvremote -s 10.0.10.84 change_setting=protocols.raop.protocol_version,1
+Traceback (most recent call last):
+...
+protocol_version
+  Input should be a valid string [type=string_type, input_value=1, input_type=int]
+    For further information visit https://errors.pydantic.dev/2.1/v/string_type
+```
+
+It expects a string but `atvremote` automatically converts 1 to an integer. To
+circumvent this, you can force an argument to be treated as a string like this:
+
+```raw
+$ atvremote -s 10.0.10.81 'change_setting=protocols.raop.protocol_version,"1"'
+```
+
+
+
 ## Removing Settings
 
 To remove all settings for a device (reverting to defaults), run:

--- a/pyatv/protocols/raop/__init__.py
+++ b/pyatv/protocols/raop/__init__.py
@@ -44,10 +44,7 @@ from pyatv.interface import (
     Stream,
 )
 from pyatv.protocols.airplay.auth import extract_credentials
-from pyatv.protocols.airplay.pairing import (
-    AirPlayPairingHandler,
-    get_preferred_auth_type,
-)
+from pyatv.protocols.airplay.pairing import AirPlayPairingHandler
 from pyatv.protocols.airplay.utils import (
     AirPlayMajorVersion,
     dbfs_to_pct,
@@ -147,7 +144,9 @@ class RaopPlaybackManager:
         )
         self._rtsp = RtspSession(self._connection)
 
-        protocol_version = get_protocol_version(service)
+        protocol_version = get_protocol_version(
+            service, self.core.settings.protocols.raop.protocol_version
+        )
         _LOGGER.debug("Using AirPlay version %s", protocol_version)
 
         protocol_class = (
@@ -592,4 +591,10 @@ def setup(  # pylint: disable=too-many-locals
 
 def pair(core: Core, **kwargs) -> PairingHandler:
     """Return pairing handler for protocol."""
-    return AirPlayPairingHandler(core, get_preferred_auth_type(core.service), **kwargs)
+    return AirPlayPairingHandler(
+        core,
+        get_protocol_version(
+            core.service, core.settings.protocols.raop.protocol_version
+        ),
+        **kwargs,
+    )

--- a/pyatv/scripts/atvremote.py
+++ b/pyatv/scripts/atvremote.py
@@ -814,6 +814,10 @@ def _extract_command_with_args(cmd):
     """
 
     def _typeparse(value):
+        # Special case where input is forced to be treated as a string by quoting
+        if isinstance(value, str) and value.startswith('"') and value.endswith('"'):
+            return value[1:-1]
+
         try:
             return int(value)
         except ValueError:

--- a/pyatv/settings.py
+++ b/pyatv/settings.py
@@ -1,4 +1,5 @@
 """Settings for configuring pyatv."""
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -33,6 +34,19 @@ DEFAULT_MODEL = "iPhone10,6"
 DEFAULT_OS_NAME = "iPhone OS"
 DEFAULT_OS_BUILD = "18G82"
 DEFAULT_OS_VERSION = "14.7.1"
+
+# pylint: disable=invalid-name
+
+
+class AirPlayVersion(str, Enum):
+    """AirPlay version to use."""
+
+    Auto = "auto"
+    V1 = "1"
+    V2 = "2"
+
+
+# pylint: enable=invalid-name
 
 
 class InfoSettings(BaseModel, extra="ignore"):  # type: ignore[call-arg]
@@ -82,6 +96,13 @@ class RaopSettings(BaseModel, extra="ignore"):  # type: ignore[call-arg]
     identifier: Optional[str] = None
     credentials: Optional[str] = None
     password: Optional[str] = None
+
+    protocol_version: AirPlayVersion = AirPlayVersion.Auto
+    """Protocol version used.
+
+    In reality this corresponds to the AirPlay version used. Set to 0 for automatic
+    mode (recommended), or 1 or 2 for AirPlay 1 or 2 respectively.
+    """
 
     timing_port: int = 0
     """Server side (UDP) port used by timing server.


### PR DESCRIPTION
The setting `protocols.raop.protocol_version` can be set to auto, 1 or 2 to force a specific AirPlay version instead of always falling back to automatic mode.

Relates to #2204

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2206"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

