### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,143 @@
 # CHANGES
 
+## 0.15.0 Ralph (2024-08-10)
+
+It has been a long time since the last release (christmas!), so a it's really
+due for a new one. I have mostly been busy with other (personal) stuff, so I
+have not done much more than maintenance. There are a few changes from the
+community though.
+
+Some hightlights:
+
+* Uplift of various dependencies, e.g, fix breaking change in cryptography
+* It is possible to skip forward/backwards (Companion) with custom intervals,
+  thanks @thiccaxe!
+* @bdraco fixed a bug related to changes in chacha20poly1305-reuseable
+* Python 3.12 is now (finally) offically supported
+
+This is a minor update indeed. I hope to see some updates in the near future,
+especially related to tvOS 18 compatibility as well as new features. I am very
+grateful for any help from the community. So if you want to help out
+implementing anything, please send a PR and I'll try my best to find time to
+review it!
+
+**Changes:**
+
+*Other:*
+
+```
+7716858a fix styling for 2462
+41b039f9 precise skip in companion, mrp, dmap
+618e93a4 companion skip implementation
+8331c783 deps: Bump protobuf base version to 4.25.3
+2a8afa68 deps: Sync some versions with base versions
+9f2f7cd3 Added touch gesture to companion protocol (#2402)
+55f3455e deps: Bump some lowest deps versions
+31b57b27 cq: Fix pylint issues
+42ff35ab docs: Fix codespell issues
+ea9d3339 Fix Chacha20Cipher with companion
+a84774c1 test: Improve MRP volume tests
+8080aaae test: Improve dispatch test
+aad6bcd7 test: Improve aiothttp session closing
+ed20bf72 Bump setup-python to v5
+1b780d46 gha: Bump setup-python tp v4
+541ba00d Update tests.yml
+ec402a68 gha: Run tests with python 3.12
+1037d5ef dep: Bump chacha20poly1305-reuseable and cryptography
+1fc1cb0f cq: Run black to fix errors
+5c721409 gha: Remove automerge workflow
+90b23cc4 Update index.md
+7fdfa28a still need to pad for hap
+29ad6fc0 still need to pad for hap
+e817af09 still need to pad for hap
+0c1f6674 lint
+d5a29d7e Simplify ChaCha20 Poly1305 implementation
+8d78f516 Fix typo in README.
+```
+
+**All changes:**
+
+```
+e7487a8b build(deps): Bump python from 3.11.0-alpine to 3.12.5-alpine
+81cd5819 build(deps): Bump aiohttp from 3.10.1 to 3.10.2 in /requirements
+7716858a fix styling for 2462
+41b039f9 precise skip in companion, mrp, dmap
+618e93a4 companion skip implementation
+0d2d3fc9 build(deps): Bump flake8 from 7.1.0 to 7.1.1 in /requirements
+1e0d7991 build(deps): Bump black from 24.4.2 to 24.8.0 in /requirements
+5f801d4c build(deps): Bump aiohttp from 3.10.0 to 3.10.1 in /requirements
+95c43b1c build(deps): Bump mypy-protobuf from 3.5.0 to 3.6.0 in /requirements
+8331c783 deps: Bump protobuf base version to 4.25.3
+80fd95e6 build(deps): Bump pylint from 3.2.5 to 3.2.6 in /requirements
+0abc130b build(deps): Bump protobuf from 5.27.2 to 5.27.3 in /requirements
+1bda482d build(deps): Bump mypy from 1.10.1 to 1.11.1 in /requirements
+2a8afa68 deps: Sync some versions with base versions
+1b38c96f build(deps): Bump pytest-httpserver in /requirements
+961340f8 build(deps): Bump pytest from 8.2.2 to 8.3.2 in /requirements
+64cc5847 build(deps): Bump aiohttp from 3.9.5 to 3.10.0 in /requirements (#2463)
+18ceacd4 build(deps): Bump miniaudio from 1.60 to 1.61 in /requirements (#2459)
+9f2f7cd3 Added touch gesture to companion protocol (#2402)
+55f3455e deps: Bump some lowest deps versions
+c263ff54 build(deps): Bump pydantic from 2.7.4 to 2.8.2 in /requirements
+cba3eb9a build(deps): Bump chacha20poly1305-reuseable in /requirements
+6e9cc70d build(deps): Bump miniaudio from 1.59 to 1.60 in /requirements
+21becc1e build(deps): Bump pytest-asyncio from 0.23.6 to 0.23.8 in /requirements
+98dd3f2d build(deps): Bump protobuf from 5.27.1 to 5.27.2 in /requirements
+0e024712 build(deps): Bump requests from 2.32.2 to 2.32.3 in /requirements
+31b57b27 cq: Fix pylint issues
+8d942aa2 build(deps): Bump pylint from 3.0.3 to 3.2.5 in /requirements
+42ff35ab docs: Fix codespell issues
+1e256440 build(deps): Bump codespell from 2.2.6 to 2.3.0 in /requirements
+bbfb6ec2 build(deps): Bump pytest-httpserver in /requirements
+d70a9a47 build(deps): Bump zeroconf from 0.131.0 to 0.132.2 in /requirements
+9dbdcae1 build(deps): Bump mypy from 1.8.0 to 1.10.1 in /requirements
+e84219bb build(deps): Bump pytest-cov from 4.1.0 to 5.0.0 in /requirements
+0eec178c build(deps): Bump types-protobuf in /requirements
+b1bd82b5 build(deps): Bump pyfakefs from 5.4.1 to 5.6.0 in /requirements
+d789cd08 build(deps): Bump pytest-timeout from 2.2.0 to 2.3.1 in /requirements
+80b9c91d build(deps): Bump pydantic from 2.5.3 to 2.7.4 in /requirements
+ee725bd7 build(deps): Bump pytest-xdist from 3.5.0 to 3.6.1 in /requirements
+1c7f3719 build(deps): Bump black from 24.4.0 to 24.4.2 in /requirements
+f2152da3 build(deps): Bump protobuf from 4.25.2 to 5.27.1 in /requirements
+30bcb66e build(deps): Bump cryptography from 42.0.5 to 42.0.8 in /requirements
+ea9d3339 Fix Chacha20Cipher with companion
+fb78faf6 build(deps): Bump flake8 from 7.0.0 to 7.1.0 in /requirements
+5e6f1b17 build(deps): Bump deepdiff from 6.7.1 to 7.0.1 in /requirements
+c5f182af build(deps): Bump pdoc3 from 0.10.0 to 0.11.0 in /requirements
+a84774c1 test: Improve MRP volume tests
+8080aaae test: Improve dispatch test
+aad6bcd7 test: Improve aiothttp session closing
+ed20bf72 Bump setup-python to v5
+1b780d46 gha: Bump setup-python tp v4
+541ba00d Update tests.yml
+ec402a68 gha: Run tests with python 3.12
+39a868f9 build(deps): Bump pytest from 7.4.3 to 8.2.2 in /requirements
+a0aa0d6e build(deps): Bump flake8 from 6.1.0 to 7.0.0 in /requirements
+1037d5ef dep: Bump chacha20poly1305-reuseable and cryptography
+1fc1cb0f cq: Run black to fix errors
+2b0cc6a0 build(deps): Bump black from 23.12.1 to 24.4.0 in /requirements
+62020c36 build(deps): Bump types-protobuf in /requirements
+5c721409 gha: Remove automerge workflow
+90b23cc4 Update index.md
+7589ec8b build(deps): Bump types-tabulate in /requirements
+7fdfa28a still need to pad for hap
+29ad6fc0 still need to pad for hap
+e817af09 still need to pad for hap
+0c1f6674 lint
+d5a29d7e Simplify ChaCha20 Poly1305 implementation
+601e553a build(deps): Bump requests from 2.31.0 to 2.32.2 in /requirements
+7bff8b32 build(deps): Bump pytest-asyncio from 0.23.2 to 0.23.6 in /requirements
+a2da7611 build(deps): Bump pyfakefs from 5.3.2 to 5.4.1 in /requirements
+eaf73bf9 build(deps): Bump aiohttp from 3.9.1 to 3.9.5 in /requirements
+8d78f516 Fix typo in README.
+4b00261b build(deps): Bump protobuf from 4.25.1 to 4.25.2 in /requirements
+2f7e2fd1 build(deps): Bump pytest-asyncio from 0.21.1 to 0.23.2 in /requirements
+4cd32600 build(deps): Bump isort from 5.12.0 to 5.13.2 in /requirements
+51458f95 build(deps): Bump pyfakefs from 5.3.0 to 5.3.2 in /requirements
+9d0e7f4c build(deps): Bump pydantic from 2.4.2 to 2.5.3 in /requirements
+6d2762df build(deps): Bump pytest-xdist from 3.3.1 to 3.5.0 in /requirements
+```
+
 ## 0.14.5 Quimby (2023-12-24)
 
 Merry christmas everyone, here comes a small present! In this

