### PR TITLE
facade: wire power listener to all protocol implementations

### DIFF
--- a/pyatv/core/facade.py
+++ b/pyatv/core/facade.py
@@ -773,14 +773,12 @@ class FacadeAppleTV(interface.AppleTV):
 
         self._device_info = interface.DeviceInfo(devinfo)
 
-        # Forward power events in case an interface exists for it
-        try:
-            power = cast(
-                interface.Power, self._interfaces[interface.Power].main_instance
-            )
-            power.listener = self._interfaces[interface.Power]
-        except exceptions.NotSupportedError:
-            _LOGGER.debug("Power management not supported by any protocols")
+        # Forward power events from all protocol implementations to the facade
+        # so that events are not lost when a non-main protocol detects a change
+        # (e.g. MRP detects power state change while Companion is unavailable).
+        facade_power = self._interfaces[interface.Power]
+        for power_impl in facade_power.instances:
+            cast(interface.Power, power_impl).listener = facade_power
 
     def close(self) -> Set[asyncio.Task]:
         """Close connection and release allocated resources."""

--- a/tests/core/test_facade.py
+++ b/tests/core/test_facade.py
@@ -113,6 +113,7 @@ class DummyFeatures(Features):
 
 class DummyPower(Power):
     def __init__(self) -> None:
+        super().__init__()
         self.current_state = PowerState.Off
         self.turn_on_called = False
         self.turn_off_called = False
@@ -699,6 +700,32 @@ async def test_power_prefer_companion(feature, func, facade_dummy, register_inte
 
     assert not getattr(power_mrp, f"{func}_called")
     assert getattr(power_comp, f"{func}_called")
+
+
+async def test_power_events_forwarded_from_all_protocols(
+    facade_dummy, register_interface
+):
+    """Power events from non-main protocol must also reach the facade listener."""
+    listener = SavingPowerListener()
+
+    power_mrp, _ = register_interface(
+        FeatureName.PowerState, DummyPower(), Protocol.MRP
+    )
+    power_comp, _ = register_interface(
+        FeatureName.PowerState, DummyPower(), Protocol.Companion
+    )
+
+    await facade_dummy.connect()
+    facade_dummy.power.listener = listener
+
+    # Simulate MRP detecting a power state change
+    power_mrp.listener.powerstate_update(PowerState.Off, PowerState.On)
+    assert listener.last_update == PowerState.On
+
+    # Simulate Companion detecting a power state change
+    power_comp.listener.powerstate_update(PowerState.On, PowerState.Off)
+    assert listener.last_update == PowerState.Off
+    assert len(listener.all_updates) == 2
 
 
 @pytest_asyncio.fixture(name="power_instance")


### PR DESCRIPTION
## Summary

- Previously only the main (highest priority) power implementation had its listener set to `FacadePower`. When Companion is the main protocol but fails to track power state (e.g. `FetchAttentionState` times out on newer tvOS), MRP power events were silently dropped because `MrpPower` had no listener wired up.
- Set `FacadePower` as the listener on every registered power implementation so events from any protocol reach the consumer.
- Added test verifying power events from both MRP and Companion reach the facade listener.

## Context

On newer tvOS versions, `FetchAttentionState` may time out or be rejected during companion protocol initialization. The 0.18.0 fix ([`5ed97a3`](https://github.com/postlund/pyatv/commit/5ed97a39)) correctly moved event subscriptions outside the initial fetch try-block, but even when companion event subscriptions also fail, MRP still detects power state changes. However, those MRP events never reached the facade listener because `FacadeAppleTV.connect()` only called:

```python
power = self._interfaces[interface.Power].main_instance
power.listener = self._interfaces[interface.Power]
```

With `FacadePower.OVERRIDE_PRIORITIES = [Companion, MRP, ...]`, `main_instance` always returns `CompanionPower`, leaving `MrpPower.listener` unset. The `StateProducer._ListenerProxy` silently no-ops when no listener is set, so MRP power events are swallowed.

## Test plan

- [x] Added `test_power_events_forwarded_from_all_protocols` — registers both MRP and Companion power, simulates events from each, asserts both reach the facade listener
- [x] All 48 existing `tests/core/test_facade.py` tests pass