### PR TITLE
Use asyncio.timeout for Python 3.11+

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -1,5 +1,5 @@
 aiohttp==3.8.3,<5
-async-timeout==4.0.2
+async-timeout==4.0.2;python_version<'3.11'
 cryptography==44.0.1
 chacha20poly1305-reuseable==0.13.2
 ifaddr==0.1.7

--- a/pyatv/protocols/mrp/protocol.py
+++ b/pyatv/protocols/mrp/protocol.py
@@ -4,10 +4,9 @@ import asyncio
 from collections import namedtuple
 from enum import Enum
 import logging
+import sys
 from typing import Dict, NamedTuple, Optional
 import uuid
-
-import async_timeout
 
 from pyatv import exceptions
 from pyatv.auth.hap_pairing import parse_credentials
@@ -19,6 +18,11 @@ from pyatv.protocols.mrp.auth import MrpPairVerifyProcedure
 from pyatv.protocols.mrp.connection import AbstractMrpConnection
 from pyatv.settings import InfoSettings
 from pyatv.support import error_handler
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -271,7 +275,7 @@ class MrpProtocol(MessageDispatcher[int, protobuf.ProtocolMessage]):
 
         try:
             # The connection instance will dispatch the message
-            async with async_timeout.timeout(timeout):
+            async with async_timeout(timeout):
                 await semaphore.acquire()
 
         except Exception:

--- a/pyatv/support/http.py
+++ b/pyatv/support/http.py
@@ -8,6 +8,7 @@ import logging
 import pathlib
 import plistlib
 import re
+import sys
 from typing import (
     Any,
     Callable,
@@ -22,12 +23,16 @@ from typing import (
 
 from aiohttp import ClientSession, web
 from aiohttp.web import middleware
-import async_timeout
 from requests.structures import CaseInsensitiveDict
 
 from pyatv import const, exceptions
 from pyatv.support import log_binary
 from pyatv.support.net import unused_port
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -460,7 +465,7 @@ class HttpConnection(asyncio.Protocol):
         pending_request = HttpConnection.PendingRequest(event=asyncio.Event())
         self._requests.appendleft(pending_request)
         try:
-            async with async_timeout.timeout(timeout):
+            async with async_timeout(timeout):
                 await pending_request.event.wait()
 
             if pending_request.connection_closed:

--- a/pyatv/support/rtsp.py
+++ b/pyatv/support/rtsp.py
@@ -9,13 +9,17 @@ from hashlib import md5
 import logging
 import plistlib
 from random import randrange
+import sys
 from typing import Any, Dict, Mapping, NamedTuple, Optional, Tuple, Union
-
-import async_timeout
 
 from pyatv.protocols.dmap import tags
 from pyatv.support.http import HttpConnection, HttpResponse, decode_bplist_from_body
 from pyatv.support.metadata import MediaMetadata
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -314,7 +318,7 @@ class RtspSession:
 
         # Wait for response to the CSeq we expect
         try:
-            async with async_timeout.timeout(4):
+            async with async_timeout(4):
                 await self.requests[cseq][0].wait()
             response = self.requests[cseq][1]
         except asyncio.TimeoutError as ex:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.12.13
-async-timeout==5.0.1
+async-timeout==5.0.1;python_version<'3.11'
 cryptography==45.0.4
 chacha20poly1305-reuseable==0.13.2
 ifaddr==0.2.0


### PR DESCRIPTION
`async-timeout` is deprecated for Python 3.11+ as it's now included in the stdlib.
https://github.com/aio-libs/async-timeout