--- a/docs/api/pyatv.const.html
+++ b/docs/api/pyatv.const.html
@@ -50,6 +50,7 @@ link_group: api
 <h4><code><a title="pyatv.const.FeatureName" href="#pyatv.const.FeatureName">FeatureName</a></code></h4>
 <ul class="two-column">
 <li><code><a title="pyatv.const.FeatureName.AccountList" href="#pyatv.const.FeatureName.AccountList">AccountList</a></code></li>
+<li><code><a title="pyatv.const.FeatureName.Action" href="#pyatv.const.FeatureName.Action">Action</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.AddOutputDevices" href="#pyatv.const.FeatureName.AddOutputDevices">AddOutputDevices</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.Album" href="#pyatv.const.FeatureName.Album">Album</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.App" href="#pyatv.const.FeatureName.App">App</a></code></li>
@@ -58,6 +59,7 @@ link_group: api
 <li><code><a title="pyatv.const.FeatureName.Artwork" href="#pyatv.const.FeatureName.Artwork">Artwork</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.ChannelDown" href="#pyatv.const.FeatureName.ChannelDown">ChannelDown</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.ChannelUp" href="#pyatv.const.FeatureName.ChannelUp">ChannelUp</a></code></li>
+<li><code><a title="pyatv.const.FeatureName.Click" href="#pyatv.const.FeatureName.Click">Click</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.ContentIdentifier" href="#pyatv.const.FeatureName.ContentIdentifier">ContentIdentifier</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.Down" href="#pyatv.const.FeatureName.Down">Down</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.EpisodeNumber" href="#pyatv.const.FeatureName.EpisodeNumber">EpisodeNumber</a></code></li>
@@ -95,6 +97,7 @@ link_group: api
 <li><code><a title="pyatv.const.FeatureName.Stop" href="#pyatv.const.FeatureName.Stop">Stop</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.StreamFile" href="#pyatv.const.FeatureName.StreamFile">StreamFile</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.Suspend" href="#pyatv.const.FeatureName.Suspend">Suspend</a></code></li>
