### PR TITLE
Fix a bug that causes atvscript push_updates to never report the current app

### DIFF
--- a/pyatv/scripts/atvscript.py
+++ b/pyatv/scripts/atvscript.py
@@ -50,7 +50,7 @@ class PushPrinter(PushListener):
         """Inform about changes to what is currently playing."""
         app = (
             self.atv.metadata.app
-            if not self.atv.features.in_state(FeatureState.Unavailable)
+            if not self.atv.features.in_state(FeatureState.Unavailable, FeatureName.App)
             else None
         )
         print(


### PR DESCRIPTION
Hi,

I have noticed a bug which causes the `atvscript push_updates` command to never report the App that is currently playing. I believe this bug was caused in https://github.com/postlund/pyatv/pull/1962 which solves https://github.com/postlund/pyatv/issues/1930.

The solution in https://github.com/postlund/pyatv/pull/1962 is supposed to be checking wether or not the `App` feature is available and only then return it. https://github.com/postlund/pyatv/blob/b35b7ba9bcc93c11754c61ebd99f0cb88d0ce3f2/pyatv/scripts/atvscript.py#L48 However, I think that this is supposed to look like one if these two options:

```python
if not self.atv.features.get_feature(FeatureName.App).state == FeatureState.Unavailable
```

```python
if not self.atv.features.in_state(FeatureState.Unavailable, FeatureName.App)
```


The output of `atvscript -s xxx.xxx.xxx.xxx push_updates` before ...

```json
{
    "result": "success",
    "datetime": "2023-12-04T19:17:02.766358+01:00",
    "hash": "com.apple.avkit.11338.d4e1c618",
    "media_type": "video",
    "device_state": "paused",
    "title": "Fast & Furious 8",
    "artist": null,
    "album": null,
    "genre": null,
    "total_time": 8164,
    "position": 2675,
    "shuffle": "off",
    "repeat": "off",
    "series_name": null,
    "season_number": null,
    "episode_number": null,
    "content_identifier": null,
    "app": null,
    "app_id": null
}
```

... and after (see attributes `app` and `app_id`) ...

```json
{
    "result": "success",
    "datetime": "2023-12-04T19:36:08.452114+01:00",
    "hash": "com.apple.avkit.11338.d4e1c618",
    "media_type": "video",
    "device_state": "paused",
    "title": "Fast & Furious 8",
    "artist": null,
    "album": null,
    "genre": null,
    "total_time": 8164,
    "position": 2691,
    "shuffle": "off",
    "repeat": "off",
    "series_name": null,
    "season_number": null,
    "episode_number": null,
    "content_identifier": null,
    "app": "Netflix",
    "app_id": "com.netflix.Netflix"
}
```

