### PR TITLE
FIx for Keyboard Focus state changed not working

### DIFF
--- a/pyatv/settings.py
+++ b/pyatv/settings.py
@@ -82,7 +82,7 @@ class InfoSettings(BaseModel, extra="ignore"):  # type: ignore[call-arg]
     mac: str = DEFUALT_MAC
     model: str = DEFAULT_MODEL
     device_id: str = DEFAULT_DEVICE_ID
-    rp_id: Optional[str] = None
+    rp_id: str = Field(default_factory=lambda: os.urandom(6).hex())
     os_name: str = DEFAULT_OS_NAME
     os_build: str = DEFAULT_OS_BUILD
     os_version: str = DEFAULT_OS_VERSION
@@ -95,7 +95,7 @@ class InfoSettings(BaseModel, extra="ignore"):  # type: ignore[call-arg]
             raise ValueError(f"{mac} is not a valid MAC address")
         return mac
 
-    @field_validator("rp_id")
+    @field_validator("rp_id", mode="before")
     @classmethod
     def fill_missing_rp_id(cls, v):
         """Generate a new random rp_id if it is missing."""


### PR DESCRIPTION
Fix for #2853 
Need to be tested on previous tvOS.

On pyatv version 0.16.1 with pydantic v1 `@field_validator("rp_id", always=True)` made the validator run even when rp_id was not set, so pyatv generated a random rp_id.
On version 0.17.0 with pydantic v2, the always=True has been correctly removed, however that validator is not called on the default None, so when sending _systemInfo message, the "_i" could be None and, after that, no keyboard focus state changes are fired.

With this fix, the default_factory generates the rp_id if it's missing and the validator works only if the rp_id is None.