+<li><code><a title="pyatv.const.FeatureName.Swipe" href="#pyatv.const.FeatureName.Swipe">Swipe</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.SwitchAccount" href="#pyatv.const.FeatureName.SwitchAccount">SwitchAccount</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.TextAppend" href="#pyatv.const.FeatureName.TextAppend">TextAppend</a></code></li>
 <li><code><a title="pyatv.const.FeatureName.TextClear" href="#pyatv.const.FeatureName.TextClear">TextClear</a></code></li>
@@ -201,6 +204,15 @@ link_group: api
 <li><code><a title="pyatv.const.ShuffleState.Songs" href="#pyatv.const.ShuffleState.Songs">Songs</a></code></li>
 </ul>
 </li>
+<li>
+<h4><code><a title="pyatv.const.TouchAction" href="#pyatv.const.TouchAction">TouchAction</a></code></h4>
+<ul class="">
+<li><code><a title="pyatv.const.TouchAction.Click" href="#pyatv.const.TouchAction.Click">Click</a></code></li>
+<li><code><a title="pyatv.const.TouchAction.Hold" href="#pyatv.const.TouchAction.Hold">Hold</a></code></li>
+<li><code><a title="pyatv.const.TouchAction.Press" href="#pyatv.const.TouchAction.Press">Press</a></code></li>
+<li><code><a title="pyatv.const.TouchAction.Release" href="#pyatv.const.TouchAction.Release">Release</a></code></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -211,7 +223,7 @@ link_group: api
 </header>
 <section id="section-intro">
 <p>Constants used in the public API.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L1-L436" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L1-L454" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -336,7 +348,7 @@ future.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>All supported features.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L249-L436" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L249-L445" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -346,6 +358,10 @@ future.</p></section>
 <dt id="pyatv.const.FeatureName.AccountList"><code class="name">var <span class="ident">AccountList</span> = 55</code></dt>
 <dd>
 <section class="desc"><p>List of user accounts.</p></section>
+</dd>
+<dt id="pyatv.const.FeatureName.Action"><code class="name">var <span class="ident">Action</span> = 64</code></dt>
+<dd>
+<section class="desc"><p>Touch event to given coordinates.</p></section>
 </dd>
 <dt id="pyatv.const.FeatureName.AddOutputDevices"><code class="name">var <span class="ident">AddOutputDevices</span> = 60</code></dt>
 <dd>
@@ -378,6 +394,10 @@ future.</p></section>
 <dt id="pyatv.const.FeatureName.ChannelUp"><code class="name">var <span class="ident">ChannelUp</span> = 48</code></dt>
 <dd>
 <section class="desc"><p>Select next channel.</p></section>
+</dd>
+<dt id="pyatv.const.FeatureName.Click"><code class="name">var <span class="ident">Click</span> = 65</code></dt>
+<dd>
+<section class="desc"><p>Touch click command.</p></section>
 </dd>
 <dt id="pyatv.const.FeatureName.ContentIdentifier"><code class="name">var <span class="ident">ContentIdentifier</span> = 47</code></dt>
 <dd>
@@ -526,6 +546,10 @@ future.</p></section>
 <dt id="pyatv.const.FeatureName.Suspend"><code class="name">var <span class="ident">Suspend</span> = 17</code></dt>
 <dd>
 <section class="desc"><p>Suspend device (deprecated; use Power.turn_off).</p></section>
+</dd>
+<dt id="pyatv.const.FeatureName.Swipe"><code class="name">var <span class="ident">Swipe</span> = 63</code></dt>
+<dd>
+<section class="desc"><p>Touch swipe from given coordinates and duration.</p></section>
 </dd>
 <dt id="pyatv.const.FeatureName.SwitchAccount"><code class="name">var <span class="ident">SwitchAccount</span> = 56</code></dt>
 <dd>
@@ -898,6 +922,37 @@ is Apple TV Software (pre-tvOS).</p></section>
 <dt id="pyatv.const.ShuffleState.Songs"><code class="name">var <span class="ident">Songs</span> = 2</code></dt>
 <dd>
 <section class="desc"><p>Shuffle on song level.</p></section>
+</dd>
+</dl>
+</dd>
+<dt id="pyatv.const.TouchAction"><code class="flex name class">
+<span>class <span class="ident">TouchAction</span></span>
+<span>(</span><span>value, names=None, *, module=None, qualname=None, type=None, start=1)</span>
+</code></dt>
+<dd>
+<section class="desc"><p>Touch action constants.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/const.py#L448-L454" class="git-link">Browse git</a></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>enum.Enum</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="pyatv.const.TouchAction.Click"><code class="name">var <span class="ident">Click</span> = 5</code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
+<dt id="pyatv.const.TouchAction.Hold"><code class="name">var <span class="ident">Hold</span> = 3</code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
+<dt id="pyatv.const.TouchAction.Press"><code class="name">var <span class="ident">Press</span> = 1</code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
+<dt id="pyatv.const.TouchAction.Release"><code class="name">var <span class="ident">Release</span> = 4</code></dt>
+<dd>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>

