### PR TITLE
Check companion pairing authentication status code

### DIFF
--- a/pyatv/protocols/companion/auth.py
+++ b/pyatv/protocols/companion/auth.py
@@ -158,7 +158,10 @@ class CompanionPairVerifyProcedure(PairVerifyProcedure):
             },
         )
 
-        # TODO: check status code
+        # check status code
+        if resp['_pd'][2] != 4:
+            _LOGGER.warning("companion pairing credentials are invalid")
+            raise exceptions.AuthenticationError("companion pairing credentials are invalid")
 
         return True
 


### PR DESCRIPTION
Adds the status code check for companion pairing authentication, raises an AuthenticationError if they are not the expected status code.