### PR TITLE
companion: Use static id for _i in _systemInfo

### DIFF
--- a/docs/api/pyatv.const.html
+++ b/docs/api/pyatv.const.html
@@ -950,19 +950,19 @@ is Apple TV Software (pre-tvOS).</p></section>
 <dl>
 <dt id="pyatv.const.TouchAction.Click"><code class="name">var <span class="ident">Click</span> = 5</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.const.TouchAction.Hold"><code class="name">var <span class="ident">Hold</span> = 3</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.const.TouchAction.Press"><code class="name">var <span class="ident">Press</span> = 1</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.const.TouchAction.Release"><code class="name">var <span class="ident">Release</span> = 4</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>

--- a/docs/api/pyatv.interface.html
+++ b/docs/api/pyatv.interface.html
@@ -968,7 +968,7 @@ original value).</p></section>
 <dl>
 <dt id="pyatv.interface.DeviceInfo.OUTPUT_DEVICE_ID"><code class="name">var <span class="ident">OUTPUT_DEVICE_ID</span></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 <h3>Instance variables</h3>
@@ -1253,23 +1253,23 @@ interface: <code>pyatv.interfaces.KeyboardListener</code></p>
 <dl>
 <dt id="pyatv.interface.MediaMetadata.album"><code class="name">var <span class="ident">album</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.interface.MediaMetadata.artist"><code class="name">var <span class="ident">artist</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.interface.MediaMetadata.artwork"><code class="name">var <span class="ident">artwork</span> -> bytes | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.interface.MediaMetadata.duration"><code class="name">var <span class="ident">duration</span> -> float | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.interface.MediaMetadata.title"><code class="name">var <span class="ident">title</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>

--- a/docs/api/pyatv.settings.html
+++ b/docs/api/pyatv.settings.html
@@ -54,6 +54,7 @@ This module has additional documentation
 <h4><code><a title="pyatv.settings.InfoSettings" href="#pyatv.settings.InfoSettings">InfoSettings</a></code></h4>
 <ul class="two-column">
 <li><code><a title="pyatv.settings.InfoSettings.device_id" href="#pyatv.settings.InfoSettings.device_id">device_id</a></code></li>
+<li><code><a title="pyatv.settings.InfoSettings.fill_missing_rp_id" href="#pyatv.settings.InfoSettings.fill_missing_rp_id">fill_missing_rp_id</a></code></li>
 <li><code><a title="pyatv.settings.InfoSettings.mac" href="#pyatv.settings.InfoSettings.mac">mac</a></code></li>
 <li><code><a title="pyatv.settings.InfoSettings.mac_validator" href="#pyatv.settings.InfoSettings.mac_validator">mac_validator</a></code></li>
 <li><code><a title="pyatv.settings.InfoSettings.model" href="#pyatv.settings.InfoSettings.model">model</a></code></li>
@@ -61,6 +62,7 @@ This module has additional documentation
 <li><code><a title="pyatv.settings.InfoSettings.os_build" href="#pyatv.settings.InfoSettings.os_build">os_build</a></code></li>
 <li><code><a title="pyatv.settings.InfoSettings.os_name" href="#pyatv.settings.InfoSettings.os_name">os_name</a></code></li>
 <li><code><a title="pyatv.settings.InfoSettings.os_version" href="#pyatv.settings.InfoSettings.os_version">os_version</a></code></li>
+<li><code><a title="pyatv.settings.InfoSettings.rp_id" href="#pyatv.settings.InfoSettings.rp_id">rp_id</a></code></li>
 </ul>
 </li>
 <li>