--- a/docs/api/pyatv.interface.html
+++ b/docs/api/pyatv.interface.html
@@ -46,6 +46,7 @@ link_group: api
 <li><code><a title="pyatv.interface.AppleTV.service" href="#pyatv.interface.AppleTV.service">service</a></code></li>
 <li><code><a title="pyatv.interface.AppleTV.settings" href="#pyatv.interface.AppleTV.settings">settings</a></code></li>
 <li><code><a title="pyatv.interface.AppleTV.stream" href="#pyatv.interface.AppleTV.stream">stream</a></code></li>
+<li><code><a title="pyatv.interface.AppleTV.touch" href="#pyatv.interface.AppleTV.touch">touch</a></code></li>
 <li><code><a title="pyatv.interface.AppleTV.user_accounts" href="#pyatv.interface.AppleTV.user_accounts">user_accounts</a></code></li>
 </ul>
 </li>
@@ -311,6 +312,14 @@ link_group: api
 </ul>
 </li>
 <li>
+<h4><code><a title="pyatv.interface.TouchGestures" href="#pyatv.interface.TouchGestures">TouchGestures</a></code></h4>
+<ul class="">
+<li><code><a title="pyatv.interface.TouchGestures.action" href="#pyatv.interface.TouchGestures.action">action</a></code></li>
+<li><code><a title="pyatv.interface.TouchGestures.click" href="#pyatv.interface.TouchGestures.click">click</a></code></li>
+<li><code><a title="pyatv.interface.TouchGestures.swipe" href="#pyatv.interface.TouchGestures.swipe">swipe</a></code></li>
+</ul>
+</li>
+<li>
 <h4><code><a title="pyatv.interface.UserAccount" href="#pyatv.interface.UserAccount">UserAccount</a></code></h4>
 <ul class="">
 <li><code><a title="pyatv.interface.UserAccount.identifier" href="#pyatv.interface.UserAccount.identifier">identifier</a></code></li>
@@ -336,7 +345,7 @@ link_group: api
 <p>Public interface exposed by library.</p>
 <p>This module contains all the interfaces that represents a generic Apple TV device and
 all its features.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1-L1526" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1-L1573" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -365,7 +374,7 @@ all its features.</p>
 <dd>
 <section class="desc"><p>Information about an app.</p>
 <p>Initialize a new App instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L677-L703" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L680-L706" class="git-link">Browse git</a></div>
 <h3>Instance variables</h3>
 <dl>
 <dt id="pyatv.interface.App.identifier"><code class="name">var <span class="ident">identifier</span> -> str</code></dt>
@@ -386,7 +395,7 @@ all its features.</p>
 <section class="desc"><p>Base class representing an Apple TV.</p>
 <p>Listener interface: <code>pyatv.interfaces.DeviceListener</code></p>
 <p>Initialize a new StateProducer instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1446-L1526" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1488-L1573" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -447,6 +456,10 @@ all its features.</p>
 <dd>
 <section class="desc"><p>Return API for streaming media.</p></section>
 </dd>
+<dt id="pyatv.interface.AppleTV.touch"><code class="name">var <span class="ident">touch</span> -> <a title="pyatv.interface.TouchGestures" href="#pyatv.interface.TouchGestures">TouchGestures</a></code></dt>
+<dd>
+<section class="desc"><p>Return touch gestures interface.</p></section>
+</dd>
 <dt id="pyatv.interface.AppleTV.user_accounts"><code class="name">var <span class="ident">user_accounts</span> -> <a title="pyatv.interface.UserAccounts" href="#pyatv.interface.UserAccounts">UserAccounts</a></code></dt>
 <dd>
 <section class="desc"><p>Return user accounts interface.</p></section>
@@ -478,7 +491,7 @@ all its features.</p>
 </code></dt>
 <dd>
 <section class="desc"><p>Base class for app handling.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L706-L717" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L709-L720" class="git-link">Browse git</a></div>
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li>pyatv.core.facade.FacadeApps</li>
@@ -518,7 +531,7 @@ all its features.</p>
 </code></dt>
 <dd>
 <section class="desc"><p>Artwork information.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L64-L70" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L65-L71" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>builtins.tuple</li>
@@ -552,7 +565,7 @@ all its features.</p>
 <p>Volume level is managed in percent where 0 is muted and 100 is max volume.</p>
 <p>Listener interface: <code>pyatv.interfaces.AudioListener</code></p>
 <p>Initialize a new StateProducer instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1135-L1204" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1138-L1207" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -669,7 +682,7 @@ possible and supported).</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Listener interface for audio updates.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1119-L1132" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1122-L1135" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -708,7 +721,7 @@ possible and supported).</p></section>
 several services depending on the protocols it supports, e.g. DMAP or
 AirPlay.</p>
 <p>Initialize a new BaseConfig instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1252-L1399" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1294-L1441" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -810,7 +823,7 @@ returned.</p></section>
 <dd>
 <section class="desc"><p>Base class for protocol services.</p>
 <p>Initialize a new BaseService.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L140-L241" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L141-L242" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -890,7 +903,7 @@ original value).</p></section>
 <dd>
 <section class="desc"><p>General information about device.</p>
 <p>Initialize a new DeviceInfo instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L926-L1052" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L929-L1055" class="git-link">Browse git</a></div>
 <h3>Class variables</h3>
 <dl>
 <dt id="pyatv.interface.DeviceInfo.OUTPUT_DEVICE_ID"><code class="name">var <span class="ident">OUTPUT_DEVICE_ID</span></code></dt>
