### PR TITLE
mrp: handle NaN elapsed time when calculating position

### DIFF
--- a/pyatv/protocols/mrp/__init__.py
+++ b/pyatv/protocols/mrp/__init__.py
@@ -210,10 +210,16 @@ def build_playing_instance(  # pylint: disable=too-many-locals
         elapsed_timestamp = state.metadata_field("elapsedTimeTimestamp")
 
         # If we don't have reference time, we can't do anything
-        if not elapsed_timestamp:
+        if not elapsed_timestamp or math.isnan(elapsed_timestamp):
             return None
 
-        elapsed_time: int = state.metadata_field("elapsedTime") or 0
+        # Both fields are doubles in the protobuf definition and devices do report NaN
+        # for them, which is not convertible to an integer (NaN is also truthy, so "or"
+        # does not help here).
+        elapsed_time: float = state.metadata_field("elapsedTime") or 0.0
+        if math.isnan(elapsed_time):
+            return None
+
         diff = (
             datetime.datetime.now() - _cocoa_to_timestamp(elapsed_timestamp)
         ).total_seconds()

--- a/tests/protocols/mrp/test_mrp_interface.py
+++ b/tests/protocols/mrp/test_mrp_interface.py
@@ -409,3 +409,18 @@ async def test_metadata_position_calculation(metadata, playing_metadata, player_
         player_state.playback_state = protobuf.PlaybackState.Playing
         playing_metadata["playbackRate"] = 0.0
         assert (await metadata.playing()).position == ELAPSED_TIME
+
+
+async def test_metadata_position_nan(metadata, playing_metadata, player_state):
+    # Devices sometimes report NaN as elapsed time, which cannot be converted to an
+    # integer. Treat it as no position at all instead of raising ValueError.
+    playing_metadata["elapsedTime"] = math.nan
+
+    with faketime("pyatv", NOW_TIME):
+        # Paused state
+        assert (await metadata.playing()).position is None
+
+        # Playing state
+        player_state.playback_state = protobuf.PlaybackState.Playing
+        playing_metadata["playbackRate"] = 1.0
+        assert (await metadata.playing()).position is None


### PR DESCRIPTION
## Problem

`playing()` raises `ValueError: cannot convert float NaN to integer` when a device
reports NaN as elapsed time, which makes the whole call fail:

    File "pyatv/protocols/mrp/__init__.py", line 284, in build_playing_instance
        position=position(),
    File "pyatv/protocols/mrp/__init__.py", line 226, in position
        return int(elapsed_time)
    ValueError: cannot convert float NaN to integer

Seen in the wild via `atvscript` (as used by node-pyatv/homebridge-appletv-enhanced),
where the raised error terminates the process.

## Cause

`elapsedTime` and `elapsedTimeTimestamp` are both `double` in `ContentItemMetadata.proto`
(lines 150 and 189), and devices do occasionally report NaN for them. `position()`
annotated `elapsed_time` as `int` and relied on `... or 0` as a fallback, but NaN is
truthy, so it goes straight into `int()` and raises. `total_time()` right above already
guards its (also `double`) `duration` field with `math.isnan`; `position()` never got the
same treatment.

## Change

* Return `None` from `position()` when `elapsedTime` or `elapsedTimeTimestamp` is NaN,
  consistent with what `total_time()` does for a NaN `duration`. A NaN timestamp would
  otherwise raise the same `ValueError` from `datetime.fromtimestamp()` inside
  `_cocoa_to_timestamp()`.
* Correct the `elapsed_time` annotation from `int` to `float`, matching the type the
  protobuf definition actually specifies.

## Tests

Added `test_metadata_position_nan`, which fails on master with the traceback above and
passes with this change. Full test suite and chickn linting pass locally.
