### PR TITLE
deps: Set cryptography 44.0.1 as base version

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,6 +1,6 @@
 aiohttp==3.8.3,<5
 async-timeout==4.0.2
-cryptography==43.0.0
+cryptography==44.0.1
 chacha20poly1305-reuseable==0.13.2
 ifaddr==0.1.7
 miniaudio==1.45


### PR DESCRIPTION
Earlier versions has a vulnerability so we should not support that.