### PR TITLE
Wrap coroutines passed to asyncio.wait with create_tasks because asyncio.wait does not support passing coroutines since python 3.11

### DIFF
--- a/pyatv/scripts/atvscript.py
+++ b/pyatv/scripts/atvscript.py
@@ -164,8 +164,10 @@ async def wait_for_input(loop, abort_sem):
     reader = asyncio.StreamReader(loop=loop)
     reader_protocol = asyncio.StreamReaderProtocol(reader)
     await loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
+    reader_readline = asyncio.create_task(reader.readline())
+    abort_sem_acquire = asyncio.create_task(abort_sem.acquire())
     await asyncio.wait(
-        [reader.readline(), abort_sem.acquire()], return_when=asyncio.FIRST_COMPLETED
+        [reader_readline, abort_sem_acquire], return_when=asyncio.FIRST_COMPLETED
     )
 
 

--- a/pyatv/support/knock.py
+++ b/pyatv/support/knock.py
@@ -51,7 +51,11 @@ async def knock(address: IPv4Address, ports: List[int], timeout: float) -> None:
         # yield to the event loop to ensure we do not block
         await asyncio.sleep(0)
         _LOGGER.debug("Knocking at port %s on %s", port, address)
-        tasks.append(asyncio.ensure_future(_async_knock(address, port, knock_runtime)))
+        tasks.append(
+            asyncio.ensure_future(
+                asyncio.create_task(_async_knock(address, port, knock_runtime))
+            )
+        )
     _, pending = await asyncio.wait(tasks, return_when=FIRST_EXCEPTION)
     if pending:
         for task in pending:


### PR DESCRIPTION
Hello everybody,

yesterday I reported the bug #2268.

Today, I have taken a look at the problem. It was a fairly easy fix. The problem was that [asyncio.wait](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait) forbidds to pass coroutine objects directly since Python 3.11.

To fix this issue, the coroutines can just be wrapped in a task by utilizing [asyncio.create_task](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task).

If there are any questions, feel free to ask :).