### PR TITLE
Release 0.15.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # CHANGES
 
+## 0.15.1 Seymour (2024-09-06)
+
+Audio streaming stopped working in the previous version and is fixed in this
+version. It also includes a fix to sequence number handling for outgoing
+messages, potentially improving audio streaming to AirPlay receivers from
+third party vendors (not tested however).
+
+**Changes:**
+
+*Protocol: RAOP:*
+
+```
+8a8d176f raop: Fix broken audio streaming
+```
+
+**All changes:**
+
+```
+8a8d176f raop: Fix broken audio streaming
+2cbaf5f5 build(deps): Bump pytest-httpserver in /requirements
+```
+
 ## 0.15.0 Ralph (2024-08-10)
 
 It has been a long time since the last release (christmas!), so a it's really

--- a/pyatv/const.py
+++ b/pyatv/const.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 MAJOR_VERSION = "0"
 MINOR_VERSION = "15"
-PATCH_VERSION = "0"
+PATCH_VERSION = "1"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
## 0.15.1 Seymour (2024-09-06)

Audio streaming stopped working in the previous version and is fixed in this
version. It also includes a fix to sequence number handling for outgoing
messages, potentially improving audio streaming to AirPlay receivers from
third party vendors (not tested however).

**Changes:**

*Protocol: RAOP:*

```
8a8d176f raop: Fix broken audio streaming
```

**All changes:**

```
8a8d176f raop: Fix broken audio streaming
2cbaf5f5 build(deps): Bump pytest-httpserver in /requirements
```