@@ -116,7 +118,7 @@ This module has additional documentation
 </header>
 <section id="section-intro">
 <p>Settings for configuring pyatv.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L1-L168" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L1-L178" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -135,7 +137,7 @@ This module has additional documentation
 <section class="desc"><p>Settings related to AirPlay.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L96-L103" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L106-L113" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -145,19 +147,19 @@ This module has additional documentation
 <dl>
 <dt id="pyatv.settings.AirPlaySettings.credentials"><code class="name">var <span class="ident">credentials</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.AirPlaySettings.identifier"><code class="name">var <span class="ident">identifier</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.AirPlaySettings.mrp_tunnel"><code class="name">var <span class="ident">mrp_tunnel</span> -> <a title="pyatv.settings.MrpTunnel" href="#pyatv.settings.MrpTunnel">MrpTunnel</a></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.AirPlaySettings.password"><code class="name">var <span class="ident">password</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>
@@ -167,7 +169,7 @@ This module has additional documentation
 </code></dt>
 <dd>
 <section class="desc"><p>AirPlay version to use.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L47-L57" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L49-L59" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>builtins.str</li>
@@ -197,7 +199,7 @@ This module has additional documentation
 <section class="desc"><p>Settings related to Companion.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L106-L110" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L116-L120" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -207,11 +209,11 @@ This module has additional documentation
 <dl>
 <dt id="pyatv.settings.CompanionSettings.credentials"><code class="name">var <span class="ident">credentials</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.CompanionSettings.identifier"><code class="name">var <span class="ident">identifier</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>
@@ -223,7 +225,7 @@ This module has additional documentation
 <section class="desc"><p>Settings related to DMAP.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L113-L117" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L123-L127" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -233,11 +235,11 @@ This module has additional documentation
 <dl>
 <dt id="pyatv.settings.DmapSettings.credentials"><code class="name">var <span class="ident">credentials</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.DmapSettings.identifier"><code class="name">var <span class="ident">identifier</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>
@@ -249,7 +251,7 @@ This module has additional documentation
 <section class="desc"><p>Information related settings.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L76-L93" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L78-L103" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -259,35 +261,47 @@ This module has additional documentation
 <dl>
 <dt id="pyatv.settings.InfoSettings.device_id"><code class="name">var <span class="ident">device_id</span> -> str</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.InfoSettings.mac"><code class="name">var <span class="ident">mac</span> -> str</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.InfoSettings.model"><code class="name">var <span class="ident">model</span> -> str</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.InfoSettings.name"><code class="name">var <span class="ident">name</span> -> str</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.InfoSettings.os_build"><code class="name">var <span class="ident">os_build</span> -> str</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.InfoSettings.os_name"><code class="name">var <span class="ident">os_name</span> -> str</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.InfoSettings.os_version"><code class="name">var <span class="ident">os_version</span> -> str</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
+</dd>
+<dt id="pyatv.settings.InfoSettings.rp_id"><code class="name">var <span class="ident">rp_id</span> -> str | None</code></dt>
+<dd>
+<section class="desc"></section>
 </dd>
 </dl>
 <h3>Static methods</h3>
 <dl>
+<dt id="pyatv.settings.InfoSettings.fill_missing_rp_id">
+<code class="name flex">
+<span>def <span class="ident">fill_missing_rp_id</span></span>(<span>v)</span>
+</code>
+</dt>
+<dd>
+<section class="desc"></section>
+</dd>
 <dt id="pyatv.settings.InfoSettings.mac_validator">
 <code class="name flex">
 <span>def <span class="ident">mac_validator</span></span>(<span>mac: str) -> str</span>
@@ -306,7 +320,7 @@ This module has additional documentation
 <section class="desc"><p>Settings related to MRP.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L120-L124" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L130-L134" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -316,11 +330,11 @@ This module has additional documentation
 <dl>
 <dt id="pyatv.settings.MrpSettings.credentials"><code class="name">var <span class="ident">credentials</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.MrpSettings.identifier"><code class="name">var <span class="ident">identifier</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>
@@ -330,7 +344,7 @@ This module has additional documentation
 </code></dt>
 <dd>
 <section class="desc"><p>How MRP tunneling over AirPlay is handled.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L60-L70" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L62-L72" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>builtins.str</li>
