### PR TITLE
api: Use error_handler when connecting

### DIFF
--- a/pyatv/protocols/mrp/protocol.py
+++ b/pyatv/protocols/mrp/protocol.py
@@ -18,6 +18,7 @@ from pyatv.protocols.mrp import messages, protobuf
 from pyatv.protocols.mrp.auth import MrpPairVerifyProcedure
 from pyatv.protocols.mrp.connection import AbstractMrpConnection
 from pyatv.settings import InfoSettings
+from pyatv.support import error_handler
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -155,7 +156,7 @@ class MrpProtocol(MessageDispatcher[int, protobuf.ProtocolMessage]):
             if skip_initial_messages:
                 return
 
-            await self._enable_encryption()
+            await error_handler(self._enable_encryption, exceptions.AuthenticationError)
 
             # This should be the first message sent after encryption has
             # been enabled
@@ -215,14 +216,11 @@ class MrpProtocol(MessageDispatcher[int, protobuf.ProtocolMessage]):
         credentials = parse_credentials(self.service.credentials)
         pair_verifier = MrpPairVerifyProcedure(self, self.srp, credentials)
 
-        try:
-            await pair_verifier.verify_credentials()
-            output_key, input_key = pair_verifier.encryption_keys(
-                SRP_SALT, SRP_OUTPUT_INFO, SRP_INPUT_INFO
-            )
-            self.connection.enable_encryption(output_key, input_key)
-        except Exception as ex:
-            raise exceptions.AuthenticationError(str(ex)) from ex
+        await pair_verifier.verify_credentials()
+        output_key, input_key = pair_verifier.encryption_keys(
+            SRP_SALT, SRP_OUTPUT_INFO, SRP_INPUT_INFO
+        )
+        self.connection.enable_encryption(output_key, input_key)
 
     async def send(self, message: protobuf.ProtocolMessage) -> None:
         """Send a message and expect no response."""

--- a/pyatv/support/__init__.py
+++ b/pyatv/support/__init__.py
@@ -71,9 +71,7 @@ async def error_handler(func, fallback, *args, **kwargs):
         return await func(*args, **kwargs)
     except (OSError, asyncio.TimeoutError) as ex:
         raise exceptions.ConnectionFailedError(str(ex)) from ex
-    except exceptions.BackOffError:
-        raise
-    except exceptions.NoCredentialsError:
+    except (exceptions.BackOffError, exceptions.NoCredentialsError):
         raise
     except Exception as ex:
         raise fallback(str(ex)) from ex


### PR DESCRIPTION
Use error_handler when connecting to pass-through a few exceptions, to enaure they are not hidden behind an AuthenticationError. This helps a lot in Home Assistant currently.

Relates to #2242