@@ -943,7 +956,7 @@ then this property contains the raw model string (if any is available).</p></sec
 </code></dt>
 <dd>
 <section class="desc"><p>Listener interface for generic device updates.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L878-L889" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L881-L892" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -979,7 +992,7 @@ then this property contains the raw model string (if any is available).</p></sec
 </code></dt>
 <dd>
 <section class="desc"><p>Feature state and options.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L85-L89" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L86-L90" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>builtins.tuple</li>
@@ -1001,7 +1014,7 @@ then this property contains the raw model string (if any is available).</p></sec
 </code></dt>
 <dd>
 <section class="desc"><p>Base class for supported feature functionality.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1055-L1087" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1058-L1090" class="git-link">Browse git</a></div>
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li>pyatv.core.facade.FacadeFeatures</li>
@@ -1051,7 +1064,7 @@ in one of the listed states.</p></section>
 <p>Listener
 interface: <code>pyatv.interfaces.KeyboardListener</code></p>
 <p>Initialize a new StateProducer instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1218-L1249" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1221-L1252" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -1127,7 +1140,7 @@ interface: <code>pyatv.interfaces.KeyboardListener</code></p>
 </code></dt>
 <dd>
 <section class="desc"><p>Listener interface for keyboard updates.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1207-L1215" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1210-L1218" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -1154,7 +1167,7 @@ interface: <code>pyatv.interfaces.KeyboardListener</code></p>
 </code></dt>
 <dd>
 <section class="desc"><p>Container for media (e.g. audio or video) metadata.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L73-L82" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L74-L83" class="git-link">Browse git</a></div>
 <h3>Class variables</h3>
 <dl>
 <dt id="pyatv.interface.MediaMetadata.album"><code class="name">var <span class="ident">album</span> -> Optional[str]</code></dt>
@@ -1184,7 +1197,7 @@ interface: <code>pyatv.interfaces.KeyboardListener</code></p>
 </code></dt>
 <dd>
 <section class="desc"><p>Base class for retrieving metadata from an Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L763-L803" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L766-L806" class="git-link">Browse git</a></div>
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li>pyatv.core.facade.FacadeMetadata</li>
@@ -1246,7 +1259,7 @@ aspect ratio.</p></section>
 <dd>
 <section class="desc"><p>Information about an output device.</p>
 <p>Initialize a new OutputDevice instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1090-L1116" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1093-L1119" class="git-link">Browse git</a></div>
 <h3>Instance variables</h3>
 <dl>
 <dt id="pyatv.interface.OutputDevice.identifier"><code class="name">var <span class="ident">identifier</span> -> str</code></dt>
@@ -1266,7 +1279,7 @@ aspect ratio.</p></section>
 <dd>
 <section class="desc"><p>Base class for API used to pair with an Apple TV.</p>
 <p>Initialize a new instance of PairingHandler.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L244-L288" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L245-L289" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -1337,7 +1350,7 @@ aspect ratio.</p></section>
 <dd>
 <section class="desc"><p>Base class for retrieving what is currently playing.</p>
 <p>Initialize a new Playing instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L456-L674" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L459-L677" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -1416,7 +1429,7 @@ always be the same for the same content, but it is not guaranteed.</p></section>
 <section class="desc"><p>Base class for retrieving power state from an Apple TV.</p>
 <p>Listener interface: <code>pyatv.interfaces.PowerListener</code></p>
 <p>Initialize a new StateProducer instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L903-L923" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L906-L926" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -1469,7 +1482,7 @@ always be the same for the same content, but it is not guaranteed.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Listener interface for power updates.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L892-L900" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L895-L903" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -1497,7 +1510,7 @@ always be the same for the same content, but it is not guaranteed.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Listener interface for push updates.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L806-L815" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L809-L818" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -1538,7 +1551,7 @@ always be the same for the same content, but it is not guaranteed.</p></section>
 actually changes.</p>
 <p>Listener interface: <code><a title="pyatv.interface.PushListener" href="#pyatv.interface.PushListener">PushListener</a></code>.</p>
 <p>Initialize a new StateProducer instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L818-L845" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L821-L848" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -1587,7 +1600,7 @@ actually changes.</p>
 </code></dt>
 <dd>
 <section class="desc"><p>Base class for API used to control an Apple TV.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L291-L452" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L292-L455" class="git-link">Browse git</a></div>
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li>pyatv.core.facade.FacadeRemoteControl</li>
@@ -1817,29 +1830,31 @@ actually changes.</p>
 </dd>
 <dt id="pyatv.interface.RemoteControl.skip_backward">
 <code class="name flex">
-<span>async def <span class="ident">skip_backward</span></span>(<span>self) -> None</span>
+<span>async def <span class="ident">skip_backward</span></span>(<span>self, time_interval: float = 0.0) -> None</span>
 </code>
 </dt>
 <dd>
 <div class="api_feature">
 <span>Feature: <a title="pyatv.const.FeatureName.SkipBackward" href="/api/const#pyatv.const.FeatureName.SkipBackward">FeatureName.SkipBackward</a>,</span>
