### PR TITLE
companion: keep power-state subscription when initial fetch fails (tvOS 26.x)

### DIFF
--- a/pyatv/protocols/companion/__init__.py
+++ b/pyatv/protocols/companion/__init__.py
@@ -218,6 +218,11 @@ class CompanionPower(Power):
 
     async def initialize(self) -> None:
         """Initialize Power module."""
+        # Fetching the initial power state snapshot can fail on newer tvOS
+        # versions where FetchAttentionState is no longer handled (the device
+        # replies with "No request handler"). This must not prevent us from
+        # subscribing to live status updates, otherwise power_state stays
+        # Unknown forever and can never recover from pushed events.
         try:
             system_status = await self.api.fetch_attention_state()
 
@@ -225,17 +230,20 @@ class CompanionPower(Power):
                 system_status
             )
 
+            _LOGGER.debug("Initial power state is %s", self.power_state)
+        except Exception as ex:
+            _LOGGER.debug("Could not fetch initial SystemStatus (%s)", ex)
+
+        # Subscribe regardless, so power state can still be tracked via pushed
+        # SystemStatus/TVSystemStatus events even if the initial fetch failed.
+        try:
             self.api.listen_to("SystemStatus", self._handle_system_status_update)
             await self.api.subscribe_event("SystemStatus")
 
             self.api.listen_to("TVSystemStatus", self._handle_system_status_update)
             await self.api.subscribe_event("TVSystemStatus")
-
-            _LOGGER.debug("Initial power state is %s", self.power_state)
         except Exception as ex:
-            _LOGGER.exception(
-                "Could not fetch SystemStatus, power_state will not work (%s)", ex
-            )
+            _LOGGER.debug("Could not subscribe to SystemStatus updates (%s)", ex)
 
     @property
     def power_state(self) -> PowerState:


### PR DESCRIPTION
On tvOS 26.x the Companion command `FetchAttentionState` is rejected with
`Command failed: No request handler`. In `CompanionPower.initialize()` this call sat in the
same `try` block as the `SystemStatus`/`TVSystemStatus` subscriptions, so the exception
aborted initialization before subscribing — leaving `power_state` permanently `Unknown`
with no way to recover from pushed events.

This decouples the one-shot snapshot fetch from the event subscription. If the initial fetch
fails, we now log at debug level and still subscribe, so power state can recover as soon as
the device pushes a status update. If subscription itself fails, it degrades gracefully
instead of disabling power state entirely.

Refs #2823. Downstream reports: home-assistant/core#166545 and related.

Note: I don't have a tvOS 26.x device to confirm whether `SystemStatus`/`TVSystemStatus`
events are still pushed on these versions. If they are, this restores power-state tracking;
if not, it at least stops disabling power state outright. Happy to adjust.