### PR TITLE
Output all identifiers and mac address when scanning with atvscript

### DIFF
--- a/docs/documentation/atvscript.md
+++ b/docs/documentation/atvscript.md
@@ -73,7 +73,12 @@ $ atvscript scan
       "name": "Vardagsrum",
       "address": "10.0.10.81",
       "identifier": "xxx",
-      {
+      "all_identifiers": [
+        "xxx",
+        "xxx",
+        "xxx"
+      ],
+      "device_info": {
         "model": "Gen4K",
         "model_str": "Apple TV 4K",
         "operating_system": "TvOS",
@@ -94,6 +99,11 @@ $ atvscript scan
       "name": "Apple TV",
       "address": "10.0.10.123",
       "identifier": "xxx",
+      "all_identifiers": [
+        "xxx",
+        "xxx",
+        "xxx"
+      ],
       "device_info": {
         "model": "Gen3",
         "model_str": "Apple TV 3",
@@ -115,6 +125,11 @@ $ atvscript scan
       "name": "Proxy",
       "address": "10.0.10.254",
       "identifier": "xxx",
+      "all_identifiers": [
+        "xxx",
+        "xxx",
+        "xxx"
+      ],
       "device_info": {
         "model": "Unknown",
         "model_str": "Unknown",
@@ -145,6 +160,11 @@ $ atvscript -s 10.0.10.81 scan
       "name": "Vardagsrum",
       "address": "10.0.10.81",
       "identifier": "xxx",
+      "all_identifiers": [
+        "xxx",
+        "xxx",
+        "xxx"
+      ],
       "device_info": {
         "model": "Gen4K",
         "model_str": "Apple TV 4K",

--- a/docs/documentation/atvscript.md
+++ b/docs/documentation/atvscript.md
@@ -79,6 +79,7 @@ $ atvscript scan
         "xxx"
       ],
       "device_info": {
+        "mac": "AA:BB:CC:DD:EE:FF",
         "model": "Gen4K",
         "model_str": "Apple TV 4K",
         "operating_system": "TvOS",
@@ -105,6 +106,7 @@ $ atvscript scan
         "xxx"
       ],
       "device_info": {
+        "mac": "AA:BB:CC:DD:EE:FF",
         "model": "Gen3",
         "model_str": "Apple TV 3",
         "operating_system": "Legacy",
@@ -131,6 +133,7 @@ $ atvscript scan
         "xxx"
       ],
       "device_info": {
+        "mac": null,
         "model": "Unknown",
         "model_str": "Unknown",
         "operating_system": "Unknown",
@@ -166,6 +169,7 @@ $ atvscript -s 10.0.10.81 scan
         "xxx"
       ],
       "device_info": {
+        "mac": "AA:BB:CC:DD:EE:FF",
         "model": "Gen4K",
         "model_str": "Apple TV 4K",
         "operating_system": "TvOS",

--- a/pyatv/scripts/atvscript.py
+++ b/pyatv/scripts/atvscript.py
@@ -223,6 +223,7 @@ async def _scan_devices(loop, storage: Storage, hosts):
                 "identifier": atv.identifier,
                 "all_identifiers": atv.all_identifiers,
                 "device_info": {
+                    "mac": atv.device_info.mac,
                     "model": atv.device_info.model.name,
                     "model_str": atv.device_info.model_str,
                     "operating_system": atv.device_info.operating_system.name,

--- a/pyatv/scripts/atvscript.py
+++ b/pyatv/scripts/atvscript.py
@@ -221,6 +221,7 @@ async def _scan_devices(loop, storage: Storage, hosts):
                 "name": atv.name,
                 "address": str(atv.address),
                 "identifier": atv.identifier,
+                "all_identifiers": atv.all_identifiers,
                 "device_info": {
                     "model": atv.device_info.model.name,
                     "model_str": atv.device_info.model_str,

--- a/tests/scripts/test_atvscript.py
+++ b/tests/scripts/test_atvscript.py
@@ -8,7 +8,7 @@ import pytest
 
 from pyatv.const import Protocol
 
-from tests.scripts.conftest import DMAP_ID, IP_1, IP_2, MRP_ID
+from tests.scripts.conftest import AIRPLAY_ID, DMAP_ID, IP_1, IP_2, MRP_ID
 
 _LOGGER = logging.getLogger(__name__)
 HASH = "ca496c14642c78af6dd4250191fe175f6dafd72b4c33bcbab43c454aae051da1"
@@ -41,6 +41,7 @@ async def test_scan_devices(scriptenv, fake_atv):
                     "name": "Apple TV 1",
                     "address": IP_1,
                     "identifier": DMAP_ID,
+                    "all_identifiers": [DMAP_ID],
                     "device_info": {
                         "model": "Unknown",
                         "model_str": "Unknown",
@@ -53,6 +54,7 @@ async def test_scan_devices(scriptenv, fake_atv):
                     "name": "Apple TV 2",
                     "address": IP_2,
                     "identifier": MRP_ID,
+                    "all_identifiers": [AIRPLAY_ID, MRP_ID],
                     "device_info": {
                         "model": "Unknown",
                         "model_str": "pyatv",

--- a/tests/scripts/test_atvscript.py
+++ b/tests/scripts/test_atvscript.py
@@ -43,6 +43,7 @@ async def test_scan_devices(scriptenv, fake_atv):
                     "identifier": DMAP_ID,
                     "all_identifiers": [DMAP_ID],
                     "device_info": {
+                        "mac": None,
                         "model": "Unknown",
                         "model_str": "Unknown",
                         "operating_system": "Legacy",
@@ -56,6 +57,7 @@ async def test_scan_devices(scriptenv, fake_atv):
                     "identifier": MRP_ID,
                     "all_identifiers": [AIRPLAY_ID, MRP_ID],
                     "device_info": {
+                        "mac": AIRPLAY_ID,
                         "model": "Unknown",
                         "model_str": "pyatv",
                         "operating_system": "TvOS",


### PR DESCRIPTION
Hi @postlund ,

for the use-case I am currently working on, I use Airplay MAC-Adresses as an identifier https://github.com/maxileith/homebridge-appletv-enhanced/issues/20. Therefore, I always need to get the MAC-Address as an identifier from `atvscript`. However, currently the returned identifier from `atvscript scan` is not always the MAC-Address. Therefore, I would suggest to add an attribute `all_identifieres` to the output json. By not touching `identifier` of the output json, backward compatability is given.

I'd love to hear your thoughts on that.