### PR TITLE
Modernize packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
             python scripts/version.py sha1
           fi
 
-          python -m pip install --upgrade setuptools pip wheel
-          python setup.py sdist bdist_wheel
+          python -m pip install --upgrade build
+          python -m build
           echo "version=$(python scripts/version.py get)" >> $GITHUB_OUTPUT
 
       - name: Log in to the Container registry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,48 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=77.0"]
+
+[project]
+name="pyatv"
+license = "MIT"
+license-files = ["LICENSE.md"]
+description = "A client library for Apple TV and AirPlay devices"
+readme = "README.md"
+authors = [{ name = "Pierre Ståhl", email = "pierre.staahl@gmail.com" }]
+requires-python = ">=3.9.0"
+keywords = ["apple", "tv", "airplay", "raop", "companion", "dmap", "dacp"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Home Automation",
+    "Typing :: Typed",
+]
+dynamic = ["version", "dependencies"]
+
+[project.urls]
+"Homepage" = "https://pyatv.dev"
+"Repository" = "https://github.com/postlund/pyatv"
+"Bug Reports" = "https://github.com/postlund/pyatv/issues"
+
+[project.scripts]
+atvremote = "pyatv.scripts.atvremote:main"
+atvproxy = "pyatv.scripts.atvproxy:main"
+atvscript = "pyatv.scripts.atvscript:main"
+atvlog = "pyatv.scripts.atvlog:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "pyatv.const.__version__" }
+
+[tool.setuptools.packages.find]
+include = ["pyatv*"]
+
 [tool.black]
 target-version = ["py35", "py36", "py37", "py38"]
 extend-exclude = '(protobuf/(__init__|.*_pb2).py)|__pycache__'

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,7 @@
 
 from pathlib import Path
 from os.path import join, dirname
-from setuptools import setup, find_packages
-
-GITHUB_URL = "https://github.com/postlund/pyatv"
-
-# Read in version without importing pyatv
-# http://stackoverflow.com/questions/6357361/alternative-to-execfile-in-python-3
-exec(compile(open("pyatv/const.py", "rb").read(), "pyatv/const.py", "exec"))
+from setuptools import setup
 
 
 def read(fname):
@@ -23,50 +17,5 @@ def get_requirements():
 
 
 setup(
-    name="pyatv",
-    version=__version__,
-    license="MIT",
-    url="https://pyatv.dev",
-    download_url=f"{GITHUB_URL}/archive/refs/tags/v{__version__}.zip",
-    project_urls={
-        "Repository": GITHUB_URL,
-        "Bug Reports": f"{GITHUB_URL}/issues"
-    },
-    author="Pierre Ståhl",
-    author_email="pierre.staahl@gmail.com",
-    description="A client library for Apple TV and AirPlay devices",
-    long_description=read("README.md"),
-    long_description_content_type="text/markdown",
-    packages=find_packages(exclude=["tests", "tests.*", "examples"]),
-    include_package_data=True,
-    zip_safe=False,
-    platforms="any",
     install_requires=get_requirements(),
-    test_suite="tests",
-    keywords=["apple", "tv", "airplay", "raop", "companion", "dmap", "dacp"],
-    setup_requires=["pytest-runner"],
-    tests_require=["pytest==6.2.5", "pytest-xdist==2.4.0"],
-    python_requires=">=3.9.0",
-    entry_points={
-        "console_scripts": [
-            "atvremote = pyatv.scripts.atvremote:main",
-            "atvproxy = pyatv.scripts.atvproxy:main",
-            "atvscript = pyatv.scripts.atvscript:main",
-            "atvlog = pyatv.scripts.atvlog:main",
-        ]
-    },
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Home Automation",
-        "Typing :: Typed",
-    ],
 )


### PR DESCRIPTION
- Move static metadata to `pyproject.toml`
- Adopt PEP 639 license expression
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
- Remove `zip_safe`. It's considered obsolete.
- Remove `platforms="any"`. It's basically unused at this point. The better option is the `"Operating System :: OS Independent"` classifier which is already present.
- Remove explicit `include_package_data=True`. This is the default for `pyproject.toml` based configs in setuptools.
- Remove `setup_requires`. This has been replaced by `build-system.requires`. Furthermore `pytest-runner` isn't required for the build itself.
- Remove `test_suite` and `tests_require`. Running tests via setuptools has long been deprecated and isn't used here anyways.
- Remove `download_url`. This can be obtained from PyPI and is unnecessary.
- Replace `python setup.py` call with `python -m build`.

Metadata diff
```diff
 ...
-Author: Pierre Ståhl
-Author-email: pierre.staahl@gmail.com
+Author-email: Pierre Ståhl <pierre.staahl@gmail.com>
-License: MIT
+License-Expression: MIT
-Home-page: https://pyatv.dev
-Download-URL: https://github.com/postlund/pyatv/archive/refs/tags/v0.16.0.zip
+Project-URL: Homepage, https://pyatv.dev
 ...
-Platform: any
 ...
-Classifier: License :: OSI Approved :: MIT License
 Classifier: Operating System :: OS Independent
 ...
```