@@ -360,7 +374,7 @@ This module has additional documentation
 <section class="desc"><p>Container for protocol specific settings.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L154-L161" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L164-L171" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -370,23 +384,23 @@ This module has additional documentation
 <dl>
 <dt id="pyatv.settings.ProtocolSettings.airplay"><code class="name">var <span class="ident">airplay</span> -> <a title="pyatv.settings.AirPlaySettings" href="#pyatv.settings.AirPlaySettings">AirPlaySettings</a></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.ProtocolSettings.companion"><code class="name">var <span class="ident">companion</span> -> <a title="pyatv.settings.CompanionSettings" href="#pyatv.settings.CompanionSettings">CompanionSettings</a></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.ProtocolSettings.dmap"><code class="name">var <span class="ident">dmap</span> -> <a title="pyatv.settings.DmapSettings" href="#pyatv.settings.DmapSettings">DmapSettings</a></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.ProtocolSettings.mrp"><code class="name">var <span class="ident">mrp</span> -> <a title="pyatv.settings.MrpSettings" href="#pyatv.settings.MrpSettings">MrpSettings</a></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.ProtocolSettings.raop"><code class="name">var <span class="ident">raop</span> -> <a title="pyatv.settings.RaopSettings" href="#pyatv.settings.RaopSettings">RaopSettings</a></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>
@@ -398,7 +412,7 @@ This module has additional documentation
 <section class="desc"><p>Settings related to RAOP.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L127-L151" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L137-L161" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -413,15 +427,15 @@ This module has additional documentation
 </dd>
 <dt id="pyatv.settings.RaopSettings.credentials"><code class="name">var <span class="ident">credentials</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.RaopSettings.identifier"><code class="name">var <span class="ident">identifier</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.RaopSettings.password"><code class="name">var <span class="ident">password</span> -> str | None</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.RaopSettings.protocol_version"><code class="name">var <span class="ident">protocol_version</span> -> <a title="pyatv.settings.AirPlayVersion" href="#pyatv.settings.AirPlayVersion">AirPlayVersion</a></code></dt>
 <dd>
@@ -444,7 +458,7 @@ mode (recommended), or 1 or 2 for AirPlay 1 or 2 respectively.</p></section>
 <section class="desc"><p>Settings container class.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L164-L168" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/settings.py#L174-L178" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -454,11 +468,11 @@ mode (recommended), or 1 or 2 for AirPlay 1 or 2 respectively.</p></section>
 <dl>
 <dt id="pyatv.settings.Settings.info"><code class="name">var <span class="ident">info</span> -> <a title="pyatv.settings.InfoSettings" href="#pyatv.settings.InfoSettings">InfoSettings</a></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.settings.Settings.protocols"><code class="name">var <span class="ident">protocols</span> -> <a title="pyatv.settings.ProtocolSettings" href="#pyatv.settings.ProtocolSettings">ProtocolSettings</a></code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>

--- a/docs/api/pyatv.storage.file_storage.html
+++ b/docs/api/pyatv.storage.file_storage.html
@@ -35,7 +35,7 @@ This module has additional documentation
 </header>
 <section id="section-intro">
 <p>File based storage module.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L1-L69" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L1-L70" class="git-link">Browse git</a></div>
 </section>
 <section>
 </section>
@@ -53,7 +53,7 @@ This module has additional documentation
 <dd>
 <section class="desc"><p>Storage module storing settings in a file.</p>
 <p>Initialize a new FileStorage instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L16-L69" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/file_storage.py#L16-L70" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="pyatv.storage.AbstractStorage" href="#pyatv.storage.AbstractStorage">AbstractStorage</a></li>
@@ -81,14 +81,14 @@ on Windows).</p></section>
 <ul class="hlist">
 <li><code><b><a title="pyatv.storage.AbstractStorage" href="#pyatv.storage.AbstractStorage">AbstractStorage</a></b></code>:
 <ul class="hlist">
