### PR TITLE
Drop support for pydantic v1

### DIFF
--- a/base_versions.txt
+++ b/base_versions.txt
@@ -5,7 +5,7 @@ chacha20poly1305-reuseable==0.13.2
 ifaddr==0.1.7
 miniaudio==1.45
 protobuf==6.31.1
-pydantic==1.10.10
+pydantic==2.0.0
 requests==2.30.0
 srptools==0.2.0
 tabulate==0.9.0

--- a/pyatv/settings.py
+++ b/pyatv/settings.py
@@ -5,7 +5,7 @@ import os
 import re
 from typing import Optional
 
-from pyatv.support.pydantic_compat import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 __pdoc__ = {
     "InfoSettings.model_config": False,
@@ -95,7 +95,7 @@ class InfoSettings(BaseModel, extra="ignore"):  # type: ignore[call-arg]
             raise ValueError(f"{mac} is not a valid MAC address")
         return mac
 
-    @field_validator("rp_id", always=True)
+    @field_validator("rp_id")
     @classmethod
     def fill_missing_rp_id(cls, v):
         """Generate a new random rp_id if it is missing."""

--- a/pyatv/storage/__init__.py
+++ b/pyatv/storage/__init__.py
@@ -4,11 +4,13 @@ from hashlib import sha256
 import json
 from typing import Any, Iterator, List, Sequence, Tuple
 
+from pydantic import BaseModel
+
 from pyatv.const import Protocol
 from pyatv.exceptions import DeviceIdMissingError, SettingsError
 from pyatv.interface import BaseConfig, Storage
 from pyatv.settings import Settings
-from pyatv.support.pydantic_compat import BaseModel, model_copy
+from pyatv.support.pydantic_compat import model_copy
 
 __pdoc_dev_page__ = "/development/storage"
 
@@ -168,7 +170,7 @@ class AbstractStorage(Storage):
         # If settings are empty for a device (e.e. no settings overridden or credentials
         # saved), then the output will just be an empty dict. To not pollute the output
         # with those, we do some filtering here.
-        dumped = self.storage_model.dict(exclude_defaults=True)
+        dumped = self.storage_model.model_dump(exclude_defaults=True)
         dumped["devices"] = [device for device in dumped["devices"] if device != {}]
         return iter(dumped.items())
 

--- a/pyatv/storage/file_storage.py
+++ b/pyatv/storage/file_storage.py
@@ -53,7 +53,7 @@ class FileStorage(AbstractStorage):
             _LOGGER.debug("Loading settings from %s", self._filename)
             model_json = await self._loop.run_in_executor(None, self._read_file)
             raw_data = json.loads(model_json)
-            self.storage_model = StorageModel.parse_obj(raw_data)
+            self.storage_model = StorageModel.model_validate(raw_data)
 
             # Update hash based on what we read from file rather than serializing the
             # model. The reasonf for this is that pydantic might (because of

--- a/pyatv/support/__init__.py
+++ b/pyatv/support/__init__.py
@@ -9,10 +9,10 @@ from typing import Any, List, Sequence, Union
 import warnings
 
 from google.protobuf.text_format import MessageToString
+from pydantic import BaseModel
 
 import pyatv
 from pyatv import exceptions
-from pyatv.support.pydantic_compat import BaseModel
 
 _PROTOBUF_LINE_LENGTH = 150
 _BINARY_LINE_LENGTH = 512
@@ -208,5 +208,5 @@ def update_model_field(
     if len(splitted_path) > 1:
         update_model_field(getattr(model, next_field), splitted_path[1], value)
     else:
-        model.parse_obj({field: value})
+        model.model_validate({field: value})
         setattr(model, field, value)

--- a/pyatv/support/pydantic_compat.py
+++ b/pyatv/support/pydantic_compat.py
@@ -10,27 +10,20 @@ but instead getting import from here. That makes it easy to remove these changes
 later on.
 """
 
-from typing import Any, Mapping
+from typing import Any, Mapping, TypeVar
 
-# pylint: disable=unused-import
+from pydantic import BaseModel
 
-try:
-    from pydantic.v1 import BaseModel, Field, ValidationError  # noqa
-    from pydantic.v1 import validator as field_validator  # noqa
-except ImportError:
-    from pydantic import BaseModel, Field, ValidationError  # noqa
-    from pydantic import validator as field_validator  # noqa
-
-# pylint: enable=unused-import
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 
-def model_copy(model: BaseModel, /, update: Mapping[str, Any]) -> BaseModel:
+def model_copy(model: _ModelT, /, update: Mapping[str, Any]) -> _ModelT:
     """Model copy compatible with pydantic v2.
 
     Seems like pydantic v1 carries over keys with None values even though target model
     doesn't have the key. Not the case with v2. This method removes keys with None
     values.
     """
-    return model.copy(
+    return model.model_copy(
         update={key: value for key, value in update.items() if value is not None}
     )

--- a/tests/support/test_support.py
+++ b/tests/support/test_support.py
@@ -9,6 +9,7 @@ from typing import Optional
 from unittest.mock import MagicMock, patch
 
 from deepdiff import DeepDiff
+from pydantic import BaseModel, Field, ValidationError
 import pytest
 
 from pyatv import exceptions
@@ -23,7 +24,6 @@ from pyatv.support import (
     stringify_model,
     update_model_field,
 )
-from pyatv.support.pydantic_compat import BaseModel, Field, ValidationError
 
 
 class DummyException(Exception):

--- a/tests/test_storage_functional.py
+++ b/tests/test_storage_functional.py
@@ -51,7 +51,7 @@ async def test_scan_inserts_into_storage(unicast_scan, mockfs):
     # Compare content to ensure they are exactly the same.
     storage2 = await new_storage(STORAGE_FILENAME, loop)
     settings2 = await storage2.get_settings(conf)
-    assert not DeepDiff(settings2.dict(), settings1.dict())
+    assert not DeepDiff(settings2.model_dump(), settings1.model_dump())
 
 
 async def test_provides_storage_to_pairing_handler(


### PR DESCRIPTION
Pydantic will only support Python 3.14 for `v2` models. Home Assistant has since also moved to `v2`, so it's likely safe to drop support for `v1`. https://github.com/pydantic/pydantic/issues/11613#issuecomment-3061291322