### PR TITLE
Fix Companion Protocol Power State Handling

### DIFF
--- a/docs/documentation/protocols.md
+++ b/docs/documentation/protocols.md
@@ -950,6 +950,24 @@ Once a command has been called, it will be cached making it possible to call it 
 sending `_sessionStart` again. This is probably why `_launchApp` keeps working after
 requesting the list from Shortcuts (as it will set up a new session).
 
+A client should also register a *TV Remote Client* session by sending
+`TVRCSessionStart` after `_sessionStart`. Some Apple TVs will not answer commands
+such as `FetchAttentionState` until this session has been registered:
+
+```javascript
+{
+    '_i': 'TVRCSessionStart',
+    '_x': 123,
+    '_t': 2,
+    '_c': {
+        'ProtocolVersionKey': '1.2'
+    }
+}
+```
+
+The response echoes the negotiated `ProtocolVersionKey`. Older devices that do not
+implement this message return an error, so it is safe to always send it.
+
 #### Events
 
 It is possible to subscribe to events using `_interest`:
@@ -966,8 +984,10 @@ It is possible to subscribe to events using `_interest`:
 }
 ```
 
-No explicit response is sent to the request, other than an event update. So far `_iMC`
-(Media Control) is the only known event type. An event update might look like this:
+No explicit response is sent to the request, other than an event update. Known event
+types include `_iMC` (Media Control) and `SystemStatus`/`TVSystemStatus` (power state).
+The Apple TV only pushes `SystemStatus`/`TVSystemStatus` events to a client that sent a
+non-null `_i` in its `_systemInfo`. An event update might look like this:
 
 ```javascript
 {

--- a/pyatv/protocols/companion/api.py
+++ b/pyatv/protocols/companion/api.py
@@ -153,6 +153,7 @@ class CompanionAPI(
         await self.system_info()
         await self._touch_start()
         await self._session_start()
+        await self._tv_rc_session_start()
         await self._text_input_start()
 
         await self.subscribe_event("_iMC")
@@ -220,6 +221,20 @@ class CompanionAPI(
         remote_sid = cast(Mapping[str, Any], resp["_c"])["_sid"]
         self.sid = (remote_sid << 32) | local_sid
         _LOGGER.debug("Started session with SID 0x%X", self.sid)
+
+    async def _tv_rc_session_start(self) -> None:
+        """Open a TV Remote Client session.
+
+        tvOS does not answer FetchAttentionState until a TV Remote
+        Client session is registered with the tvremoted process.
+        """
+        try:
+            resp = await self._send_command(
+                "TVRCSessionStart", {"ProtocolVersionKey": "1.2"}
+            )
+            _LOGGER.debug("Started TV RC session: %s", resp.get("_c"))
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.debug("TVRCSessionStart not supported: %s", ex)
 
     async def _session_stop(self) -> None:
         await self._send_command(

--- a/pyatv/protocols/companion/api.py
+++ b/pyatv/protocols/companion/api.py
@@ -197,7 +197,9 @@ class CompanionAPI(
                 "_bf": 0,
                 "_cf": 512,
                 "_clFl": 128,
-                "_i": info.rp_id,
+                # A null "_i" stops the device from pushing TVSystemStatus
+                # (power state) events; fall back to a stable identifier.
+                "_i": info.rp_id or info.device_id.replace(":", "").lower(),
                 "_idsID": creds.client_id,
                 # Not really device id here, but better then anything...
                 "_pubID": info.device_id,

--- a/tests/fake_device/companion.py
+++ b/tests/fake_device/companion.py
@@ -97,6 +97,8 @@ class FakeCompanionState:
         self.powered_on: bool = True
         self.sid: int = 0
         self.service_type: Optional[str] = None
+        self.system_info: Optional[dict] = None
+        self.tv_rc_protocol_version: Optional[str] = None
         self.latest_button: Optional[str] = None
         self.media_control_flags: int = MediaControlFlags.Volume
         self.interests: Set[str] = set()
@@ -485,7 +487,12 @@ class FakeCompanionService(CompanionServerAuth, asyncio.Protocol):
             self.send_error(message, "Invalid SID")
 
     def handle__systeminfo(self, message):
+        self.state.system_info = message["_c"]
         self.send_response(message, {})
+
+    def handle_tvrcsessionstart(self, message):
+        self.state.tv_rc_protocol_version = message["_c"].get("ProtocolVersionKey")
+        self.send_response(message, message.get("_c", {}))
 
     def handle__interest(self, message):
         content = message["_c"]

--- a/tests/protocols/companion/test_companion_functional.py
+++ b/tests/protocols/companion/test_companion_functional.py
@@ -188,6 +188,15 @@ async def test_session_start_and_stop(companion_client, companion_state):
     assert companion_state.sid == 0
 
 
+async def test_tv_rc_session_start(companion_client, companion_state):
+    assert companion_state.tv_rc_protocol_version == "1.2"
+
+
+async def test_system_info_includes_identifier(companion_client, companion_state):
+    assert companion_state.system_info is not None
+    assert companion_state.system_info.get("_i")
+
+
 @pytest.mark.parametrize(
     "button",
     [


### PR DESCRIPTION
Fixes how the Companion protocol fetches and subscribes to power state by (1) starting a `TVRCSessionStart` session during connect and (2) sending a non-null `_i` in `_systemInfo`.

## Problem

After #2598 made Companion the preferred power state source (v0.16.1), power state stopped working reliably.

On a new connection — e.g. a full Home Assistant restart — the initial `FetchAttentionState` succeeds, so power state is briefly correct. Later `FetchAttentionState` calls stop being answered, and `CompanionPower.initialize` logs:

```
Could not fetch SystemStatus, power_state will not work (...)
```

After that, power state never recovers. `TVSystemStatus` events are also never pushed.

## Cause

Found by proxying an iOS Remote client against the same Apple TV and replaying its message sequence with single messages dropped:

- Without a TV Remote Client session, the Apple TV stops answering `FetchAttentionState` **and** does not honor the `SystemStatus`/`TVSystemStatus` event subscriptions. We confirmed this by moving past the failed fetch to see whether power state events would still be published — they weren't. That isolated the missing `TVRCSessionStart`, which pyatv never sent.
- Even with the session, the Apple TV only pushes `SystemStatus`/`TVSystemStatus` events to a client whose `_systemInfo` carried a non-null `_i`. pyatv sent `_i: info.rp_id`, which is `None` when no Rapport ID is known.

## Changes

- Send `TVRCSessionStart` after `_sessionStart` during connect. Wrapped in try/except so older devices that reject it are unaffected.
- Fall back to a stable identifier (`device_id` with colons stripped) when `rp_id` is `None`, so `_i` is never null.
- Add functional tests for both, plus fake device support.
- Document `TVRCSessionStart` and the `_i` requirement in `protocols.md`.

## Testing

- Reproduced the proxy/replay bisection that isolated each cause.
- Verified end to end on Home Assistant: power state now tracks `off`/`idle`/`playing`.
- All Companion tests pass; the two new tests fail without the fix.

Related: #2845, #2847