-<li><code><a title="pyatv.storage.AbstractStorage.changed" href="#pyatv.storage.AbstractStorage.changed">changed</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.get_settings" href="#pyatv.storage.AbstractStorage.get_settings">get_settings</a></code></li>
+<li><code><a title="pyatv.storage.AbstractStorage.has_changed" href="#pyatv.storage.AbstractStorage.has_changed">has_changed</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.load" href="../../interface#pyatv.interface.Storage.load">load</a></code></li>
-<li><code><a title="pyatv.storage.AbstractStorage.mark_as_saved" href="#pyatv.storage.AbstractStorage.mark_as_saved">mark_as_saved</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.remove_settings" href="../../interface#pyatv.interface.Storage.remove_settings">remove_settings</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.save" href="../../interface#pyatv.interface.Storage.save">save</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.settings" href="../../interface#pyatv.interface.Storage.settings">settings</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.storage_model" href="#pyatv.storage.AbstractStorage.storage_model">storage_model</a></code></li>
+<li><code><a title="pyatv.storage.AbstractStorage.update_hash" href="#pyatv.storage.AbstractStorage.update_hash">update_hash</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.update_settings" href="../../interface#pyatv.interface.Storage.update_settings">update_settings</a></code></li>
 </ul>
 </li>

--- a/docs/api/pyatv.storage.html
+++ b/docs/api/pyatv.storage.html
@@ -23,15 +23,20 @@ This module has additional documentation
 <li><code><a title="pyatv.storage.memory_storage" href="memory_storage/">pyatv.storage.memory_storage</a></code></li>
 </ul>
 </li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="pyatv.storage.dict_hash" href="#pyatv.storage.dict_hash">dict_hash</a></code></li>
+</ul>
+</li>
 <li><h3><a href="#header-classes">Classes</a></h3>
 <ul>
 <li>
 <h4><code><a title="pyatv.storage.AbstractStorage" href="#pyatv.storage.AbstractStorage">AbstractStorage</a></code></h4>
 <ul class="">
-<li><code><a title="pyatv.storage.AbstractStorage.changed" href="#pyatv.storage.AbstractStorage.changed">changed</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.get_settings" href="#pyatv.storage.AbstractStorage.get_settings">get_settings</a></code></li>
-<li><code><a title="pyatv.storage.AbstractStorage.mark_as_saved" href="#pyatv.storage.AbstractStorage.mark_as_saved">mark_as_saved</a></code></li>
+<li><code><a title="pyatv.storage.AbstractStorage.has_changed" href="#pyatv.storage.AbstractStorage.has_changed">has_changed</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.storage_model" href="#pyatv.storage.AbstractStorage.storage_model">storage_model</a></code></li>
+<li><code><a title="pyatv.storage.AbstractStorage.update_hash" href="#pyatv.storage.AbstractStorage.update_hash">update_hash</a></code></li>
 </ul>
 </li>
 <li>
@@ -51,7 +56,7 @@ This module has additional documentation
 </header>
 <section id="section-intro">
 <p>Storage module.</p>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L1-L175" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L1-L176" class="git-link">Browse git</a></div>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -69,6 +74,18 @@ This module has additional documentation
 <section>
 </section>
 <section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="pyatv.storage.dict_hash">
+<code class="name flex">
+<span>def <span class="ident">dict_hash</span></span>(<span>data: dict) -> str</span>
+</code>
+</dt>
+<dd>
+<section class="desc"></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L23-L29" class="git-link">Browse git</a></div>
+</dd>
+</dl>
 </section>
 <section>
 <h2 class="section-title" id="header-classes">Classes</h2>
@@ -81,7 +98,7 @@ This module has additional documentation
 <p>New storage modules should generally inherit from this class and implement save and
 load according to the underlying storage mechanism.</p>
 <p>Initialize a new AbstractStorage instance.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L42-L175" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L41-L176" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="pyatv.interface.Storage" href="../../interface#pyatv.interface.Storage">Storage</a></li>