-<span>Supported by: <a title="pyatv.const.Protocol.DMAP" href="/api/const#pyatv.const.Protocol.DMAP">Protocol.DMAP</a>, <a title="pyatv.const.Protocol.MRP" href="/api/const#pyatv.const.Protocol.MRP">Protocol.MRP</a></span>
+<span>Supported by: <a title="pyatv.const.Protocol.Companion" href="/api/const#pyatv.const.Protocol.Companion">Protocol.Companion</a>, <a title="pyatv.const.Protocol.DMAP" href="/api/const#pyatv.const.Protocol.DMAP">Protocol.DMAP</a>, <a title="pyatv.const.Protocol.MRP" href="/api/const#pyatv.const.Protocol.MRP">Protocol.MRP</a></span>
 </div>
-<section class="desc"><p>Skip backwards a time interval.</p>
-<p>Skip interval is typically 15-30s, but is decided by the app.</p></section>
+<section class="desc"><p>Skip backward a time interval.</p>
+<p>If time_interval is not positive or not present, a default or app-chosen
+time interval is used, which is typically 10, 15, 30, etc. seconds.</p></section>
 </dd>
 <dt id="pyatv.interface.RemoteControl.skip_forward">
 <code class="name flex">
-<span>async def <span class="ident">skip_forward</span></span>(<span>self) -> None</span>
+<span>async def <span class="ident">skip_forward</span></span>(<span>self, time_interval: float = 0.0) -> None</span>
 </code>
 </dt>
 <dd>
 <div class="api_feature">
 <span>Feature: <a title="pyatv.const.FeatureName.SkipForward" href="/api/const#pyatv.const.FeatureName.SkipForward">FeatureName.SkipForward</a>,</span>
-<span>Supported by: <a title="pyatv.const.Protocol.DMAP" href="/api/const#pyatv.const.Protocol.DMAP">Protocol.DMAP</a>, <a title="pyatv.const.Protocol.MRP" href="/api/const#pyatv.const.Protocol.MRP">Protocol.MRP</a></span>
+<span>Supported by: <a title="pyatv.const.Protocol.Companion" href="/api/const#pyatv.const.Protocol.Companion">Protocol.Companion</a>, <a title="pyatv.const.Protocol.DMAP" href="/api/const#pyatv.const.Protocol.DMAP">Protocol.DMAP</a>, <a title="pyatv.const.Protocol.MRP" href="/api/const#pyatv.const.Protocol.MRP">Protocol.MRP</a></span>
 </div>
 <section class="desc"><p>Skip forward a time interval.</p>
-<p>Skip interval is typically 15-30s, but is decided by the app.</p></section>
+<p>If time_interval is not positive or not present, a default or app-chosen
+time interval is used, which is typically 10, 15, 30, etc. seconds.</p></section>
 </dd>
 <dt id="pyatv.interface.RemoteControl.stop">
 <code class="name flex">
@@ -1936,7 +1951,7 @@ actually changes.</p>
 </code></dt>
 <dd>
 <section class="desc"><p>Base class for storage modules.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1402-L1443" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1444-L1485" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>abc.ABC</li>
@@ -2009,7 +2024,7 @@ the storage.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Base class for stream functionality.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L848-L875" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L851-L878" class="git-link">Browse git</a></div>
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li>pyatv.core.facade.FacadeStream</li>
@@ -2054,6 +2069,72 @@ the storage.</p></section>
 </dd>
 </dl>
 </dd>
+<dt id="pyatv.interface.TouchGestures"><code class="flex name class">
+<span>class <span class="ident">TouchGestures</span></span>
+</code></dt>
+<dd>
+<section class="desc"><p>Base class for touch gestures.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L1255-L1291" class="git-link">Browse git</a></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>abc.ABC</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li>pyatv.core.facade.FacadeTouchGestures</li>
+<li>pyatv.protocols.companion.CompanionTouchGestures</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="pyatv.interface.TouchGestures.action">
+<code class="name flex">
+<span>async def <span class="ident">action</span></span>(<span>self, x: int, y: int, mode: <a title="pyatv.const.TouchAction" href="../const#pyatv.const.TouchAction">TouchAction</a>) -> None</span>
+</code>
+</dt>
+<dd>
+<div class="api_feature">
+<span>Feature: <a title="pyatv.const.FeatureName.TouchAction" href="/api/const#pyatv.const.FeatureName.TouchAction">FeatureName.TouchAction</a>,</span>
+<span>Supported by: <a title="pyatv.const.Protocol.Companion" href="/api/const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
+</div>
+<section class="desc"><p>Generate a touch event to x,y coordinates (in range [0,1000]).</p>
+<p>:param x: x coordinate
+:param y: y coordinate
+:param mode: touch mode (1: press, 3: hold, 4: release)</p></section>
+</dd>
+<dt id="pyatv.interface.TouchGestures.click">
+<code class="name flex">
+<span>async def <span class="ident">click</span></span>(<span>self, action: <a title="pyatv.const.InputAction" href="../const#pyatv.const.InputAction">InputAction</a>)</span>
+</code>
+</dt>
+<dd>
+<div class="api_feature">
+<span>Feature: <a title="pyatv.const.FeatureName.TouchClick" href="/api/const#pyatv.const.FeatureName.TouchClick">FeatureName.TouchClick</a>,</span>
+<span>Supported by: <a title="pyatv.const.Protocol.Companion" href="/api/const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
+</div>
+<section class="desc"><p>Send a touch click.</p>
+<p>:param action: action mode single tap (0), double tap (1), or hold (2)</p></section>
+</dd>
+<dt id="pyatv.interface.TouchGestures.swipe">
+<code class="name flex">
+<span>async def <span class="ident">swipe</span></span>(<span>self, start_x: int, start_y: int, end_x: int, end_y: int, duration_ms: int) -> None</span>
+</code>
+</dt>
+<dd>
+<div class="api_feature">
+<span>Feature: <a title="pyatv.const.FeatureName.Swipe" href="/api/const#pyatv.const.FeatureName.Swipe">FeatureName.Swipe</a>,</span>
+<span>Supported by: <a title="pyatv.const.Protocol.Companion" href="/api/const#pyatv.const.Protocol.Companion">Protocol.Companion</a></span>
+</div>
+<section class="desc"><p>Generate a swipe gesture.</p>
+<p>From start to end x,y coordinates (in range [0,1000])
+in a given time (in milliseconds).</p>
+<p>:param start_x: Start x coordinate
+:param start_y: Start y coordinate
+:param end_x: End x coordinate
+:param end_y: Endi x coordinate
+:param duration_ms: Time in milliseconds to reach the end coordinates</p></section>
+</dd>
+</dl>
+</dd>
 <dt id="pyatv.interface.UserAccount"><code class="flex name class">
 <span>class <span class="ident">UserAccount</span></span>
 <span>(</span><span>name: str, identifier: str)</span>
