### PR TITLE
Pin Python version in dockerfile to 3.14.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.15.0a5-alpine
+FROM python:3.14.2-alpine
 ARG VERSION
 
 WORKDIR .


### PR DESCRIPTION
Fix failing CI job. For details, see: https://github.com/postlund/pyatv/pull/2813#issuecomment-3780626552