@@ -94,18 +111,10 @@ load according to the underlying storage mechanism.</p>
 </ul>
 <h3>Instance variables</h3>
 <dl>
-<dt id="pyatv.storage.AbstractStorage.changed"><code class="name">var <span class="ident">changed</span> -> bool</code></dt>
-<dd>
-<section class="desc"><p>Return if anything has changed in the model since loading.</p>
-<p>This property will return True if a any setting has been changed. It is reset
-when data is loaded into storage (by calling load) or manually by calling
-mark_as_solved (typically done by save).</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L54-L62" class="git-link">Browse git</a></div>
-</dd>
 <dt id="pyatv.storage.AbstractStorage.storage_model"><code class="name">var <span class="ident">storage_model</span> -> <a title="pyatv.storage.StorageModel" href="#pyatv.storage.StorageModel">StorageModel</a></code></dt>
 <dd>
 <section class="desc"><p>Return storage model representation.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L69-L72" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L66-L69" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 <h3>Methods</h3>
@@ -124,18 +133,27 @@ automatically and returned. If the configuration does not contain any valid
 identitiers, DeviceIdMissingError will be raised.</p>
 <p>If settings exists for a configuration but mismatch, they will be automatically
 updated in the storage. Set ignore_update to False to not update storage.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L89-L122" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L82-L115" class="git-link">Browse git</a></div>
 </dd>
-<dt id="pyatv.storage.AbstractStorage.mark_as_saved">
+<dt id="pyatv.storage.AbstractStorage.has_changed">
 <code class="name flex">
-<span>def <span class="ident">mark_as_saved</span></span>(<span>self) -> None</span>
+<span>def <span class="ident">has_changed</span></span>(<span>self, data: dict) -> bool</span>
 </code>
 </dt>
 <dd>
-<section class="desc"><p>Call after saving to indicate settings have been saved.</p>
-<p>The changed property reflects whether something has been changed in the model
-or not based on calling this method.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L81-L87" class="git-link">Browse git</a></div>
+<section class="desc"><p>Return if anything has changed in the model since loading.</p>
+<p>This method compares a hash of the saved data with the provided data to deduce
+if anything has changed.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L53-L59" class="git-link">Browse git</a></div>
+</dd>
+<dt id="pyatv.storage.AbstractStorage.update_hash">
+<code class="name flex">
+<span>def <span class="ident">update_hash</span></span>(<span>self, data: dict) -> None</span>
+</code>
+</dt>
+<dd>
+<section class="desc"><p>Call after saving to indicate settings have been saved.</p></section>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L78-L80" class="git-link">Browse git</a></div>
 </dd>
 </dl>
 <h3>Inherited members</h3>
@@ -159,7 +177,7 @@ or not based on calling this method.</p></section>
 <section class="desc"><p>Storage model of data that is saved or restored to underlying storage.</p>
 <p>Create a new model by parsing and validating input data from keyword arguments.</p>
 <p>Raises ValidationError if the input data cannot be parsed to form a valid model.</p></section>
-<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L35-L39" class="git-link">Browse git</a></div>
+<div class="git-link-div"><a href="https://github.com/postlund/pyatv/blob/master/pyatv/storage/__init__.py#L34-L38" class="git-link">Browse git</a></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>pydantic.v1.main.BaseModel</li>
@@ -169,11 +187,11 @@ or not based on calling this method.</p></section>
 <dl>
 <dt id="pyatv.storage.StorageModel.devices"><code class="name">var <span class="ident">devices</span> -> List[<a title="pyatv.settings.Settings" href="../../settings#pyatv.settings.Settings">Settings</a>]</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 <dt id="pyatv.storage.StorageModel.version"><code class="name">var <span class="ident">version</span> -> int</code></dt>
 <dd>
-<section class="desc"><p>The type of the None singleton.</p></section>
+<section class="desc"></section>
 </dd>
 </dl>
 </dd>