@@ -2061,7 +2142,7 @@ the storage.</p></section>
 <dd>
 <section class="desc"><p>Information about a user account.</p>
 <p>Initialize a new UserAccount instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L720-L746" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L723-L749" class="git-link">Browse git</a></div>
 <h3>Instance variables</h3>
 <dl>
 <dt id="pyatv.interface.UserAccount.identifier"><code class="name">var <span class="ident">identifier</span> -> str</code></dt>
@@ -2079,7 +2160,7 @@ the storage.</p></section>
 </code></dt>
 <dd>
 <section class="desc"><p>Base class for account handling.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L749-L760" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/interface.py#L752-L763" class="git-link">Browse git</a></div>
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li>pyatv.core.facade.FacadeUserAccounts</li>

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -5,8 +5,8 @@
 from enum import Enum
 
 MAJOR_VERSION = "0"
-MINOR_VERSION = "14"
-PATCH_VERSION = "5"
+MINOR_VERSION = "15"
+PATCH_VERSION = "0"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
## 0.15.0 Ralph (2024-08-10)

It has been a long time since the last release (christmas!), so a it's really
due for a new one. I have mostly been busy with other (personal) stuff, so I
have not done much more than maintenance. There are a few changes from the
community though.

Some hightlights:

* Uplift of various dependencies, e.g, fix breaking change in cryptography
* It is possible to skip forward/backwards (Companion) with custom intervals,
  thanks @thiccaxe!
* @bdraco fixed a bug related to changes in chacha20poly1305-reuseable
* Python 3.12 is now (finally) offically supported

This is a minor update indeed. I hope to see some updates in the near future,
especially related to tvOS 18 compatibility as well as new features. I am very
grateful for any help from the community. So if you want to help out
implementing anything, please send a PR and I'll try my best to find time to
review it!

**Changes:**

*Other:*

```
7716858a fix styling for 2462
41b039f9 precise skip in companion, mrp, dmap
618e93a4 companion skip implementation
8331c783 deps: Bump protobuf base version to 4.25.3
2a8afa68 deps: Sync some versions with base versions
9f2f7cd3 Added touch gesture to companion protocol (#2402)
55f3455e deps: Bump some lowest deps versions
31b57b27 cq: Fix pylint issues
42ff35ab docs: Fix codespell issues
ea9d3339 Fix Chacha20Cipher with companion
a84774c1 test: Improve MRP volume tests
8080aaae test: Improve dispatch test
aad6bcd7 test: Improve aiothttp session closing
ed20bf72 Bump setup-python to v5
1b780d46 gha: Bump setup-python tp v4
541ba00d Update tests.yml
ec402a68 gha: Run tests with python 3.12
1037d5ef dep: Bump chacha20poly1305-reuseable and cryptography
1fc1cb0f cq: Run black to fix errors
5c721409 gha: Remove automerge workflow
90b23cc4 Update index.md
7fdfa28a still need to pad for hap
29ad6fc0 still need to pad for hap
e817af09 still need to pad for hap
0c1f6674 lint
d5a29d7e Simplify ChaCha20 Poly1305 implementation
8d78f516 Fix typo in README.
```

**All changes:**

