### PR TITLE
Feat/fire and forget remote

### DIFF
--- a/pyatv/core/facade.py
+++ b/pyatv/core/facade.py
@@ -47,6 +47,24 @@ class FacadeRemoteControl(Relayer, interface.RemoteControl):
 
     # pylint: disable=invalid-name
     @shield.guard
+    async def send_command(
+        self,
+        command,
+        *,
+        wait_for_response: bool = True,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> None:
+        """Send a protocol-specific command (fire-and-forget or with response)."""
+        return await self.relay("send_command")(
+            command=command,
+            wait_for_response=wait_for_response,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    # pylint: disable=invalid-name
+    @shield.guard
     async def up(self, action: InputAction = InputAction.SingleTap) -> None:
         """Press key up."""
         return await self.relay("up")(action=action)

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -353,6 +353,17 @@ class RemoteControl:
         """Press key menu."""
         raise exceptions.NotSupportedError()
 
+    async def send_command(
+        self,
+        command,
+        *,
+        wait_for_response: bool = True,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> None:
+        """Send a protocol-specific command (fire-and-forget or with response)."""
+        raise exceptions.NotSupportedError()
+
     @feature(12, "VolumeUp", "Increase volume (deprecated: use Audio.volume_up).")
     async def volume_up(self) -> None:
         """Press key volume up.


### PR DESCRIPTION
This pull request introduces several reliability and usability improvements to the MRP protocol implementation, focusing on robust connection handling, improved command sending flexibility, and enhanced compatibility with sandboxed network environments. It also adds new tests to ensure correct behavior in these areas.

**MRP Protocol Reliability and Command Handling:**

- Added robust connection checks and error handling in `send` and `send_raw` methods of `MrpConnection`, raising `ConnectionLostError` if the connection is closed or lost during send operations. [[1]](diffhunk://#diff-54134f37d950b726b585344b66f0c8964dcb13d87863e5ecee91d65a07ccdf89R124-R135) [[2]](diffhunk://#diff-54134f37d950b726b585344b66f0c8964dcb13d87863e5ecee91d65a07ccdf89R146-R157)
- Refactored `MrpProtocol` to centralize connection state checks with `_ensure_send_possible`, ensuring proper exceptions are raised for invalid or closed states. Enhanced `send` and `send_and_receive` to handle fire-and-forget (no response) operations and propagate connection errors. [[1]](diffhunk://#diff-192e15381e48437df478e7c9d2ebd53f2c46dbaa5881dcc28e378c5fcc1b7f40R225-R265) [[2]](diffhunk://#diff-192e15381e48437df478e7c9d2ebd53f2c46dbaa5881dcc28e378c5fcc1b7f40R280-R291) [[3]](diffhunk://#diff-192e15381e48437df478e7c9d2ebd53f2c46dbaa5881dcc28e378c5fcc1b7f40R300-R321)
- Updated internal `_send_command` and public `send_command` in `MrpRemoteControl` to support fire-and-forget commands and custom timeouts, improving API flexibility. [[1]](diffhunk://#diff-d14c27257cfb47f4e5b278ef342478daddd85b4f5d457822795ba820519aee04R75) [[2]](diffhunk://#diff-d14c27257cfb47f4e5b278ef342478daddd85b4f5d457822795ba820519aee04L341-R359) [[3]](diffhunk://#diff-d14c27257cfb47f4e5b278ef342478daddd85b4f5d457822795ba820519aee04R372-R384)

**Network Compatibility Improvements:**

- Improved multicast socket setup and private address detection to work on sandboxed platforms (e.g., iOS, Docker) by probing the default IPv4 address as a fallback when no adapters are reported. [[1]](diffhunk://#diff-d231de9cbfc1619ab0a23633d01b4c77fdc1e363962ae47c0b8c1dc27ae06ad4R50-R69) [[2]](diffhunk://#diff-d231de9cbfc1619ab0a23633d01b4c77fdc1e363962ae47c0b8c1dc27ae06ad4R97-R107)

**Testing Enhancements:**

- Added tests for fire-and-forget command sending, connection loss handling, and the new fallback network behaviors to ensure correctness and reliability. [[1]](diffhunk://#diff-9f0b41f45ce59f2c87d8b51eebc71a24f1399dac230626ba961efddfee23ba79R386-R396) [[2]](diffhunk://#diff-ef98c42ec4bf12aa95497e881b9caca0546b061d893c51de04ed9f21695aacdfL12-R18) [[3]](diffhunk://#diff-ef98c42ec4bf12aa95497e881b9caca0546b061d893c51de04ed9f21695aacdfR28-R57) [[4]](diffhunk://#diff-ef98c42ec4bf12aa95497e881b9caca0546b061d893c51de04ed9f21695aacdfR97-R123)