--- a/docs/api/pyatv.storage.memory_storage.html
+++ b/docs/api/pyatv.storage.memory_storage.html
@@ -62,14 +62,14 @@ be forgotten when restarting the python interpreter.</p>
 <ul class="hlist">
 <li><code><b><a title="pyatv.storage.AbstractStorage" href="#pyatv.storage.AbstractStorage">AbstractStorage</a></b></code>:
 <ul class="hlist">
-<li><code><a title="pyatv.storage.AbstractStorage.changed" href="#pyatv.storage.AbstractStorage.changed">changed</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.get_settings" href="#pyatv.storage.AbstractStorage.get_settings">get_settings</a></code></li>
+<li><code><a title="pyatv.storage.AbstractStorage.has_changed" href="#pyatv.storage.AbstractStorage.has_changed">has_changed</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.load" href="../../interface#pyatv.interface.Storage.load">load</a></code></li>
-<li><code><a title="pyatv.storage.AbstractStorage.mark_as_saved" href="#pyatv.storage.AbstractStorage.mark_as_saved">mark_as_saved</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.remove_settings" href="../../interface#pyatv.interface.Storage.remove_settings">remove_settings</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.save" href="../../interface#pyatv.interface.Storage.save">save</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.settings" href="../../interface#pyatv.interface.Storage.settings">settings</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.storage_model" href="#pyatv.storage.AbstractStorage.storage_model">storage_model</a></code></li>
+<li><code><a title="pyatv.storage.AbstractStorage.update_hash" href="#pyatv.storage.AbstractStorage.update_hash">update_hash</a></code></li>
 <li><code><a title="pyatv.storage.AbstractStorage.update_settings" href="../../interface#pyatv.interface.Storage.update_settings">update_settings</a></code></li>
 </ul>
 </li>

