### PR TITLE
Release 0.14.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,74 @@
 # CHANGES
 
+## 0.14.1 Marge (2023-09-27)
+
+Minor release coming up today:
+
+* Fix Companion credentials not being saved when pairing
+* Actually use storage in the wizard (atvremote)
+* Add FileStorage.default_storage() to get the same storage
+  as used by scripts shipped with pyatv (i.e. you can share
+  credentials with your applications)
+* Add setting to force AirPlay version to use with RAOP
+* Add settings for RAOP control and timing ports
+
+**Changes:**
+
+*Protocol: Companion:*
+
+```
+e551954 companion: Fix credentials not saved
+```
+
+*Protocol: RAOP:*
+
+```
+c17f304 raop: Add protocol_version setting
+391be8b raop: Add settings for timing and control ports
+```
+
+*Script: atvremote:*
+
+```
+fa2f7b1 atvremote: Fix storage passing to pair
+```
+
+*Other:*
+
+```
+fd7135b tests: Add test for atvremote wizard
+e8a812d tests: Migrate scripts tests to pytest
+6704359 docs: Add minor change template
+74d2de5 storage: Add FileStorage.default_storage
+621adff docs: Some updates to README.md
+f13a353 docs: More link fixes
+d394708 storage: Use pydantic-extra-types for MAC
+```
+
+**All changes:**
+
+```
+e551954 companion: Fix credentials not saved
+1c4b4d3 build(deps): Bump types-protobuf in /requirements
+91fdc71 build(deps): Bump zeroconf from 0.108.0 to 0.112.0 in /requirements
+c17f304 raop: Add protocol_version setting
+fd7135b tests: Add test for atvremote wizard
+e8a812d tests: Migrate scripts tests to pytest
+fa2f7b1 atvremote: Fix storage passing to pair
+95d7d54 build(deps): Bump deepdiff from 6.4.1 to 6.5.0 in /requirements
+6704359 docs: Add minor change template
+712f105 build(deps): Bump zeroconf from 0.97.0 to 0.108.0 in /requirements
+46d50f0 build(deps): Bump black from 23.7.0 to 23.9.1 in /requirements
+391be8b raop: Add settings for timing and control ports
+2808c5d build(deps): Bump pytest from 7.4.1 to 7.4.2 in /requirements
+d426ae8 build(deps): Bump protobuf from 4.24.2 to 4.24.3 in /requirements
+01e4cc0 build(deps): Bump pytest-aiohttp from 1.0.4 to 1.0.5 in /requirements
+74d2de5 storage: Add FileStorage.default_storage
+621adff docs: Some updates to README.md
+f13a353 docs: More link fixes
+d394708 storage: Use pydantic-extra-types for MAC
+```
+
 ## 0.14.0 Lisa (2023-09-04)
 
 Finally time for a new release and this (despite the few number

--- a/docs/_includes/atvremote_scan
+++ b/docs/_includes/atvremote_scan
@@ -1,0 +1,32 @@
+```raw
+$ atvremote acan
+Scan Results
+========================================
+       Name: Living Room
+   Model/SW: Apple TV 4K, tvOS 16.6 build 20M73
+    Address: 10.0.0.5
+        MAC: AA:BB:CC:DD:EE:FF
+ Deep Sleep: True
+Identifiers:
+ - 01234567-89AB-CDEF-0123-4567890ABCDE
+ - AA:BB:CC:DD:EE:FF
+ - 01234567-89AB-CDEF-0123-AAAAAAAAAAAA
+ - AABBCCDDEEFF
+Services:
+ - Protocol: Companion, Port: 49153, Credentials:None, Requires Password: False, Password: None, Pairing: Mandatory
+ - Protocol: AirPlay, Port: 7000, Credentials: None, Requires Password: False, Password: None, Pairing: Mandatory
+ - Protocol: MRP, Port: 49154, Credentials: None, Requires Password: False, Password: None, Pairing: NotNeeded (Disabled)
+ - Protocol: RAOP, Port: 7000, Credentials: None, Requires Password: False, Password: None, Pairing: Mandatory
+
+       Name: Pierre's AirPort Express
+   Model/SW: AirPort Express (gen 2), AirPortOS 7.8.1
+    Address: 10.0.0.6
+        MAC: BB:BB:BB:BB:BB:BB
+ Deep Sleep: False
+Identifiers:
+ - BB:BB:BB:BB:BB:BB
+ - BBBBBBBBBBBB
+Services:
+ - Protocol: AirPlay, Port: 7000, Credentials: None, Requires Password: False, Password: None, Pairing: NotNeeded
+ - Protocol: RAOP, Port: 7000, Credentials: None, Requires Password: False, Password: None, Pairing: NotNeeded
+```

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 MAJOR_VERSION = "0"
 MINOR_VERSION = "14"
-PATCH_VERSION = "0"
+PATCH_VERSION = "1"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
## 0.14.1 Marge (2023-09-27)

Minor release coming up today:

* Fix Companion credentials not being saved when pairing
* Actually use storage in the wizard (atvremote)
* Add FileStorage.default_storage() to get the same storage
  as used by scripts shipped with pyatv (i.e. you can share
  credentials with your applications)
* Add setting to force AirPlay version to use with RAOP
* Add settings for RAOP control and timing ports

**Changes:**

*Protocol: Companion:*

```
e551954 companion: Fix credentials not saved
```

*Protocol: RAOP:*

```
c17f304 raop: Add protocol_version setting
391be8b raop: Add settings for timing and control ports
```

*Script: atvremote:*

```
fa2f7b1 atvremote: Fix storage passing to pair
```

*Other:*

```
fd7135b tests: Add test for atvremote wizard
e8a812d tests: Migrate scripts tests to pytest
6704359 docs: Add minor change template
74d2de5 storage: Add FileStorage.default_storage
621adff docs: Some updates to README.md
f13a353 docs: More link fixes
d394708 storage: Use pydantic-extra-types for MAC
```

**All changes:**

```
e551954 companion: Fix credentials not saved
1c4b4d3 build(deps): Bump types-protobuf in /requirements
91fdc71 build(deps): Bump zeroconf from 0.108.0 to 0.112.0 in /requirements
c17f304 raop: Add protocol_version setting
fd7135b tests: Add test for atvremote wizard
e8a812d tests: Migrate scripts tests to pytest
fa2f7b1 atvremote: Fix storage passing to pair
95d7d54 build(deps): Bump deepdiff from 6.4.1 to 6.5.0 in /requirements
6704359 docs: Add minor change template
712f105 build(deps): Bump zeroconf from 0.97.0 to 0.108.0 in /requirements
46d50f0 build(deps): Bump black from 23.7.0 to 23.9.1 in /requirements
391be8b raop: Add settings for timing and control ports
2808c5d build(deps): Bump pytest from 7.4.1 to 7.4.2 in /requirements
d426ae8 build(deps): Bump protobuf from 4.24.2 to 4.24.3 in /requirements
01e4cc0 build(deps): Bump pytest-aiohttp from 1.0.4 to 1.0.5 in /requirements
74d2de5 storage: Add FileStorage.default_storage
621adff docs: Some updates to README.md
f13a353 docs: More link fixes
d394708 storage: Use pydantic-extra-types for MAC
```

<a href="https://gitpod.io/#https://github.com/postlund/pyatv/pull/2219"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