```
e7487a8b build(deps): Bump python from 3.11.0-alpine to 3.12.5-alpine
81cd5819 build(deps): Bump aiohttp from 3.10.1 to 3.10.2 in /requirements
7716858a fix styling for 2462
41b039f9 precise skip in companion, mrp, dmap
618e93a4 companion skip implementation
0d2d3fc9 build(deps): Bump flake8 from 7.1.0 to 7.1.1 in /requirements
1e0d7991 build(deps): Bump black from 24.4.2 to 24.8.0 in /requirements
5f801d4c build(deps): Bump aiohttp from 3.10.0 to 3.10.1 in /requirements
95c43b1c build(deps): Bump mypy-protobuf from 3.5.0 to 3.6.0 in /requirements
8331c783 deps: Bump protobuf base version to 4.25.3
80fd95e6 build(deps): Bump pylint from 3.2.5 to 3.2.6 in /requirements
0abc130b build(deps): Bump protobuf from 5.27.2 to 5.27.3 in /requirements
1bda482d build(deps): Bump mypy from 1.10.1 to 1.11.1 in /requirements
2a8afa68 deps: Sync some versions with base versions
1b38c96f build(deps): Bump pytest-httpserver in /requirements
961340f8 build(deps): Bump pytest from 8.2.2 to 8.3.2 in /requirements
64cc5847 build(deps): Bump aiohttp from 3.9.5 to 3.10.0 in /requirements (#2463)
18ceacd4 build(deps): Bump miniaudio from 1.60 to 1.61 in /requirements (#2459)
9f2f7cd3 Added touch gesture to companion protocol (#2402)
55f3455e deps: Bump some lowest deps versions
c263ff54 build(deps): Bump pydantic from 2.7.4 to 2.8.2 in /requirements
cba3eb9a build(deps): Bump chacha20poly1305-reuseable in /requirements
6e9cc70d build(deps): Bump miniaudio from 1.59 to 1.60 in /requirements
21becc1e build(deps): Bump pytest-asyncio from 0.23.6 to 0.23.8 in /requirements
98dd3f2d build(deps): Bump protobuf from 5.27.1 to 5.27.2 in /requirements
0e024712 build(deps): Bump requests from 2.32.2 to 2.32.3 in /requirements
31b57b27 cq: Fix pylint issues
8d942aa2 build(deps): Bump pylint from 3.0.3 to 3.2.5 in /requirements
42ff35ab docs: Fix codespell issues
1e256440 build(deps): Bump codespell from 2.2.6 to 2.3.0 in /requirements
bbfb6ec2 build(deps): Bump pytest-httpserver in /requirements
d70a9a47 build(deps): Bump zeroconf from 0.131.0 to 0.132.2 in /requirements
9dbdcae1 build(deps): Bump mypy from 1.8.0 to 1.10.1 in /requirements
e84219bb build(deps): Bump pytest-cov from 4.1.0 to 5.0.0 in /requirements
0eec178c build(deps): Bump types-protobuf in /requirements
b1bd82b5 build(deps): Bump pyfakefs from 5.4.1 to 5.6.0 in /requirements
d789cd08 build(deps): Bump pytest-timeout from 2.2.0 to 2.3.1 in /requirements
80b9c91d build(deps): Bump pydantic from 2.5.3 to 2.7.4 in /requirements
ee725bd7 build(deps): Bump pytest-xdist from 3.5.0 to 3.6.1 in /requirements
1c7f3719 build(deps): Bump black from 24.4.0 to 24.4.2 in /requirements
f2152da3 build(deps): Bump protobuf from 4.25.2 to 5.27.1 in /requirements
30bcb66e build(deps): Bump cryptography from 42.0.5 to 42.0.8 in /requirements
ea9d3339 Fix Chacha20Cipher with companion
fb78faf6 build(deps): Bump flake8 from 7.0.0 to 7.1.0 in /requirements
5e6f1b17 build(deps): Bump deepdiff from 6.7.1 to 7.0.1 in /requirements
c5f182af build(deps): Bump pdoc3 from 0.10.0 to 0.11.0 in /requirements
a84774c1 test: Improve MRP volume tests
8080aaae test: Improve dispatch test
aad6bcd7 test: Improve aiothttp session closing
ed20bf72 Bump setup-python to v5
1b780d46 gha: Bump setup-python tp v4
541ba00d Update tests.yml
ec402a68 gha: Run tests with python 3.12
39a868f9 build(deps): Bump pytest from 7.4.3 to 8.2.2 in /requirements
a0aa0d6e build(deps): Bump flake8 from 6.1.0 to 7.0.0 in /requirements
1037d5ef dep: Bump chacha20poly1305-reuseable and cryptography
1fc1cb0f cq: Run black to fix errors
2b0cc6a0 build(deps): Bump black from 23.12.1 to 24.4.0 in /requirements
62020c36 build(deps): Bump types-protobuf in /requirements
5c721409 gha: Remove automerge workflow
90b23cc4 Update index.md
7589ec8b build(deps): Bump types-tabulate in /requirements
7fdfa28a still need to pad for hap
29ad6fc0 still need to pad for hap
e817af09 still need to pad for hap
0c1f6674 lint
d5a29d7e Simplify ChaCha20 Poly1305 implementation
601e553a build(deps): Bump requests from 2.31.0 to 2.32.2 in /requirements
7bff8b32 build(deps): Bump pytest-asyncio from 0.23.2 to 0.23.6 in /requirements
a2da7611 build(deps): Bump pyfakefs from 5.3.2 to 5.4.1 in /requirements
eaf73bf9 build(deps): Bump aiohttp from 3.9.1 to 3.9.5 in /requirements
8d78f516 Fix typo in README.
4b00261b build(deps): Bump protobuf from 4.25.1 to 4.25.2 in /requirements
2f7e2fd1 build(deps): Bump pytest-asyncio from 0.21.1 to 0.23.2 in /requirements
4cd32600 build(deps): Bump isort from 5.12.0 to 5.13.2 in /requirements
51458f95 build(deps): Bump pyfakefs from 5.3.0 to 5.3.2 in /requirements
9d0e7f4c build(deps): Bump pydantic from 2.4.2 to 2.5.3 in /requirements
6d2762df build(deps): Bump pytest-xdist from 3.3.1 to 3.5.0 in /requirements
```