--- a/pyatv/protocols/companion/api.py
+++ b/pyatv/protocols/companion/api.py
@@ -196,7 +196,7 @@ class CompanionAPI(
                 "_bf": 0,
                 "_cf": 512,
                 "_clFl": 128,
-                "_i": "cafecafecafe",  # TODO: Figure out what to put here
+                "_i": info.rp_id,
                 "_idsID": creds.client_id,
                 # Not really device id here, but better then anything...
                 "_pubID": info.device_id,

--- a/pyatv/settings.py
+++ b/pyatv/settings.py
@@ -1,6 +1,7 @@
 """Settings for configuring pyatv."""
 
 from enum import Enum
+import os
 import re
 from typing import Optional
 
@@ -36,6 +37,7 @@ _MAC_REGEX = r"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}"
 DEFAULT_NAME = "pyatv"
 DEFUALT_MAC = "02:70:79:61:74:76"  # Locally administrated (02) + "pyatv" in hex
 DEFAULT_DEVICE_ID = "FF:70:79:61:74:76"  # 0xFF + "pyatv"
+DEFAULT_RP_ID = "cafecafecafe"
 DEFAULT_MODEL = "iPhone10,6"
 DEFAULT_OS_NAME = "iPhone OS"
 DEFAULT_OS_BUILD = "18G82"
@@ -80,6 +82,7 @@ class InfoSettings(BaseModel, extra="ignore"):  # type: ignore[call-arg]
     mac: str = DEFUALT_MAC
     model: str = DEFAULT_MODEL
     device_id: str = DEFAULT_DEVICE_ID
+    rp_id: Optional[str] = None
     os_name: str = DEFAULT_OS_NAME
     os_build: str = DEFAULT_OS_BUILD
     os_version: str = DEFAULT_OS_VERSION
@@ -91,6 +94,14 @@ class InfoSettings(BaseModel, extra="ignore"):  # type: ignore[call-arg]
         if re.match(_MAC_REGEX, mac) is None:
             raise ValueError(f"{mac} is not a valid MAC address")
         return mac
+
+    @field_validator("rp_id", always=True)
+    @classmethod
+    def fill_missing_rp_id(cls, v):
+        """Generate a new random rp_id if it is missing."""
+        if v is None:
+            return os.urandom(6).hex()
+        return v
 
 
 class AirPlaySettings(BaseModel, extra="ignore"):  # type: ignore[call-arg]

--- a/pyatv/storage/__init__.py
+++ b/pyatv/storage/__init__.py
@@ -1,6 +1,7 @@
 """Storage module."""
 
 from hashlib import sha256
+import json
 from typing import List, Sequence
 
 from pyatv.const import Protocol
@@ -19,14 +20,12 @@ __pdoc__ = {
 MODEL_VERSION = 1
 
 
-def _calculate_settings_hash(settings: List[Settings]) -> str:
+def dict_hash(data: dict) -> str:
     # Calculate a hash of all settings by dumping content to JSON and hashing all
     # output using SHA256 (arbitrarily chosen for now). This is not very efficient
     # (especially when making multiple calls) but should be reliable and good enough.
     hasher = sha256()
-    for setting in settings:
-        setting_json = setting.json(exclude_defaults=True)
-        hasher.update(setting_json.encode("utf-8"))
+    hasher.update(json.dumps(data).encode("utf-8"))
     return hasher.hexdigest()
 
 
@@ -49,17 +48,15 @@ class AbstractStorage(Storage):
     def __init__(self) -> None:
         """Initialize a new AbstractStorage instance."""
         self._settings: List[Settings] = []
-        self._settings_hash: str = _calculate_settings_hash(self._settings)
+        self._hash: str = dict_hash({})
 
-    @property
-    def changed(self) -> bool:
+    def has_changed(self, data: dict) -> bool:
         """Return if anything has changed in the model since loading.
 
-        This property will return True if a any setting has been changed. It is reset
-        when data is loaded into storage (by calling load) or manually by calling
-        mark_as_solved (typically done by save).
+        This method compares a hash of the saved data with the provided data to deduce
+        if anything has changed.
         """
-        return self._settings_hash != _calculate_settings_hash(self._settings)
+        return self._hash != dict_hash(data)
 
     @property
     def settings(self) -> Sequence[Settings]:
@@ -78,13 +75,9 @@ class AbstractStorage(Storage):
             raise SettingsError(f"unsupported version: {other.version}")
         self._settings = other.devices
 
-    def mark_as_saved(self) -> None:
-        """Call after saving to indicate settings have been saved.
-
-        The changed property reflects whether something has been changed in the model
-        or not based on calling this method.
-        """
-        self._settings_hash = _calculate_settings_hash(self._settings)
+    def update_hash(self, data: dict) -> None:
+        """Call after saving to indicate settings have been saved."""
+        self._hash = dict_hash(data)
 
     async def get_settings(self, config: BaseConfig) -> Settings:
         """Return settings for a specific configuration (device).
@@ -169,6 +162,14 @@ class AbstractStorage(Storage):
                     settings.protocols.raop, update=service.settings()
                 )
                 settings.protocols.raop.identifier = service.identifier
+
+    def __iter__(self) -> dict:
+        # If settings are empty for a device (e.e. no settings overridden or credentials
+        # saved), then the output will just be an empty dict. To not pollute the output
+        # with those, we do some filtering here.
+        dumped = self.storage_model.dict(exclude_defaults=True)
+        dumped["devices"] = [device for device in dumped["devices"] if device != {}]
+        return iter(dumped.items())
 
     def __repr__(self) -> str:
         """Return representation of MemoryStorage."""


### PR DESCRIPTION
This change generates a random "rp identifier" that is included in _systemInfo sent by the Companion protocol. It's not really known what this identifier is, but it comes from rapportd/Rapport.framework and seems to be unique per device. So we generate a unique one per device and store it with settings.

Adjustments have been made so that if this identifier is missing in settings, a new identifier will be generated and saved automatically.

Relates to #2656