### PR TITLE
opack: implement dates

### DIFF
--- a/tests/support/test_opack.py
+++ b/tests/support/test_opack.py
@@ -36,8 +36,7 @@ def test_pack_uuid():
 
 
 def test_pack_absolute_time():
-    with pytest.raises(NotImplementedError):
-        pack(datetime.now())
+    assert pack(datetime.fromtimestamp(978307200.0)) == b"\x06" + (b"\x00" * 8)
 
 
 def test_pack_small_integers():
@@ -223,8 +222,10 @@ def test_unpack_uuid():
 
 
 def test_unpack_absolute_time():
-    # TODO: This is not implemented, it only parses the time stamp as an integer
-    assert unpack(b"\x06\x01\x00\x00\x00\x00\x00\x00\x00") == (1, b"")
+    assert unpack(b"\x06\x00\x00\x00\x00\x00\x00\x00\x00") == (
+        datetime.fromtimestamp(978307200.0),
+        b"",
+    )
 
 
 def test_unpack_small_integers():


### PR DESCRIPTION
I'd also like to add support for negative integers into opack, if possible. If anyone has a mac, I'd ask if you could test this piece of code https://github.com/fabianfreyer/opack-tools/ to see whether or not opack supports negative integers in the first place. 

My suspicion is that OPACK does not, in fact, have a data type for signed integers, and attempting to encode negative integer will be treated as an unsigned integer internally. (e.g. `OPACKDecode(OPACKEncode(NSNumber(-15))) = NSNumber(4294967281)`, at a high level)