### PR TITLE
deps: Bump some lowest deps versions

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,7 +1,7 @@
 aiohttp==3.8.3,<5
 async-timeout==4.0.2
-cryptography==42.0.0
-chacha20poly1305-reuseable==0.12.1
+cryptography==43.0.0
+chacha20poly1305-reuseable==0.13.2
 ifaddr==0.1.7
 mediafile==0.8.1
 miniaudio==1.45


### PR DESCRIPTION
Cryptography 43.0.0 and needed by chacha20poly1305-reusable, so bumping to that. Should fix #2451.

Relates to #2451